### PR TITLE
feat(convert): commit each conversion in its own transaction

### DIFF
--- a/docs/commands/convert.md
+++ b/docs/commands/convert.md
@@ -25,6 +25,12 @@ All conversions target **16-bit / 44.1 kHz**, with a few nuances:
 - `all` — always delete the original
 - `none` — never delete the original
 
+## Interrupted Runs
+
+If a run stops partway, whether from a conversion failure, a full disk, or a Ctrl-C, everything it finished is kept and nothing is left half-converted. `convert` tells you which file it stopped on, how many converted, and how many it never got to. Rerun the same command to pick up where it left off.
+
+A track whose file has moved or been deleted since the preview is skipped, and the rest of the batch continues.
+
 ## Examples
 
 ```bash

--- a/rekordbox_edit/api/convert.py
+++ b/rekordbox_edit/api/convert.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Literal, NamedTuple, Tuple
 
@@ -42,6 +43,10 @@ TARGET_SAMPLE_RATE = 44100
 
 # Rekordbox FileType codes RBE converts from: the lossless whitelist.
 _INPUT_FILE_TYPES = {info.code for info in FILE_TYPES.items() if info.convertable}
+
+# Encoding writes here first, so a hard kill leaves a recognizable orphan
+# rather than a truncated file at the name the database will point at.
+TEMP_PREFIX = ".rbe-convert-"
 
 _HI_RES_CODECS = {
     "aiff": "pcm_s16be",
@@ -207,6 +212,42 @@ def _update_database_record(
     _apply_converted_record(content, probe, new_filename, new_folder, output_format)
 
 
+def _temp_output_path(output_path: str) -> str:
+    """A sibling of `output_path` to encode into. Keeping it in the destination
+    directory means the move into place never crosses a filesystem, so it stays
+    atomic. The extension is preserved because ffmpeg reads the output format
+    from it."""
+    directory, filename = os.path.split(output_path)
+    return os.path.join(directory, f"{TEMP_PREFIX}{os.getpid()}-{filename}")
+
+
+def _remove_temp_file(temp_path: str) -> None:
+    try:
+        os.remove(temp_path)
+        logger.debug(f"Removed temp output {temp_path}")
+    except OSError as e:
+        logger.debug(f"Could not remove temp output {temp_path}: {e}")
+
+
+def _sweep_orphan_temp_files(output_paths: Iterable[str]) -> None:
+    """Remove temp files a killed run left behind, in the directories this run
+    is about to write to. Only those directories are read, so the sweep never
+    walks the library."""
+    removed = 0
+    for directory in {os.path.dirname(path) for path in output_paths}:
+        try:
+            names = os.listdir(directory)
+        except OSError as e:
+            logger.debug(f"Could not sweep {directory}: {e}")
+            continue
+        for name in names:
+            if name.startswith(TEMP_PREFIX):
+                _remove_temp_file(os.path.join(directory, name))
+                removed += 1
+    if removed:
+        logger.debug(f"convert swept {removed} orphaned temp file(s)")
+
+
 def _cleanup_converted_files(converted_ops: list[ConvertOp]) -> None:
     """Clean up converted output files on error or rollback."""
     logger.debug("Cleaning up converted files due to aborted conversion.")
@@ -363,6 +404,9 @@ def convert(
     content_map = {str(c.ID): c for c in contents}
     converted_ops: list[ConvertOp] = []
     lossless_op_ids: set[str] = set()
+    _sweep_orphan_temp_files(op.output_path for op in ops)
+
+    pending_temp: str | None = None
     try:
         for i, op in enumerate(ops, 1):
             content = content_map[op.id]
@@ -384,10 +428,11 @@ def convert(
                 skipped.append(SkippedTrack(id=op.id, reason="codec_mismatch"))
                 continue
 
+            pending_temp = _temp_output_path(op.output_path)
             if args.format_out.upper() == "MP3":
                 output_sample_rate = TARGET_SAMPLE_RATE
                 success = _run_ffmpeg(
-                    src, op.output_path, _mp3_output_kwargs(output_sample_rate), "mp3"
+                    src, pending_temp, _mp3_output_kwargs(output_sample_rate), "mp3"
                 )
             else:
                 fidelity, output_sample_rate = _classify_fidelity(audio_info)
@@ -396,15 +441,18 @@ def convert(
                 output_format = OutputFormats(args.format_out.lower())
                 success = _run_ffmpeg(
                     src,
-                    op.output_path,
+                    pending_temp,
                     _hi_res_output_kwargs(output_format, output_sample_rate),
                     output_format.value,
                 )
 
             if not success:
                 raise RuntimeError(f"Conversion failed for {src}")
-            if not os.path.exists(op.output_path):
+            if not os.path.exists(pending_temp):
                 raise RuntimeError(f"Output file not created: {op.output_path}")
+
+            os.replace(pending_temp, op.output_path)
+            pending_temp = None
 
             _update_database_record(
                 content,
@@ -430,6 +478,8 @@ def convert(
         logger.debug(
             f"convert rolling back after {len(converted_ops)} partial conversion(s)"
         )
+        if pending_temp:
+            _remove_temp_file(pending_temp)
         _rollback_and_cleanup(db, converted_ops)
         raise
 

--- a/rekordbox_edit/api/convert.py
+++ b/rekordbox_edit/api/convert.py
@@ -3,7 +3,7 @@
 import logging
 import os
 from pathlib import Path
-from typing import Literal, Tuple
+from typing import Literal, NamedTuple, Tuple
 
 import ffmpeg
 from ffmpeg import Error as FfmpegError
@@ -140,31 +140,46 @@ def _run_ffmpeg(input_path, output_path, output_kwargs: dict, label: str) -> boo
         raise e
 
 
-def _update_database_record(
-    db: Rekordbox6Database,
-    content_id: str,
+class ConvertedFileProbe(NamedTuple):
+    """What a finished conversion looks like on disk.
+
+    Gathered without touching the session so the work can move off the main
+    thread, where an ORM attribute read would not be safe.
+    """
+
+    audio_info: AudioInfo
+    bitrate: int | None
+    file_size: int
+
+
+def _probe_converted_file(
+    converted_file_path: Path | str, output_format: str
+) -> ConvertedFileProbe:
+    """Probe a converted file for the values its content row needs."""
+    audio_info = get_audio_info(converted_file_path)
+    bitrate = audio_info["bitrate"]
+    if output_format.upper() == "MP3" and bitrate is None:
+        logger.debug("MP3 bitrate not found in probe, assuming 320kbps")
+        bitrate = 320
+    return ConvertedFileProbe(
+        audio_info=audio_info,
+        bitrate=bitrate,
+        file_size=os.path.getsize(converted_file_path),
+    )
+
+
+def _apply_converted_record(
+    content: DjmdContent,
+    probe: ConvertedFileProbe,
     new_filename: str,
     new_folder: str,
     output_format: str,
 ) -> None:
-    """Update database record with new file information."""
-    content = db.get_content().filter_by(ID=content_id).first()
-    if not content:
-        raise Exception(f"Content record with ID {content_id} not found")
-
-    old_path = content.FolderPath
-    converted_file_path = Path(new_folder, new_filename)
-    converted_db_path = str(converted_file_path).replace("\\", "/")
-    converted_audio_info = get_audio_info(converted_file_path)
-    converted_bitrate = converted_audio_info["bitrate"]
-
-    if output_format.upper() == "MP3" and converted_bitrate is None:
-        logger.debug("MP3 bitrate not found in probe, assuming 320kbps")
-        converted_bitrate = 320
-
+    """Write a finished conversion's file location and audio columns onto its
+    content row. Performs no filesystem work."""
     file_type = get_file_type_for_format(output_format)
-    if not file_type:
-        raise Exception(f"Unsupported output format: {output_format}")
+    old_path = content.FolderPath
+    converted_db_path = str(Path(new_folder, new_filename)).replace("\\", "/")
 
     content.FileNameL = new_filename
     content.FolderPath = converted_db_path
@@ -175,10 +190,21 @@ def _update_database_record(
 
     _sync_audio_columns(
         content,
-        {**converted_audio_info, "bitrate": converted_bitrate},
+        {**probe.audio_info, "bitrate": probe.bitrate},
         file_type,
-        os.path.getsize(converted_file_path),
+        probe.file_size,
     )
+
+
+def _update_database_record(
+    content: DjmdContent,
+    new_filename: str,
+    new_folder: str,
+    output_format: str,
+) -> None:
+    """Probe a converted file and write its values onto the content row."""
+    probe = _probe_converted_file(Path(new_folder, new_filename), output_format)
+    _apply_converted_record(content, probe, new_filename, new_folder, output_format)
 
 
 def _cleanup_converted_files(converted_ops: list[ConvertOp]) -> None:
@@ -381,8 +407,7 @@ def convert(
                 raise RuntimeError(f"Output file not created: {op.output_path}")
 
             _update_database_record(
-                db,
-                op.id,
+                content,
                 os.path.basename(op.output_path),
                 os.path.dirname(op.output_path),
                 args.format_out.upper(),

--- a/rekordbox_edit/api/convert.py
+++ b/rekordbox_edit/api/convert.py
@@ -248,34 +248,42 @@ def _sweep_orphan_temp_files(output_paths: Iterable[str]) -> None:
         logger.debug(f"convert swept {removed} orphaned temp file(s)")
 
 
-def _cleanup_converted_files(converted_ops: list[ConvertOp]) -> None:
-    """Clean up converted output files on error or rollback."""
-    logger.debug("Cleaning up converted files due to aborted conversion.")
-    for op in converted_ops:
-        try:
-            os.remove(op.output_path)
-            logger.debug(f"Cleaned up {op.output_path}")
-        except Exception:
-            pass
+class ConvertAborted(RuntimeError):
+    """A conversion failed partway through a batch.
+
+    Files converted before the failure are already committed, so the counts
+    travel with the error rather than being recovered from the response the
+    caller never receives.
+    """
+
+    def __init__(
+        self,
+        reason: str,
+        *,
+        failed_path: str,
+        converted: int,
+        not_attempted: int,
+    ):
+        self.failed_path = failed_path
+        self.converted = converted
+        self.not_attempted = not_attempted
+        super().__init__(reason)
 
 
-def _rollback_and_cleanup(db, converted_ops: list[ConvertOp]) -> None:
-    """Roll back the database session and clean up any converted files."""
+def _rollback_session(db) -> None:
+    """Roll back whatever the failing file left uncommitted. Earlier files
+    committed in their own transactions and are unaffected."""
     logger.debug("Attempting DB session rollback.")
-    rollback_error = None
-    if db and db.session:
-        try:
-            db.session.rollback()
-        except Exception as e:
-            logger.critical(f"Encountered error during session rollback: {e}")
-            logger.critical(
-                "Check the state of your rekordbox library and consider reverting to a backup database if something's not right"
-            )
-            rollback_error = e
-    if converted_ops:
-        _cleanup_converted_files(converted_ops)
-    if rollback_error:
-        raise rollback_error
+    if not (db and db.session):
+        return
+    try:
+        db.session.rollback()
+    except Exception as e:
+        logger.critical(f"Encountered error during session rollback: {e}")
+        logger.critical(
+            "Check the state of your rekordbox library and consider reverting to a backup database if something's not right"
+        )
+        raise
 
 
 def _get_output_path(content, output_format) -> Tuple[str, str, str]:
@@ -334,6 +342,13 @@ def _classify_convert(content, args: ConvertRequest) -> ConvertOp | SkippedTrack
     )
 
 
+def _deletes_original(mode: str, is_lossless: bool) -> bool:
+    """Whether this conversion's original should be deleted under `mode`."""
+    if mode == "all":
+        return True
+    return mode == "lossless" and is_lossless
+
+
 # ── Public API ────────────────────────────────────────────────────────────
 
 
@@ -348,9 +363,10 @@ def convert(
     With `dry_run=True`, returns the planned conversions without any ffmpeg or
     DB writes. With `dry_run=False` (default), commits the changes.
 
-    The rollback block protects only pre-commit work; once a database commit lands,
-    the transaction is honoured even if the delete-originals loop or response
-    re-query later fails.
+    Each file commits in its own transaction, so a failure raises
+    ConvertAborted with the files already converted left committed. Only the
+    failing file rolls back, and its post-commit work (the ANLZ path update and
+    the original deletion) only warns.
     """
     from rekordbox_edit.utils import ffmpeg_in_path, get_ffmpeg_directions
 
@@ -403,19 +419,27 @@ def convert(
     # content_map enables per-op live FolderPath / FileNameL reads in the loop.
     content_map = {str(c.ID): c for c in contents}
     converted_ops: list[ConvertOp] = []
-    lossless_op_ids: set[str] = set()
     _sweep_orphan_temp_files(op.output_path for op in ops)
 
-    pending_temp: str | None = None
-    try:
-        for i, op in enumerate(ops, 1):
-            content = content_map[op.id]
-            src = content.FolderPath or ""
-            logger.info(f"[{i}/{len(ops)}] {content.FileNameL}")
+    output_format_name = args.format_out.upper()
+    deletable = 0
+    deleted = 0
 
-            if not os.path.exists(src):
-                raise RuntimeError(f"Source not found: {src}")
+    for i, op in enumerate(ops, 1):
+        content = content_map[op.id]
+        src = content.FolderPath or ""
+        logger.info(f"[{i}/{len(ops)}] {content.FileNameL}")
 
+        if not os.path.exists(src):
+            # Classification and this loop are separated by a confirmation
+            # prompt, so a source going missing is an expected outcome of that
+            # window rather than a systemic failure worth abandoning the batch.
+            logger.warning(f"Skipping {content.FileNameL}: {src} is gone")
+            skipped.append(SkippedTrack(id=op.id, reason="file_not_found"))
+            continue
+
+        pending_temp: str | None = None
+        try:
             audio_info = get_audio_info(src)
             if not probe_matches_file_type(
                 content.FileType, audio_info["codec"], audio_info["container"]
@@ -429,15 +453,16 @@ def convert(
                 continue
 
             pending_temp = _temp_output_path(op.output_path)
-            if args.format_out.upper() == "MP3":
+            if output_format_name == "MP3":
+                # MP3 output always loses information, so it is never lossless.
+                is_lossless = False
                 output_sample_rate = TARGET_SAMPLE_RATE
                 success = _run_ffmpeg(
                     src, pending_temp, _mp3_output_kwargs(output_sample_rate), "mp3"
                 )
             else:
                 fidelity, output_sample_rate = _classify_fidelity(audio_info)
-                if fidelity == "lossless":
-                    lossless_op_ids.add(op.id)
+                is_lossless = fidelity == "lossless"
                 output_format = OutputFormats(args.format_out.lower())
                 success = _run_ffmpeg(
                     src,
@@ -458,33 +483,31 @@ def convert(
                 content,
                 os.path.basename(op.output_path),
                 os.path.dirname(op.output_path),
-                args.format_out.upper(),
+                output_format_name,
             )
-            converted_ops.append(
-                op.model_copy(
-                    update={
-                        "source_path": src,
-                        "output_sample_rate": output_sample_rate,
-                    }
-                )
+            db.session.commit()
+        except BaseException as e:
+            if pending_temp:
+                _remove_temp_file(pending_temp)
+            _rollback_session(db)
+            logger.debug(
+                f"convert aborted at {src} after {len(converted_ops)} "
+                "committed conversion(s)"
             )
+            raise ConvertAborted(
+                str(e),
+                failed_path=src,
+                converted=len(converted_ops),
+                not_attempted=len(ops) - i,
+            ) from e
 
-        db.session.commit()
-        logger.info(
-            f"\nConverted {len(converted_ops)} files to {args.format_out.upper()}"
+        converted_ops.append(
+            op.model_copy(
+                update={"source_path": src, "output_sample_rate": output_sample_rate}
+            )
         )
-        logger.debug(f"convert committed {len(converted_ops)} conversion(s)")
-    except BaseException:
-        logger.debug(
-            f"convert rolling back after {len(converted_ops)} partial conversion(s)"
-        )
-        if pending_temp:
-            _remove_temp_file(pending_temp)
-        _rollback_and_cleanup(db, converted_ops)
-        raise
 
-    for op in converted_ops:
-        content = content_map[op.id]
+        # Past this point the row is committed, so every failure only warns.
         try:
             _update_anlz_paths(db, content, os.path.basename(op.output_path))
         except Exception as e:
@@ -492,31 +515,19 @@ def convert(
                 f"Failed to update ANLZ path tags for {content.FileNameL}: {e}"
             )
 
-    if args.delete_originals == "all":
-        deletable_ops = converted_ops
-    elif args.delete_originals == "lossless":
-        deletable_ops = [op for op in converted_ops if op.id in lossless_op_ids]
-    else:
-        deletable_ops = []
-    logger.debug(
-        f"convert delete_originals={args.delete_originals}: deleting "
-        f"{len(deletable_ops)}/{len(converted_ops)} source file(s)"
-    )
+        if _deletes_original(args.delete_originals, is_lossless):
+            deletable += 1
+            try:
+                os.remove(src)
+                deleted += 1
+            except Exception as e:
+                logger.warning(f"Failed to delete {src}: {e}")
 
-    deleted = 0
-    for op in deletable_ops:
-        try:
-            os.remove(op.source_path)
-            deleted += 1
-        except Exception as e:
-            logger.warning(f"Failed to delete {op.source_path}: {e}")
+    logger.info(f"\nConverted {len(converted_ops)} files to {output_format_name}")
+    logger.debug(f"convert committed {len(converted_ops)} conversion(s)")
 
-    kept = len(converted_ops) - len(deletable_ops)
-    if (
-        args.delete_originals == "lossless"
-        and kept
-        and args.format_out.upper() != "MP3"
-    ):
+    kept = len(converted_ops) - deletable
+    if args.delete_originals == "lossless" and kept and output_format_name != "MP3":
         logger.info(f"Kept {kept} original file(s) whose conversion was lossy")
 
     converted_ids = [op.id for op in converted_ops]

--- a/rekordbox_edit/api/convert.py
+++ b/rekordbox_edit/api/convert.py
@@ -153,7 +153,6 @@ class ConvertedFileProbe(NamedTuple):
     """
 
     audio_info: AudioInfo
-    bitrate: int | None
     file_size: int
 
 
@@ -162,13 +161,11 @@ def _probe_converted_file(
 ) -> ConvertedFileProbe:
     """Probe a converted file for the values its content row needs."""
     audio_info = get_audio_info(converted_file_path)
-    bitrate = audio_info["bitrate"]
-    if output_format.upper() == "MP3" and bitrate is None:
+    if output_format.upper() == "MP3" and audio_info["bitrate"] is None:
         logger.debug("MP3 bitrate not found in probe, assuming 320kbps")
-        bitrate = 320
+        audio_info["bitrate"] = 320
     return ConvertedFileProbe(
         audio_info=audio_info,
-        bitrate=bitrate,
         file_size=os.path.getsize(converted_file_path),
     )
 
@@ -193,23 +190,7 @@ def _apply_converted_record(
     if content.OrgFolderPath == old_path:
         content.OrgFolderPath = converted_db_path
 
-    _sync_audio_columns(
-        content,
-        {**probe.audio_info, "bitrate": probe.bitrate},
-        file_type,
-        probe.file_size,
-    )
-
-
-def _update_database_record(
-    content: DjmdContent,
-    new_filename: str,
-    new_folder: str,
-    output_format: str,
-) -> None:
-    """Probe a converted file and write its values onto the content row."""
-    probe = _probe_converted_file(Path(new_folder, new_filename), output_format)
-    _apply_converted_record(content, probe, new_filename, new_folder, output_format)
+    _sync_audio_columns(content, probe.audio_info, file_type, probe.file_size)
 
 
 def _temp_output_path(output_path: str) -> str:
@@ -479,8 +460,9 @@ def convert(
             os.replace(pending_temp, op.output_path)
             pending_temp = None
 
-            _update_database_record(
+            _apply_converted_record(
                 content,
+                _probe_converted_file(op.output_path, output_format_name),
                 os.path.basename(op.output_path),
                 os.path.dirname(op.output_path),
                 output_format_name,

--- a/rekordbox_edit/cli/_utils.py
+++ b/rekordbox_edit/cli/_utils.py
@@ -51,13 +51,16 @@ def _handle_stdin(args) -> bool:
     return True
 
 
-def _validate_scripting_preconditions(print_opt, args, piped_stdin: bool) -> None:
+def _validate_scripting_preconditions(
+    print_opt, *, piped_stdin: bool, dry_run: bool, yes: bool
+) -> None:
     """Raise UsageError for invalid scripting-mode combinations."""
-    if print_opt in SCRIPTING_MODES and not (args.dry_run or args.yes):
+    confirmed = dry_run or yes
+    if print_opt in SCRIPTING_MODES and not confirmed:
         raise click.UsageError(
             "--print=ids, --print=silent, or --print=json requires --dry-run or --yes to skip confirmation"
         )
-    if piped_stdin and not (args.dry_run or args.yes):
+    if piped_stdin and not confirmed:
         raise click.UsageError("Piping track IDs requires --dry-run or --yes")
 
 

--- a/rekordbox_edit/cli/convert.py
+++ b/rekordbox_edit/cli/convert.py
@@ -70,9 +70,7 @@ def convert_command(db, **kwargs):
     set_level(print_opt)
     piped_stdin = _handle_stdin(args)
     _validate_scripting_preconditions(
-        print_opt,
-        type("_S", (), {"dry_run": dry_run, "yes": yes})(),
-        piped_stdin,
+        print_opt, piped_stdin=piped_stdin, dry_run=dry_run, yes=yes
     )
 
     scripting_mode = print_opt in SCRIPTING_MODES

--- a/rekordbox_edit/cli/convert.py
+++ b/rekordbox_edit/cli/convert.py
@@ -1,6 +1,7 @@
 """Convert CLI command."""
 
 import logging
+import sys
 
 import click
 
@@ -13,7 +14,7 @@ from rekordbox_edit._click import (
     print_option,
     track_ids_argument,
 )
-from rekordbox_edit.api.convert import convert
+from rekordbox_edit.api.convert import ConvertAborted, convert
 from rekordbox_edit.cli._utils import (
     SCRIPTING_MODES,
     _build_args,
@@ -30,6 +31,10 @@ from rekordbox_edit.models import ConvertRequest
 from rekordbox_edit.utils import UserQuit, confirm
 
 logger = logging.getLogger(__name__)
+
+# Skips a dry run cannot predict: it neither probes a source nor re-stats one,
+# so these surface only from the live pass.
+_LIVE_ONLY_SKIPS = frozenset({"codec_mismatch", "file_not_found"})
 
 
 @click.command(
@@ -73,7 +78,7 @@ def convert_command(db, **kwargs):
     scripting_mode = print_opt in SCRIPTING_MODES
 
     if yes or dry_run:
-        response = convert(db, args, dry_run=dry_run)
+        response = _convert_reporting_partials(db, args, dry_run=dry_run)
         _report_skips(response.result.skipped)
         _print_convert_result(response, print_opt, scripting_mode, dry_run=dry_run)
         return
@@ -109,7 +114,7 @@ def convert_command(db, **kwargs):
             logger.info("Cancelled.")
             return
         narrowed = _narrow_to_track_ids(args, selected_ids)
-        response = convert(db, narrowed)
+        response = _convert_reporting_partials(db, narrowed)
     else:
         try:
             if not confirm(
@@ -121,12 +126,24 @@ def convert_command(db, **kwargs):
                 return
         except UserQuit:
             return
-        response = convert(db, args)
+        response = _convert_reporting_partials(db, args)
 
-    # The preview cannot surface codec_mismatch (dry runs never probe), so
-    # report skips found only during the live run.
-    _report_skips([s for s in response.result.skipped if s.reason == "codec_mismatch"])
+    _report_skips([s for s in response.result.skipped if s.reason in _LIVE_ONLY_SKIPS])
     _print_convert_result(response, print_opt, scripting_mode, dry_run=False)
+
+
+def _convert_reporting_partials(db, args, *, dry_run: bool = False):
+    """Convert, reporting a batch that stopped partway as a plain result rather
+    than as a crash. The committed conversions are real and are kept."""
+    try:
+        return convert(db, args, dry_run=dry_run)
+    except ConvertAborted as e:
+        logger.error(f"Conversion stopped at {e.failed_path}: {e}")
+        logger.error(
+            f"{e.converted} file(s) converted and kept, 1 failed, "
+            f"{e.not_attempted} not attempted."
+        )
+        sys.exit(1)
 
 
 def _report_skips(skipped) -> None:
@@ -134,6 +151,7 @@ def _report_skips(skipped) -> None:
     unsupported = sum(1 for s in skipped if s.reason == "unsupported_source_format")
     conflicts = sum(1 for s in skipped if s.reason == "output_file_exists")
     mismatches = sum(1 for s in skipped if s.reason == "codec_mismatch")
+    missing = sum(1 for s in skipped if s.reason == "file_not_found")
     if already_target:
         logger.warning(f"Skipping {already_target} file(s): already in target format")
     if unsupported:
@@ -150,6 +168,8 @@ def _report_skips(skipped) -> None:
             f"Skipping {mismatches} file(s): file content does not match its "
             "Rekordbox file type"
         )
+    if missing:
+        logger.warning(f"Skipping {missing} file(s): source file is gone")
 
 
 def _print_convert_result(

--- a/rekordbox_edit/cli/edit.py
+++ b/rekordbox_edit/cli/edit.py
@@ -64,11 +64,8 @@ def edit_command(db, **kwargs):
     set_level(print_opt)
     piped_stdin = _handle_stdin(args)
 
-    # Sentinel object mirrors the old ConfirmationArgs shape for the validator.
     _validate_scripting_preconditions(
-        print_opt,
-        type("_S", (), {"dry_run": dry_run, "yes": yes})(),
-        piped_stdin,
+        print_opt, piped_stdin=piped_stdin, dry_run=dry_run, yes=yes
     )
 
     if yes or dry_run:

--- a/rekordbox_edit/cli/import_.py
+++ b/rekordbox_edit/cli/import_.py
@@ -53,9 +53,7 @@ def import_command(db, **kwargs):
     set_level(print_opt)
 
     _validate_scripting_preconditions(
-        print_opt,
-        type("_S", (), {"dry_run": dry_run, "yes": yes})(),
-        False,
+        print_opt, piped_stdin=False, dry_run=dry_run, yes=yes
     )
 
     interactive_ok = print_opt not in SCRIPTING_MODES and not yes

--- a/tests/api/test_convert.py
+++ b/tests/api/test_convert.py
@@ -5,6 +5,7 @@ import ffmpeg
 import pytest
 
 from rekordbox_edit.api.convert import (
+    TEMP_PREFIX,
     _classify_convert,
     _classify_fidelity,
     _cleanup_converted_files,
@@ -14,6 +15,8 @@ from rekordbox_edit.api.convert import (
     _probe_converted_file,
     _rollback_and_cleanup,
     _run_ffmpeg,
+    _sweep_orphan_temp_files,
+    _temp_output_path,
     _update_anlz_paths,
     _update_database_record,
     convert,
@@ -348,7 +351,42 @@ class TestConvertDryRun:
         assert response.result.skipped[0].reason == "already_target_format"
 
 
+class TestTempOutputPath:
+    def test_keeps_the_extension_so_ffmpeg_still_infers_the_format(self):
+        temp = _temp_output_path("/music/song.aiff")
+
+        assert temp.endswith(".aiff")
+        assert os.path.dirname(temp) == "/music"
+        assert os.path.basename(temp).startswith(TEMP_PREFIX)
+
+
+class TestSweepOrphanTempFiles:
+    def test_removes_orphans_and_leaves_everything_else(self, tmp_path):
+        orphan = tmp_path / f"{TEMP_PREFIX}999-song.aiff"
+        orphan.write_text("half an encode")
+        bystander = tmp_path / "song.wav"
+        bystander.write_text("a real track")
+
+        _sweep_orphan_temp_files([str(tmp_path / "song.aiff")])
+
+        assert not orphan.exists()
+        assert bystander.exists()
+
+    def test_an_unreadable_directory_does_not_raise(self, tmp_path):
+        _sweep_orphan_temp_files([str(tmp_path / "absent" / "song.aiff")])
+
+
 class TestConvertRealRun:
+    @pytest.fixture(autouse=True)
+    def _stub_temp_file_moves(self):
+        # These tests mock ffmpeg away, so no temp file ever exists to move
+        # into place or to sweep. TestConvertTempFiles covers the real thing.
+        with (
+            patch("rekordbox_edit.api.convert.os.replace"),
+            patch("rekordbox_edit.api.convert.os.listdir", return_value=[]),
+        ):
+            yield
+
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=False)
     def test_no_ffmpeg_raises_immediately(self, _, mock_db):
         with pytest.raises(RuntimeError, match="FFmpeg"):
@@ -486,7 +524,7 @@ class TestConvertRealRun:
 
         mock_run.assert_called_once_with(
             "/in.wav",
-            "/out.aif",
+            _temp_output_path("/out.aif"),
             _hi_res_output_kwargs(OutputFormats.AIFF, 44100),
             "aiff",
         )
@@ -701,7 +739,7 @@ class TestConvertRealRun:
 
         mock_run.assert_called_once_with(
             "/in.wav",
-            "/out.aif",
+            _temp_output_path("/out.aif"),
             _hi_res_output_kwargs(OutputFormats.AIFF, 22050),
             "aiff",
         )
@@ -1047,7 +1085,7 @@ class TestConvertRealRun:
         convert(mock_db, ConvertRequest(format_out="mp3", overwrite=True))
 
         mock_run.assert_called_once_with(
-            "/in.wav", "/out.mp3", _mp3_output_kwargs(44100), "mp3"
+            "/in.wav", _temp_output_path("/out.mp3"), _mp3_output_kwargs(44100), "mp3"
         )
 
     @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)

--- a/tests/api/test_convert.py
+++ b/tests/api/test_convert.py
@@ -6,14 +6,14 @@ import pytest
 
 from rekordbox_edit.api.convert import (
     TEMP_PREFIX,
+    ConvertAborted,
     _classify_convert,
     _classify_fidelity,
-    _cleanup_converted_files,
     _get_output_path,
     _hi_res_output_kwargs,
     _mp3_output_kwargs,
     _probe_converted_file,
-    _rollback_and_cleanup,
+    _rollback_session,
     _run_ffmpeg,
     _sweep_orphan_temp_files,
     _temp_output_path,
@@ -789,7 +789,7 @@ class TestConvertRealRun:
         assert response.result.deleted == 0
 
     @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
-    @patch("rekordbox_edit.api.convert._rollback_and_cleanup")
+    @patch("rekordbox_edit.api.convert._rollback_session")
     @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=False)
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
@@ -822,7 +822,7 @@ class TestConvertRealRun:
         mock_rollback.assert_called_once()
 
     @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
-    @patch("rekordbox_edit.api.convert._rollback_and_cleanup")
+    @patch("rekordbox_edit.api.convert._rollback_session")
     @patch("rekordbox_edit.api.convert.os.remove", side_effect=KeyboardInterrupt)
     @patch("rekordbox_edit.api.convert._update_database_record")
     @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
@@ -988,13 +988,13 @@ class TestConvertRealRun:
         assert response.result.skipped[0].reason == "output_file_exists"
         mock_db.session.commit.assert_not_called()
 
-    @patch("rekordbox_edit.api.convert._rollback_and_cleanup")
+    @patch("rekordbox_edit.api.convert._rollback_session")
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=False)
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
     @patch("rekordbox_edit.api.convert._get_output_path")
     @patch("rekordbox_edit.api.convert.get_file_type_for_format")
     @patch("rekordbox_edit.api.convert.get_filtered_content")
-    def test_missing_source_triggers_rollback_and_raises(
+    def test_missing_source_is_skipped_rather_than_aborting(
         self,
         mock_gfc,
         mock_get_type,
@@ -1012,12 +1012,15 @@ class TestConvertRealRun:
         content = make_djmd_content_item(ID="1", FileType=11, FolderPath="/in.wav")
         _seed_filter(mock_gfc, content)
 
-        with pytest.raises(RuntimeError, match="Source not found"):
-            convert(mock_db, ConvertRequest(format_out="aiff", overwrite=True))
-        mock_rollback.assert_called_once()
+        response = convert(mock_db, ConvertRequest(format_out="aiff", overwrite=True))
+
+        assert response.result.converted == []
+        assert [s.reason for s in response.result.skipped] == ["file_not_found"]
+        mock_rollback.assert_not_called()
+        mock_db.session.commit.assert_not_called()
 
     @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
-    @patch("rekordbox_edit.api.convert._rollback_and_cleanup")
+    @patch("rekordbox_edit.api.convert._rollback_session")
     @patch(
         "rekordbox_edit.api.convert._update_database_record",
         side_effect=RuntimeError("DB error"),
@@ -1173,7 +1176,7 @@ class TestConvertRealRun:
         "rekordbox_edit.api.convert._update_anlz_paths",
         side_effect=RuntimeError("ANLZ write failed"),
     )
-    @patch("rekordbox_edit.api.convert._rollback_and_cleanup")
+    @patch("rekordbox_edit.api.convert._rollback_session")
     @patch("rekordbox_edit.api.convert._update_database_record")
     @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
@@ -1218,6 +1221,158 @@ class TestConvertRealRun:
 
 
 # ── Helper-function tests (preserved from existing file) ──────────────────
+
+
+class TestConvertPerFileCommits:
+    """A failure partway through keeps the files that already converted."""
+
+    @pytest.fixture(autouse=True)
+    def _stub_temp_file_moves(self):
+        with (
+            patch("rekordbox_edit.api.convert.os.replace"),
+            patch("rekordbox_edit.api.convert.os.listdir", return_value=[]),
+        ):
+            yield
+
+    @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
+    @patch("rekordbox_edit.api.convert._update_database_record")
+    @patch("rekordbox_edit.api.convert._run_ffmpeg")
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert._get_output_path")
+    @patch("rekordbox_edit.api.convert.get_file_type_for_format")
+    @patch("rekordbox_edit.api.convert.get_filtered_content")
+    def test_a_mid_batch_failure_keeps_the_earlier_commits(
+        self,
+        mock_gfc,
+        mock_get_type,
+        mock_get_output,
+        _ffmpeg,
+        _exists,
+        mock_run,
+        _update,
+        _probe,
+        mock_db,
+        make_djmd_content_item,
+    ):
+        mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
+            fmt.upper(), 99
+        )
+        mock_get_output.side_effect = lambda content, fmt: (
+            f"/{content.ID}.aif",
+            f"{content.ID}.aif",
+            "/",
+        )
+        # The first file encodes, the second fails, the third is never reached.
+        mock_run.side_effect = [True, False]
+        contents = [
+            make_djmd_content_item(ID=str(i), FileType=11, FolderPath=f"/in{i}.wav")
+            for i in (1, 2, 3)
+        ]
+        _seed_filter(mock_gfc, *contents)
+
+        with pytest.raises(ConvertAborted) as raised:
+            convert(mock_db, ConvertRequest(format_out="aiff", overwrite=True))
+
+        assert raised.value.converted == 1
+        assert raised.value.not_attempted == 1
+        assert raised.value.failed_path == "/in2.wav"
+        assert mock_db.session.commit.call_count == 1
+        assert mock_run.call_count == 2
+
+    @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
+    @patch("rekordbox_edit.api.convert._update_database_record")
+    @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
+    @patch("rekordbox_edit.api.convert.os.path.exists")
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert._get_output_path")
+    @patch("rekordbox_edit.api.convert.get_file_type_for_format")
+    @patch("rekordbox_edit.api.convert.get_filtered_content")
+    def test_a_source_that_vanished_does_not_stop_the_batch(
+        self,
+        mock_gfc,
+        mock_get_type,
+        mock_get_output,
+        _ffmpeg,
+        mock_exists,
+        _run,
+        _update,
+        _probe,
+        mock_db,
+        make_djmd_content_item,
+    ):
+        # The user can take minutes at the confirm prompt, so a source moved in
+        # that window is routine. Skip it and keep converting the rest.
+        mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
+            fmt.upper(), 99
+        )
+        mock_get_output.side_effect = lambda content, fmt: (
+            f"/{content.ID}.aif",
+            f"{content.ID}.aif",
+            "/",
+        )
+        mock_exists.side_effect = lambda path: path != "/in2.wav"
+        contents = [
+            make_djmd_content_item(ID=str(i), FileType=11, FolderPath=f"/in{i}.wav")
+            for i in (1, 2, 3)
+        ]
+        _seed_filter(mock_gfc, *contents)
+        _seed_db(mock_db, *contents)
+
+        response = convert(mock_db, ConvertRequest(format_out="aiff", overwrite=True))
+
+        assert [op.id for op in response.result.converted] == ["1", "3"]
+        assert [(s.id, s.reason) for s in response.result.skipped] == [
+            ("2", "file_not_found")
+        ]
+        assert mock_db.session.commit.call_count == 2
+
+    @patch("rekordbox_edit.api.convert.os.remove")
+    @patch("rekordbox_edit.api.convert.get_audio_info")
+    @patch("rekordbox_edit.api.convert._update_database_record")
+    @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert._get_output_path")
+    @patch("rekordbox_edit.api.convert.get_file_type_for_format")
+    @patch("rekordbox_edit.api.convert.get_filtered_content")
+    def test_the_delete_policy_is_decided_per_file(
+        self,
+        mock_gfc,
+        mock_get_type,
+        mock_get_output,
+        _ffmpeg,
+        _exists,
+        _run,
+        _update,
+        mock_probe,
+        mock_remove,
+        mock_db,
+        make_djmd_content_item,
+    ):
+        mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
+            fmt.upper(), 99
+        )
+        mock_get_output.side_effect = lambda content, fmt: (
+            f"/{content.ID}.aif",
+            f"{content.ID}.aif",
+            "/",
+        )
+        # First source is already at the target, second is hi-res: only the
+        # first conversion is lossless, so only its original may be deleted.
+        mock_probe.side_effect = [_PROBE_WAV_16_44, _PROBE_WAV_24_96]
+        contents = [
+            make_djmd_content_item(ID=str(i), FileType=11, FolderPath=f"/in{i}.wav")
+            for i in (1, 2)
+        ]
+        _seed_filter(mock_gfc, *contents)
+        _seed_db(mock_db, *contents)
+
+        response = convert(mock_db, ConvertRequest(format_out="aiff", overwrite=True))
+
+        assert mock_db.session.commit.call_count == 2
+        assert response.result.deleted == 1
+        mock_remove.assert_called_once_with("/in1.wav")
 
 
 class TestClassifyFidelity:
@@ -1574,53 +1729,25 @@ class TestUpdateAnlzPaths:
         mock_db.read_anlz_files.assert_not_called()
 
 
-class TestCleanupConvertedFiles:
-    @patch("os.remove")
-    def test_removes_all_output_files(self, mock_remove):
-        ops = [
-            ConvertOp(id="1", source_path="/s1", output_path="/p/f1.aiff"),
-            ConvertOp(id="2", source_path="/s2", output_path="/p/f2.aiff"),
-        ]
-        _cleanup_converted_files(ops)
-        assert mock_remove.call_count == 2
-
-    @patch("os.remove", side_effect=OSError)
-    def test_oserror_is_swallowed(self, _):
-        _cleanup_converted_files(
-            [ConvertOp(id="1", source_path="/s", output_path="/p/f.aiff")]
-        )
-
-
-class TestRollbackAndCleanup:
+class TestRollbackSession:
     def test_rolls_back_session(self, mock_db):
-        _rollback_and_cleanup(mock_db, [])
+        _rollback_session(mock_db)
         mock_db.session.rollback.assert_called_once()
 
     def test_no_db_is_noop(self):
-        _rollback_and_cleanup(None, [])
+        _rollback_session(None)
 
     def test_no_session_is_noop(self):
         db = Mock()
         db.session = None
-        _rollback_and_cleanup(db, [])
-
-    @patch("rekordbox_edit.api.convert._cleanup_converted_files")
-    def test_cleans_up_converted_files(self, mock_cleanup, mock_db):
-        ops = [ConvertOp(id="1", source_path="/s", output_path="/p/f.aiff")]
-        _rollback_and_cleanup(mock_db, ops)
-        mock_cleanup.assert_called_once_with(ops)
-
-    @patch("rekordbox_edit.api.convert._cleanup_converted_files")
-    def test_skips_cleanup_when_no_converted_files(self, mock_cleanup, mock_db):
-        _rollback_and_cleanup(mock_db, [])
-        mock_cleanup.assert_not_called()
+        _rollback_session(db)
 
     @patch("rekordbox_edit.api.convert.logger")
     def test_rollback_exception_logs_critical_and_reraises(self, mock_logger, mock_db):
         mock_db.session.rollback.side_effect = Exception("DB connection lost")
 
         with pytest.raises(Exception, match="DB connection lost"):
-            _rollback_and_cleanup(mock_db, [])
+            _rollback_session(mock_db)
 
         assert mock_logger.critical.call_count == 2
 

--- a/tests/api/test_convert.py
+++ b/tests/api/test_convert.py
@@ -7,6 +7,8 @@ import pytest
 from rekordbox_edit.api.convert import (
     TEMP_PREFIX,
     ConvertAborted,
+    ConvertedFileProbe,
+    _apply_converted_record,
     _classify_convert,
     _classify_fidelity,
     _get_output_path,
@@ -18,12 +20,11 @@ from rekordbox_edit.api.convert import (
     _sweep_orphan_temp_files,
     _temp_output_path,
     _update_anlz_paths,
-    _update_database_record,
     convert,
 )
 from rekordbox_edit.models import (
-    ConvertRequest,
     ConvertOp,
+    ConvertRequest,
     ConvertResponse,
     SkippedTrack,
 )
@@ -379,11 +380,13 @@ class TestSweepOrphanTempFiles:
 class TestConvertRealRun:
     @pytest.fixture(autouse=True)
     def _stub_temp_file_moves(self):
-        # These tests mock ffmpeg away, so no temp file ever exists to move
-        # into place or to sweep. TestConvertTempFiles covers the real thing.
+        # These tests mock ffmpeg away, so no output file ever exists to move
+        # into place, to sweep, or to probe. TestApplyConvertedRecord and
+        # TestProbeConvertedFile cover those halves directly.
         with (
             patch("rekordbox_edit.api.convert.os.replace"),
             patch("rekordbox_edit.api.convert.os.listdir", return_value=[]),
+            patch("rekordbox_edit.api.convert._probe_converted_file"),
         ):
             yield
 
@@ -406,7 +409,7 @@ class TestConvertRealRun:
         mock_db.session.commit.assert_not_called()
 
     @patch("rekordbox_edit.api.convert.get_audio_info")
-    @patch("rekordbox_edit.api.convert._update_database_record")
+    @patch("rekordbox_edit.api.convert._apply_converted_record")
     @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
@@ -489,7 +492,7 @@ class TestConvertRealRun:
         assert response.result.skipped[0].reason == "codec_mismatch"
 
     @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
-    @patch("rekordbox_edit.api.convert._update_database_record")
+    @patch("rekordbox_edit.api.convert._apply_converted_record")
     @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
@@ -543,7 +546,7 @@ class TestConvertRealRun:
 
     @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
     @patch("rekordbox_edit.api.convert.os.remove")
-    @patch("rekordbox_edit.api.convert._update_database_record")
+    @patch("rekordbox_edit.api.convert._apply_converted_record")
     @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
@@ -582,7 +585,7 @@ class TestConvertRealRun:
 
     @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_24_96)
     @patch("rekordbox_edit.api.convert.os.remove")
-    @patch("rekordbox_edit.api.convert._update_database_record")
+    @patch("rekordbox_edit.api.convert._apply_converted_record")
     @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
@@ -625,7 +628,7 @@ class TestConvertRealRun:
 
     @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_24_96)
     @patch("rekordbox_edit.api.convert.os.remove")
-    @patch("rekordbox_edit.api.convert._update_database_record")
+    @patch("rekordbox_edit.api.convert._apply_converted_record")
     @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
@@ -664,7 +667,7 @@ class TestConvertRealRun:
 
     @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
     @patch("rekordbox_edit.api.convert.os.remove")
-    @patch("rekordbox_edit.api.convert._update_database_record")
+    @patch("rekordbox_edit.api.convert._apply_converted_record")
     @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
@@ -704,7 +707,7 @@ class TestConvertRealRun:
         assert response.result.deleted == 1
 
     @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_22)
-    @patch("rekordbox_edit.api.convert._update_database_record")
+    @patch("rekordbox_edit.api.convert._apply_converted_record")
     @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
@@ -749,7 +752,7 @@ class TestConvertRealRun:
 
     @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
     @patch("rekordbox_edit.api.convert.os.remove")
-    @patch("rekordbox_edit.api.convert._update_database_record")
+    @patch("rekordbox_edit.api.convert._apply_converted_record")
     @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
@@ -824,7 +827,7 @@ class TestConvertRealRun:
     @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
     @patch("rekordbox_edit.api.convert._rollback_session")
     @patch("rekordbox_edit.api.convert.os.remove", side_effect=KeyboardInterrupt)
-    @patch("rekordbox_edit.api.convert._update_database_record")
+    @patch("rekordbox_edit.api.convert._apply_converted_record")
     @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
@@ -868,7 +871,7 @@ class TestConvertRealRun:
         mock_rollback.assert_not_called()
 
     @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
-    @patch("rekordbox_edit.api.convert._update_database_record")
+    @patch("rekordbox_edit.api.convert._apply_converted_record")
     @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
@@ -915,7 +918,7 @@ class TestConvertRealRun:
         assert [t.ID for t in response.tracks] == ["A", "B", "C"]
 
     @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
-    @patch("rekordbox_edit.api.convert._update_database_record")
+    @patch("rekordbox_edit.api.convert._apply_converted_record")
     @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
@@ -1022,7 +1025,7 @@ class TestConvertRealRun:
     @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
     @patch("rekordbox_edit.api.convert._rollback_session")
     @patch(
-        "rekordbox_edit.api.convert._update_database_record",
+        "rekordbox_edit.api.convert._apply_converted_record",
         side_effect=RuntimeError("DB error"),
     )
     @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
@@ -1057,7 +1060,7 @@ class TestConvertRealRun:
         mock_rollback.assert_called_once()
 
     @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
-    @patch("rekordbox_edit.api.convert._update_database_record")
+    @patch("rekordbox_edit.api.convert._apply_converted_record")
     @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
@@ -1093,7 +1096,7 @@ class TestConvertRealRun:
 
     @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
     @patch("rekordbox_edit.api.convert.os.remove")
-    @patch("rekordbox_edit.api.convert._update_database_record")
+    @patch("rekordbox_edit.api.convert._apply_converted_record")
     @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
@@ -1132,7 +1135,7 @@ class TestConvertRealRun:
 
     @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
     @patch("rekordbox_edit.api.convert._update_anlz_paths")
-    @patch("rekordbox_edit.api.convert._update_database_record")
+    @patch("rekordbox_edit.api.convert._apply_converted_record")
     @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
@@ -1177,7 +1180,7 @@ class TestConvertRealRun:
         side_effect=RuntimeError("ANLZ write failed"),
     )
     @patch("rekordbox_edit.api.convert._rollback_session")
-    @patch("rekordbox_edit.api.convert._update_database_record")
+    @patch("rekordbox_edit.api.convert._apply_converted_record")
     @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
@@ -1231,11 +1234,12 @@ class TestConvertPerFileCommits:
         with (
             patch("rekordbox_edit.api.convert.os.replace"),
             patch("rekordbox_edit.api.convert.os.listdir", return_value=[]),
+            patch("rekordbox_edit.api.convert._probe_converted_file"),
         ):
             yield
 
     @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
-    @patch("rekordbox_edit.api.convert._update_database_record")
+    @patch("rekordbox_edit.api.convert._apply_converted_record")
     @patch("rekordbox_edit.api.convert._run_ffmpeg")
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
@@ -1281,7 +1285,7 @@ class TestConvertPerFileCommits:
         assert mock_run.call_count == 2
 
     @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
-    @patch("rekordbox_edit.api.convert._update_database_record")
+    @patch("rekordbox_edit.api.convert._apply_converted_record")
     @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
     @patch("rekordbox_edit.api.convert.os.path.exists")
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
@@ -1329,7 +1333,7 @@ class TestConvertPerFileCommits:
 
     @patch("rekordbox_edit.api.convert.os.remove")
     @patch("rekordbox_edit.api.convert.get_audio_info")
-    @patch("rekordbox_edit.api.convert._update_database_record")
+    @patch("rekordbox_edit.api.convert._apply_converted_record")
     @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
     @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
@@ -1520,7 +1524,7 @@ class TestProbeConvertedFile:
         probe = _probe_converted_file("/path/to/output.aiff", "AIFF")
 
         assert probe.file_size == 987654
-        assert probe.bitrate == 1411
+        assert probe.audio_info["bitrate"] == 1411
         assert probe.audio_info["bit_depth"] == 16
 
     @patch("rekordbox_edit.api.convert.os.path.getsize", return_value=1)
@@ -1530,176 +1534,139 @@ class TestProbeConvertedFile:
     ):
         mock_get_audio_info.return_value = {"bitrate": None}
 
-        assert _probe_converted_file("/path/to/output.mp3", "MP3").bitrate == 320
+        assert (
+            _probe_converted_file("/path/to/output.mp3", "MP3").audio_info["bitrate"]
+            == 320
+        )
 
 
-class TestUpdateDatabaseRecord:
-    @pytest.fixture(autouse=True)
-    def _mock_getsize(self):
-        # The converted file exists on disk by the time this runs in production;
-        # stub its size so the unit tests need no real file.
-        with patch("rekordbox_edit.api.convert.os.path.getsize", return_value=987654):
-            yield
+def _converted(bitrate=1000, bit_depth=16, sample_rate=44100, file_size=987654):
+    """A ConvertedFileProbe with a complete AudioInfo, for the apply half.
 
-    @patch("rekordbox_edit.api.convert.get_audio_info")
-    def test_sets_file_size_from_converted_file(
-        self, mock_get_audio_info, make_djmd_content_item
-    ):
-        mock_content = make_djmd_content_item(ID=123, BitDepth=24)
-        mock_get_audio_info.return_value = {
-            "bitrate": 1000,
-            "bit_depth": 16,
-            "sample_rate": 44100,
-        }
+    The apply half takes the probe as a value, so these tests need no file on
+    disk and no ffmpeg.
+    """
+    return ConvertedFileProbe(
+        audio_info=AudioInfo(
+            bit_depth=bit_depth,
+            sample_rate=sample_rate,
+            channels=2,
+            bitrate=bitrate,
+            codec="pcm_s16be",
+            container="aiff",
+            duration=180.0,
+        ),
+        file_size=file_size,
+    )
 
-        _update_database_record(mock_content, "output.aiff", "/path/to", "AIFF")
 
-        assert mock_content.FileSize == 987654
+class TestApplyConvertedRecord:
+    def test_sets_file_size_from_the_probe(self, make_djmd_content_item):
+        content = make_djmd_content_item(ID=123, BitDepth=24)
 
-    @patch("rekordbox_edit.api.convert.get_audio_info")
-    def test_normalizes_folder_path_separators(
-        self, mock_get_audio_info, make_djmd_content_item
-    ):
-        mock_content = make_djmd_content_item(ID=123, BitDepth=24)
-        mock_get_audio_info.return_value = {
-            "bitrate": 1000,
-            "bit_depth": 16,
-            "sample_rate": 44100,
-        }
+        _apply_converted_record(
+            content, _converted(), "output.aiff", "/path/to", "AIFF"
+        )
+
+        assert content.FileSize == 987654
+
+    def test_normalizes_folder_path_separators(self, make_djmd_content_item):
+        content = make_djmd_content_item(ID=123, BitDepth=24)
 
         # new_folder arrives with Windows separators, as os.path.dirname yields.
-        _update_database_record(mock_content, "song.aiff", r"A:\Music\dir", "AIFF")
+        _apply_converted_record(
+            content, _converted(), "song.aiff", r"A:\Music\dir", "AIFF"
+        )
 
-        assert mock_content.FolderPath == "A:/Music/dir/song.aiff"
+        assert content.FolderPath == "A:/Music/dir/song.aiff"
 
-    @patch("rekordbox_edit.api.convert.get_audio_info")
     def test_org_folder_path_follows_when_it_matched_old_path(
-        self, mock_get_audio_info, make_djmd_content_item
+        self, make_djmd_content_item
     ):
-        mock_content = make_djmd_content_item(
+        content = make_djmd_content_item(
             ID=123, BitDepth=24, FolderPath="A:/Music/song.wav"
         )
-        mock_content.OrgFolderPath = "A:/Music/song.wav"  # matches the old path
-        mock_get_audio_info.return_value = {
-            "bitrate": 1000,
-            "bit_depth": 16,
-            "sample_rate": 44100,
-        }
+        content.OrgFolderPath = "A:/Music/song.wav"  # matches the old path
 
-        _update_database_record(mock_content, "song.aiff", "A:/Music", "AIFF")
+        _apply_converted_record(content, _converted(), "song.aiff", "A:/Music", "AIFF")
 
-        assert mock_content.OrgFolderPath == "A:/Music/song.aiff"
+        assert content.OrgFolderPath == "A:/Music/song.aiff"
 
-    @patch("rekordbox_edit.api.convert.get_audio_info")
-    def test_org_folder_path_left_alone_when_it_differed(
-        self, mock_get_audio_info, make_djmd_content_item
-    ):
-        mock_content = make_djmd_content_item(
+    def test_org_folder_path_left_alone_when_it_differed(self, make_djmd_content_item):
+        content = make_djmd_content_item(
             ID=123, BitDepth=24, FolderPath="A:/Music/song.wav"
         )
-        mock_content.OrgFolderPath = "A:/OriginalImport/song.wav"  # a real original
-        mock_get_audio_info.return_value = {
-            "bitrate": 1000,
-            "bit_depth": 16,
-            "sample_rate": 44100,
-        }
+        content.OrgFolderPath = "A:/OriginalImport/song.wav"  # a real original
 
-        _update_database_record(mock_content, "song.aiff", "A:/Music", "AIFF")
+        _apply_converted_record(content, _converted(), "song.aiff", "A:/Music", "AIFF")
 
-        assert mock_content.OrgFolderPath == "A:/OriginalImport/song.wav"
+        assert content.OrgFolderPath == "A:/OriginalImport/song.wav"
 
-    @patch("rekordbox_edit.api.convert.get_audio_info")
-    def test_flac_sets_bitrate_zero(self, mock_get_audio_info, make_djmd_content_item):
-        mock_content = make_djmd_content_item(ID=123, BitDepth=24)
-        mock_get_audio_info.return_value = {
-            "bitrate": 1000,
-            "bit_depth": 24,
-            "sample_rate": 44100,
-        }
+    def test_flac_sets_bitrate_zero(self, make_djmd_content_item):
+        content = make_djmd_content_item(ID=123, BitDepth=24)
 
-        _update_database_record(mock_content, "output.flac", "/path/to", "FLAC")
+        _apply_converted_record(
+            content, _converted(bit_depth=24), "output.flac", "/path/to", "FLAC"
+        )
 
-        assert mock_content.FileNameL == "output.flac"
-        assert mock_content.FolderPath == "/path/to/output.flac"
-        assert mock_content.BitRate == 0
+        assert content.FileNameL == "output.flac"
+        assert content.FolderPath == "/path/to/output.flac"
+        assert content.BitRate == 0
 
-    @patch("rekordbox_edit.api.convert.get_audio_info")
     def test_hi_res_output_updates_bit_depth_and_sample_rate(
-        self, mock_get_audio_info, make_djmd_content_item
+        self, make_djmd_content_item
     ):
-        mock_content = make_djmd_content_item(ID=123, BitDepth=24, SampleRate=96000)
-        mock_get_audio_info.return_value = {
-            "bitrate": 1411,
-            "bit_depth": 16,
-            "sample_rate": 44100,
-        }
+        content = make_djmd_content_item(ID=123, BitDepth=24, SampleRate=96000)
 
-        _update_database_record(mock_content, "output.aiff", "/path/to", "AIFF")
+        _apply_converted_record(
+            content, _converted(bitrate=1411), "output.aiff", "/path/to", "AIFF"
+        )
 
-        assert mock_content.BitDepth == 16
-        assert mock_content.SampleRate == 44100
+        assert content.BitDepth == 16
+        assert content.SampleRate == 44100
 
-    @patch("rekordbox_edit.api.convert.get_audio_info")
     def test_unknown_probe_values_leave_db_fields_unchanged(
-        self, mock_get_audio_info, make_djmd_content_item
+        self, make_djmd_content_item
     ):
-        mock_content = make_djmd_content_item(ID=123, BitDepth=24, SampleRate=96000)
-        mock_get_audio_info.return_value = {
-            "bitrate": 1411,
-            "bit_depth": None,
-            "sample_rate": None,
-        }
+        content = make_djmd_content_item(ID=123, BitDepth=24, SampleRate=96000)
 
-        _update_database_record(mock_content, "output.aiff", "/path/to", "AIFF")
+        _apply_converted_record(
+            content,
+            _converted(bitrate=1411, bit_depth=None, sample_rate=None),
+            "output.aiff",
+            "/path/to",
+            "AIFF",
+        )
 
-        assert mock_content.BitDepth == 24
-        assert mock_content.SampleRate == 96000
+        assert content.BitDepth == 24
+        assert content.SampleRate == 96000
 
-    @patch("rekordbox_edit.api.convert.get_audio_info")
-    def test_mp3_sets_bitrate_from_probe(
-        self, mock_get_audio_info, make_djmd_content_item
-    ):
-        mock_content = make_djmd_content_item(ID=123)
-        mock_get_audio_info.return_value = {
-            "bitrate": 320,
-            "bit_depth": None,
-            "sample_rate": 44100,
-        }
+    def test_mp3_sets_bitrate_from_the_probe(self, make_djmd_content_item):
+        content = make_djmd_content_item(ID=123)
 
-        _update_database_record(mock_content, "output.mp3", "/path/to", "MP3")
+        _apply_converted_record(
+            content,
+            _converted(bitrate=320, bit_depth=None),
+            "output.mp3",
+            "/path/to",
+            "MP3",
+        )
 
-        assert mock_content.BitRate == 320
+        assert content.BitRate == 320
 
-    @patch("rekordbox_edit.api.convert.get_audio_info")
-    def test_mp3_none_bitrate_defaults_to_320(
-        self, mock_get_audio_info, make_djmd_content_item
-    ):
-        mock_content = make_djmd_content_item(ID=123)
-        mock_get_audio_info.return_value = {
-            "bitrate": None,
-            "bit_depth": None,
-            "sample_rate": 44100,
-        }
+    def test_mp3_output_updates_bit_depth_and_sample_rate(self, make_djmd_content_item):
+        content = make_djmd_content_item(ID=123, BitDepth=24, SampleRate=96000)
 
-        _update_database_record(mock_content, "output.mp3", "/path/to", "MP3")
+        _apply_converted_record(
+            content,
+            _converted(bitrate=320, bit_depth=None, sample_rate=48000),
+            "output.mp3",
+            "/path/to",
+            "MP3",
+        )
 
-        assert mock_content.BitRate == 320
-
-    @patch("rekordbox_edit.api.convert.get_audio_info")
-    def test_mp3_output_updates_bit_depth_and_sample_rate(
-        self, mock_get_audio_info, make_djmd_content_item
-    ):
-        mock_content = make_djmd_content_item(ID=123, BitDepth=24, SampleRate=96000)
-        mock_get_audio_info.return_value = {
-            "bitrate": 320,
-            "bit_depth": None,
-            "sample_rate": 48000,
-        }
-
-        _update_database_record(mock_content, "output.mp3", "/path/to", "MP3")
-
-        assert mock_content.BitDepth == 16
-        assert mock_content.SampleRate == 48000
+        assert content.BitDepth == 16
+        assert content.SampleRate == 48000
 
 
 class TestUpdateAnlzPaths:

--- a/tests/api/test_convert.py
+++ b/tests/api/test_convert.py
@@ -11,6 +11,7 @@ from rekordbox_edit.api.convert import (
     _get_output_path,
     _hi_res_output_kwargs,
     _mp3_output_kwargs,
+    _probe_converted_file,
     _rollback_and_cleanup,
     _run_ffmpeg,
     _update_anlz_paths,
@@ -1312,6 +1313,33 @@ class TestMp3OutputKwargs:
         assert _mp3_output_kwargs(22050)["ar"] == 22050
 
 
+class TestProbeConvertedFile:
+    """The probe half runs off the main thread once encoding is parallel, so it
+    must reach its answer from the filesystem alone."""
+
+    @patch("rekordbox_edit.api.convert.os.path.getsize", return_value=987654)
+    @patch("rekordbox_edit.api.convert.get_audio_info")
+    def test_reads_size_and_audio_without_a_session(
+        self, mock_get_audio_info, _mock_getsize
+    ):
+        mock_get_audio_info.return_value = {"bitrate": 1411, "bit_depth": 16}
+
+        probe = _probe_converted_file("/path/to/output.aiff", "AIFF")
+
+        assert probe.file_size == 987654
+        assert probe.bitrate == 1411
+        assert probe.audio_info["bit_depth"] == 16
+
+    @patch("rekordbox_edit.api.convert.os.path.getsize", return_value=1)
+    @patch("rekordbox_edit.api.convert.get_audio_info")
+    def test_mp3_without_a_probed_bitrate_assumes_320(
+        self, mock_get_audio_info, _mock_getsize
+    ):
+        mock_get_audio_info.return_value = {"bitrate": None}
+
+        assert _probe_converted_file("/path/to/output.mp3", "MP3").bitrate == 320
+
+
 class TestUpdateDatabaseRecord:
     @pytest.fixture(autouse=True)
     def _mock_getsize(self):
@@ -1324,16 +1352,14 @@ class TestUpdateDatabaseRecord:
     def test_sets_file_size_from_converted_file(
         self, mock_get_audio_info, make_djmd_content_item
     ):
-        mock_db = Mock()
         mock_content = make_djmd_content_item(ID=123, BitDepth=24)
-        mock_db.get_content().filter_by(ID=123).first.return_value = mock_content
         mock_get_audio_info.return_value = {
             "bitrate": 1000,
             "bit_depth": 16,
             "sample_rate": 44100,
         }
 
-        _update_database_record(mock_db, "123", "output.aiff", "/path/to", "AIFF")
+        _update_database_record(mock_content, "output.aiff", "/path/to", "AIFF")
 
         assert mock_content.FileSize == 987654
 
@@ -1341,9 +1367,7 @@ class TestUpdateDatabaseRecord:
     def test_normalizes_folder_path_separators(
         self, mock_get_audio_info, make_djmd_content_item
     ):
-        mock_db = Mock()
         mock_content = make_djmd_content_item(ID=123, BitDepth=24)
-        mock_db.get_content().filter_by(ID=123).first.return_value = mock_content
         mock_get_audio_info.return_value = {
             "bitrate": 1000,
             "bit_depth": 16,
@@ -1351,7 +1375,7 @@ class TestUpdateDatabaseRecord:
         }
 
         # new_folder arrives with Windows separators, as os.path.dirname yields.
-        _update_database_record(mock_db, "123", "song.aiff", r"A:\Music\dir", "AIFF")
+        _update_database_record(mock_content, "song.aiff", r"A:\Music\dir", "AIFF")
 
         assert mock_content.FolderPath == "A:/Music/dir/song.aiff"
 
@@ -1359,19 +1383,17 @@ class TestUpdateDatabaseRecord:
     def test_org_folder_path_follows_when_it_matched_old_path(
         self, mock_get_audio_info, make_djmd_content_item
     ):
-        mock_db = Mock()
         mock_content = make_djmd_content_item(
             ID=123, BitDepth=24, FolderPath="A:/Music/song.wav"
         )
         mock_content.OrgFolderPath = "A:/Music/song.wav"  # matches the old path
-        mock_db.get_content().filter_by(ID=123).first.return_value = mock_content
         mock_get_audio_info.return_value = {
             "bitrate": 1000,
             "bit_depth": 16,
             "sample_rate": 44100,
         }
 
-        _update_database_record(mock_db, "123", "song.aiff", "A:/Music", "AIFF")
+        _update_database_record(mock_content, "song.aiff", "A:/Music", "AIFF")
 
         assert mock_content.OrgFolderPath == "A:/Music/song.aiff"
 
@@ -1379,34 +1401,30 @@ class TestUpdateDatabaseRecord:
     def test_org_folder_path_left_alone_when_it_differed(
         self, mock_get_audio_info, make_djmd_content_item
     ):
-        mock_db = Mock()
         mock_content = make_djmd_content_item(
             ID=123, BitDepth=24, FolderPath="A:/Music/song.wav"
         )
         mock_content.OrgFolderPath = "A:/OriginalImport/song.wav"  # a real original
-        mock_db.get_content().filter_by(ID=123).first.return_value = mock_content
         mock_get_audio_info.return_value = {
             "bitrate": 1000,
             "bit_depth": 16,
             "sample_rate": 44100,
         }
 
-        _update_database_record(mock_db, "123", "song.aiff", "A:/Music", "AIFF")
+        _update_database_record(mock_content, "song.aiff", "A:/Music", "AIFF")
 
         assert mock_content.OrgFolderPath == "A:/OriginalImport/song.wav"
 
     @patch("rekordbox_edit.api.convert.get_audio_info")
     def test_flac_sets_bitrate_zero(self, mock_get_audio_info, make_djmd_content_item):
-        mock_db = Mock()
         mock_content = make_djmd_content_item(ID=123, BitDepth=24)
-        mock_db.get_content().filter_by(ID=123).first.return_value = mock_content
         mock_get_audio_info.return_value = {
             "bitrate": 1000,
             "bit_depth": 24,
             "sample_rate": 44100,
         }
 
-        _update_database_record(mock_db, "123", "output.flac", "/path/to", "FLAC")
+        _update_database_record(mock_content, "output.flac", "/path/to", "FLAC")
 
         assert mock_content.FileNameL == "output.flac"
         assert mock_content.FolderPath == "/path/to/output.flac"
@@ -1416,16 +1434,14 @@ class TestUpdateDatabaseRecord:
     def test_hi_res_output_updates_bit_depth_and_sample_rate(
         self, mock_get_audio_info, make_djmd_content_item
     ):
-        mock_db = Mock()
         mock_content = make_djmd_content_item(ID=123, BitDepth=24, SampleRate=96000)
-        mock_db.get_content().filter_by(ID=123).first.return_value = mock_content
         mock_get_audio_info.return_value = {
             "bitrate": 1411,
             "bit_depth": 16,
             "sample_rate": 44100,
         }
 
-        _update_database_record(mock_db, "123", "output.aiff", "/path/to", "AIFF")
+        _update_database_record(mock_content, "output.aiff", "/path/to", "AIFF")
 
         assert mock_content.BitDepth == 16
         assert mock_content.SampleRate == 44100
@@ -1434,16 +1450,14 @@ class TestUpdateDatabaseRecord:
     def test_unknown_probe_values_leave_db_fields_unchanged(
         self, mock_get_audio_info, make_djmd_content_item
     ):
-        mock_db = Mock()
         mock_content = make_djmd_content_item(ID=123, BitDepth=24, SampleRate=96000)
-        mock_db.get_content().filter_by(ID=123).first.return_value = mock_content
         mock_get_audio_info.return_value = {
             "bitrate": 1411,
             "bit_depth": None,
             "sample_rate": None,
         }
 
-        _update_database_record(mock_db, "123", "output.aiff", "/path/to", "AIFF")
+        _update_database_record(mock_content, "output.aiff", "/path/to", "AIFF")
 
         assert mock_content.BitDepth == 24
         assert mock_content.SampleRate == 96000
@@ -1452,16 +1466,14 @@ class TestUpdateDatabaseRecord:
     def test_mp3_sets_bitrate_from_probe(
         self, mock_get_audio_info, make_djmd_content_item
     ):
-        mock_db = Mock()
         mock_content = make_djmd_content_item(ID=123)
-        mock_db.get_content().filter_by(ID=123).first.return_value = mock_content
         mock_get_audio_info.return_value = {
             "bitrate": 320,
             "bit_depth": None,
             "sample_rate": 44100,
         }
 
-        _update_database_record(mock_db, "123", "output.mp3", "/path/to", "MP3")
+        _update_database_record(mock_content, "output.mp3", "/path/to", "MP3")
 
         assert mock_content.BitRate == 320
 
@@ -1469,16 +1481,14 @@ class TestUpdateDatabaseRecord:
     def test_mp3_none_bitrate_defaults_to_320(
         self, mock_get_audio_info, make_djmd_content_item
     ):
-        mock_db = Mock()
         mock_content = make_djmd_content_item(ID=123)
-        mock_db.get_content().filter_by(ID=123).first.return_value = mock_content
         mock_get_audio_info.return_value = {
             "bitrate": None,
             "bit_depth": None,
             "sample_rate": 44100,
         }
 
-        _update_database_record(mock_db, "123", "output.mp3", "/path/to", "MP3")
+        _update_database_record(mock_content, "output.mp3", "/path/to", "MP3")
 
         assert mock_content.BitRate == 320
 
@@ -1486,26 +1496,17 @@ class TestUpdateDatabaseRecord:
     def test_mp3_output_updates_bit_depth_and_sample_rate(
         self, mock_get_audio_info, make_djmd_content_item
     ):
-        mock_db = Mock()
         mock_content = make_djmd_content_item(ID=123, BitDepth=24, SampleRate=96000)
-        mock_db.get_content().filter_by(ID=123).first.return_value = mock_content
         mock_get_audio_info.return_value = {
             "bitrate": 320,
             "bit_depth": None,
             "sample_rate": 48000,
         }
 
-        _update_database_record(mock_db, "123", "output.mp3", "/path/to", "MP3")
+        _update_database_record(mock_content, "output.mp3", "/path/to", "MP3")
 
         assert mock_content.BitDepth == 16
         assert mock_content.SampleRate == 48000
-
-    def test_content_not_found_raises(self):
-        mock_db = Mock()
-        mock_db.get_content().filter_by(ID=123).first.return_value = None
-
-        with pytest.raises(Exception, match="Content record with ID 123 not found"):
-            _update_database_record(mock_db, "123", "output.flac", "/path/to", "FLAC")
 
 
 class TestUpdateAnlzPaths:

--- a/tests/cli/test_convert.py
+++ b/tests/cli/test_convert.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 import pytest
 from click.testing import CliRunner
 
+from rekordbox_edit.api.convert import ConvertAborted
 from rekordbox_edit.cli.convert import convert_command
 from rekordbox_edit.models import (
     ConvertOp,
@@ -306,3 +307,50 @@ class TestConvertCommand:
 
         assert result.exit_code == 0
         mock_db_class.assert_called_once()
+
+
+class TestPartialBatchReporting:
+    @patch("rekordbox_edit.cli.convert.convert")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None)
+    def test_a_stopped_batch_reports_what_survived(
+        self, _pid, mock_db_class, mock_convert, mock_logger
+    ):
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_convert.side_effect = ConvertAborted(
+            "Conversion failed for /in7.wav",
+            failed_path="/in7.wav",
+            converted=6,
+            not_attempted=3,
+        )
+
+        result = CliRunner().invoke(convert_command, ["--format-out", "aiff", "--yes"])
+
+        assert result.exit_code == 1
+        messages = " ".join(str(c) for c in mock_logger.error.call_args_list)
+        assert "/in7.wav" in messages
+        assert "6 file(s) converted and kept" in messages
+        assert "3 not attempted" in messages
+
+
+class TestMissingSourceReporting:
+    @patch("rekordbox_edit.cli.convert.convert")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None)
+    def test_a_vanished_source_is_reported_from_the_live_pass(
+        self, _pid, mock_db_class, mock_convert, mock_logger
+    ):
+        # A dry run cannot predict this one, so it has to survive the live-run
+        # filter that drops skips the preview already reported.
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_convert.side_effect = [
+            _response(),
+            _response(skipped=[SkippedTrack(id="9", reason="file_not_found")]),
+        ]
+
+        with patch("rekordbox_edit.cli.convert.confirm", return_value=True):
+            result = CliRunner().invoke(convert_command, ["--format-out", "aiff"])
+
+        assert result.exit_code == 0
+        warnings = " ".join(str(c) for c in mock_logger.warning.call_args_list)
+        assert "source file is gone" in warnings

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -12,12 +12,12 @@ from rekordbox_edit.cli._utils import (
     _validate_scripting_preconditions,
 )
 from rekordbox_edit.models import (
-    ConvertRequest,
     ConvertOp,
+    ConvertRequest,
     ConvertResponse,
     ConvertResult,
-    EditRequest,
     EditOp,
+    EditRequest,
     EditResponse,
     EditResult,
     SearchRequest,
@@ -72,18 +72,31 @@ class TestHandleStdin:
 
 class TestValidateScriptingPreconditions:
     def test_scripting_mode_without_confirmation_raises(self):
-        args = Mock(dry_run=False, yes=False)
         with pytest.raises(click.UsageError):
-            _validate_scripting_preconditions(PrintChoice.IDS, args, piped_stdin=False)
+            _validate_scripting_preconditions(
+                PrintChoice.IDS, piped_stdin=False, dry_run=False, yes=False
+            )
 
     def test_scripting_mode_with_yes_ok(self):
-        args = Mock(dry_run=False, yes=True)
-        _validate_scripting_preconditions(PrintChoice.IDS, args, piped_stdin=False)
+        _validate_scripting_preconditions(
+            PrintChoice.IDS, piped_stdin=False, dry_run=False, yes=True
+        )
+
+    def test_scripting_mode_with_dry_run_ok(self):
+        _validate_scripting_preconditions(
+            PrintChoice.IDS, piped_stdin=False, dry_run=True, yes=False
+        )
 
     def test_piped_stdin_without_confirmation_raises(self):
-        args = Mock(dry_run=False, yes=False)
         with pytest.raises(click.UsageError, match="Piping"):
-            _validate_scripting_preconditions(None, args, piped_stdin=True)
+            _validate_scripting_preconditions(
+                None, piped_stdin=True, dry_run=False, yes=False
+            )
+
+    def test_piped_stdin_with_confirmation_ok(self):
+        _validate_scripting_preconditions(
+            None, piped_stdin=True, dry_run=False, yes=True
+        )
 
 
 class TestNarrowToTrackIds:


### PR DESCRIPTION
Replaces `convert()`'s single batch commit with one commit per file.

## Changes

- Split the record update into a session-free probe half and a filesystem-free apply half, called directly from the loop, and pass the content row in rather than re-querying it.
- Encode to a `.rbe-convert-` temp file beside the destination, then `os.replace` into place. The move stays within one filesystem, so an interrupted encode never leaves a truncated file at the path the database points at. Each run sweeps orphaned temps from the directories it writes to.
- Commit each conversion in its own transaction. ANLZ path updates and the original deletion move into the loop, right after that file's commit, so peak disk stays flat instead of doubling.
- Add `ConvertAborted`, carrying the converted, failed, and not-attempted counts. Only the failing file rolls back.
- Report those counts from the CLI and exit 1, rather than falling through to `main.py`'s unhandled-exception handler.
- Drop `_cleanup_converted_files`, which deleted outputs at their final paths and could remove a file another run produced.
- Skip a source file that vanished between the preview and the conversion, reporting `file_not_found`, rather than aborting the batch. A confirmation prompt can sit for minutes, so a moved track is routine rather than systemic.
- Document what an interrupted run leaves behind in `docs/commands/convert.md`.
- Take the confirmation flags as keyword arguments in `_validate_scripting_preconditions`, so the three write commands stop building a throwaway class to carry two booleans they already hold as locals.

## Behavior Changes

- A stopped run leaves real committed work. Converted files are permanent and their originals are already gone if the delete policy called for it.
- Ctrl-C during an encode surfaces as `ConvertAborted` with the counts rather than a bare `KeyboardInterrupt`.

## Testing

593 unit and CLI tests pass, each commit green on its own. E2E docker suite passes at 33. Lint, typecheck, and `mkdocs build --strict` clean. `api/convert.py` at 99%.

New cases: a mid-batch failure keeps earlier commits and reports the right counts; a vanished source is skipped and the batch continues; the delete policy is decided per file across a mixed lossless/lossy pair; the temp path keeps its extension so ffmpeg still infers the format; the sweep removes orphans and leaves bystanders alone; the probe half works without a session.
