### PR TITLE
docs: record how master.db behaves under concurrent access

### DIFF
--- a/research/README.md
+++ b/research/README.md
@@ -26,6 +26,11 @@ formal and terse, and states findings as the evidence supports them.
 
 ## Investigations
 
+- **`database-concurrency/`** — how `master.db` behaves when more than one thing
+  writes to it: WAL mode, why a read opens no transaction, how SQLAlchemy's
+  identity map hides fresh data, and what that means for the plan-apply window
+  and for maintaining Rekordbox's USN counter. Includes a glossary of the
+  database terms the other findings use.
 - **`convert-reanalysis-impact/`** — what a `convert` run does to a track's
   analysis (the `DjmdContent` row, `DjmdCue` rows, and on-disk ANLZ files), why
   re-analysis rather than conversion is what moves a beat grid, and how far the

--- a/research/database-concurrency/database-concurrency.md
+++ b/research/database-concurrency/database-concurrency.md
@@ -1,0 +1,197 @@
+# How master.db Behaves Under Concurrent Access
+
+## Question
+
+Rekordbox-edit is a single-writer tool by design, and a merged advisory lock now
+enforces that between rekordbox-edit processes. Two writers remain outside that
+lock: Rekordbox itself, which a user may allow past the running-Rekordbox prompt,
+and the filesystem, which no database lock covers.
+
+Two design questions ran into the same wall and prompted this investigation.
+
+1. Every write command classifies twice, previewing and then re-classifying after
+   a confirmation prompt. What can change in that window? Answered in
+   [plan-apply-window.md](plan-apply-window.md).
+2. Rekordbox tracks changes with a counter that rekordbox-edit does not maintain.
+   Can that counter be maintained safely while Rekordbox may also be writing to
+   it? Answered in [usn-maintenance.md](usn-maintenance.md).
+
+This document records what both investigations established about `master.db`
+itself, independent of either design. The two write-ups above depend on it.
+
+## Terms
+
+Definitions are scoped to how each term applies here, not to their full generality.
+
+**SQLite.** The database engine Rekordbox uses. There is no server process: the
+database is a single file, and every program that opens it coordinates with the
+others through locks taken on that file. `master.db` is additionally encrypted
+with SQLCipher, which changes how the file is read but not how it is locked.
+
+**Transaction.** A group of statements that take effect together or not at all.
+A transaction ends when it is *committed*, making its changes permanent and
+visible to others, or *rolled back*, discarding them.
+
+**Write lock.** SQLite permits one writer at a time. A connection acquires the
+write lock when it first modifies data and holds it until it commits. Other
+writers wait.
+
+**Busy timeout.** How long a connection waits for a lock before giving up and
+raising `database is locked`. A wait, not a failure, provided the holder commits
+in time.
+
+**Journal mode.** How SQLite keeps the database recoverable mid-write. Two modes
+matter here. Under `DELETE`, the older default, changes are written in place and
+the original pages are kept in a side file, which means readers and writers block
+each other. Under `WAL` (write-ahead logging), changes are appended to a separate
+log file, which lets readers proceed while a writer works.
+
+**Snapshot.** Under WAL, a transaction that reads may be pinned to the database
+as it stood at that moment, so later statements in the same transaction do not
+see other connections' newer commits. Whether a snapshot is actually taken
+depends on when the driver opens the transaction, which is the subject of a
+finding below.
+
+**Deferred and immediate.** `BEGIN` (deferred) opens a transaction without taking
+any lock, acquiring one only when a statement needs it. `BEGIN IMMEDIATE` takes
+the write lock up front.
+
+**Lost update.** The failure mode where two writers each read a value, each add
+to it, and each write back, so one writer's contribution disappears. Neither sees
+an error. Avoiding it requires that the read and the write cannot be separated by
+another writer's commit.
+
+**Atomic.** Indivisible from another connection's point of view. A single
+`UPDATE` that computes from the column's own value, such as
+`SET int_1 = int_1 + 1`, is atomic in a way that reading the value and then
+writing it back is not.
+
+**SQLAlchemy.** The library that maps Python objects onto database rows, layered
+under pyrekordbox. Two of its concepts appear repeatedly.
+
+**Session.** SQLAlchemy's unit of work. Rekordbox-edit opens one per command and
+holds it for the command's duration. A Session tracks the objects it has loaded
+and the changes made to them, and issues a commit on request.
+
+**Identity map.** The Session's cache of already-loaded rows, keyed by primary
+key. Loading the same row twice in one Session returns the *same Python object*
+both times, and the second load does not refresh its values from the database.
+
+**USN.** Rekordbox's change counter, short for unique sequence number. Covered in
+[usn-maintenance.md](usn-maintenance.md).
+
+## Method
+
+Probes run against a throwaway copy of the committed e2e fixture,
+`tests/e2e/fixtures/macos/master.6.8.6.db`, through the SQLCipher engine
+pyrekordbox builds, except where a claim is about SQLite generally rather than
+about `master.db`, in which case plain SQLite is used for portability. Each probe
+is named where it is cited. Scripts live in `scripts/`, output in `evidence/`.
+
+Claims about rekordbox-edit's own behavior were established by reading
+`cli/_utils.py`, `api/edit.py`, `api/field_handlers.py`, `api/convert.py`, and
+`api/import_.py`.
+
+## Findings
+
+### master.db Uses WAL, Not DELETE
+
+`PRAGMA journal_mode` returns `wal`. An earlier analysis of this repository
+assumed `DELETE` and reasoned from it; that reasoning does not hold.
+
+The practical consequence is that a reader never blocks a writer. Rekordbox-edit
+holding a session open across a long confirmation prompt does not stop Rekordbox
+from committing, and never did.
+
+WAL also leaves `-wal` and `-shm` sidecar files beside the database. Any script
+that copies the fixture must remove all three, or a later copy inherits pages
+from an earlier run. An early version of these probes had that defect, and its
+results moved between runs.
+
+### The Driver Does Not Open a Transaction for a Read
+
+This is the finding both investigations turned on, and it is not obvious from the
+code.
+
+SQLAlchemy reports `in_transaction() == True` for the whole span of a command.
+The underlying pysqlite driver, which pysqlcipher inherits from, issues no `BEGIN`
+before a `SELECT`. It issues one only before a statement that modifies data. So
+rekordbox-edit's reads run in autocommit at the SQLite level while SQLAlchemy
+believes a transaction is open, and no snapshot is taken.
+
+`scripts/wal_snapshot.py` demonstrates this against the real engine: with
+`in_transaction()` reporting `True` throughout, an outside writer committed and
+the next read in the supposedly open transaction saw the new value.
+
+Two consequences follow, one from each investigation.
+
+Reads are not a consistent snapshot. Anything a command reads may be newer than
+what it read a moment earlier, which is the mechanism behind the plan-apply
+window.
+
+Writes need no retry logic. A statement that modifies data opens its own write
+transaction at that moment and reads current values, so it cannot fail with
+`SQLITE_BUSY_SNAPSHOT` on an upgrade that never happens.
+
+This rests on a driver default rather than on anything this repository controls.
+Setting `isolation_level=None` on the connection, or a driver change, would
+reverse both consequences.
+
+### The Identity Map Hides Fresh Data From the ORM
+
+The two paragraphs above describe SQL. Reading through mapped objects behaves
+differently, and the difference matters.
+
+`scripts/identity_probe.py` shows a second query in the same Session returning
+the *same objects* as the first, carrying the *old* values, with
+`apply_pass[0] is preview[0]` holding. The outside commit became visible only
+after an explicit `expire_all()`.
+
+So the same Session can be simultaneously fresh and stale: a `WHERE` clause is
+evaluated by SQLite against current data, while the objects handed back for rows
+already loaded carry the values they had when first read.
+
+`scripts/membership_probe.py` separates the two effects. Which rows come back can
+change; what an already-loaded row says cannot.
+
+### Reading a Counter and Writing It Back Loses Updates
+
+`scripts/concurrent_increment.py`, two writers against the real engine:
+
+```
+read-then-write  694 -> 719 (expected 744)   25 increment(s) LOST, errors: none
+atomic-update    694 -> 744 (expected 744)   OK, no duplicate stamps
+```
+
+Exactly one writer's work vanished, silently. Expressing the increment as
+`UPDATE ... SET int_1 = int_1 + :n` instead is exact, because the value is never
+read into application code and so cannot go stale.
+
+`RETURNING` is available for recovering the new value: SQLCipher reports SQLite
+3.51.1, above the 3.35 that clause requires.
+
+### The Busy Timeout Pragma Is Redundant at Its Current Value
+
+Opening the fixture through pyrekordbox with rekordbox-edit not imported, so the
+`connect` listener in `cli/_utils.py` is not registered, `PRAGMA busy_timeout`
+already returns `5000`. The Python DBAPI sets it from `sqlite3.connect`'s default
+`timeout=5.0`.
+
+`BUSY_TIMEOUT_MS` is also `5000`, so the listener sets the value that is already
+in effect. It is harmless, and it does nothing. Either raise it, so a queued
+command waits longer than the default, or remove the listener.
+
+## Conclusion
+
+`master.db` is a WAL-mode SQLite database that permits one writer at a time and
+never blocks readers. Rekordbox-edit's advisory lock excludes other rekordbox-edit
+processes, so the writer it may actually contend with is Rekordbox.
+
+The single most consequential property is that the driver opens no transaction
+for a read. Rekordbox-edit's commands do not run against a stable view of the
+database, which is what makes the plan-apply window reachable. The same property
+means writes need no retry loop, which is what makes USN maintenance cheap.
+
+Correctness for any shared value therefore has to come from the statement being
+atomic, not from having checked beforehand that no one else was writing. A check
+is a courtesy; the statement is the guarantee.

--- a/research/database-concurrency/evidence/plan-apply-probes.txt
+++ b/research/database-concurrency/evidence/plan-apply-probes.txt
@@ -1,0 +1,16 @@
+=== snapshot_probe.py ===
+preview pass reads: 'before'
+outside writer committed
+apply pass reads:   'after'
+in_transaction between passes: True
+
+=== identity_probe.py ===
+preview pass: 'before'
+apply pass:   'before'
+same object as preview: True
+after expire_all: 'after'
+
+=== membership_probe.py ===
+preview matched: [(1, 'Burial - Archangel')]
+apply matched:   [(1, 'Burial - Archangel'), (2, 'Burial - Shell of Light')]
+

--- a/research/database-concurrency/evidence/usn-spikes.txt
+++ b/research/database-concurrency/evidence/usn-spikes.txt
@@ -1,0 +1,27 @@
+=== concurrent_increment.py ===
+2 writers x 25 increments, real SQLCipher engine:
+  read-then-write  694 -> 719 (expected 744)
+    25 increment(s) LOST, errors: none
+  atomic-update    694 -> 744 (expected 744)
+    OK, errors: none, duplicate stamps handed out: 0
+
+=== block_reservation.py ===
+1. Reserving a block of N in one statement
+   start 694, reserved 7, high 701
+   stamps for this commit: [695, 696, 697, 698, 699, 700, 701]
+   contiguous and ending at the counter: True
+
+2. Outside writer commits after our transaction opened with a read
+   our read at transaction open: 694
+   outside writer committed, counter now 697
+   our bump succeeded, high 699
+   computed from the fresh value, not our stale read: True
+   final counter 699, expected 699 -> OK
+
+=== wal_snapshot.py ===
+ours: read 5 rows, counter 694, in_transaction=True
+theirs: committed, counter now 697
+ours: still in_transaction=True
+ours: bump SUCCEEDED, high 699 (fresh value + 2 = 699)
+final counter 699, expected 699
+

--- a/research/database-concurrency/plan-apply-window.md
+++ b/research/database-concurrency/plan-apply-window.md
@@ -1,0 +1,71 @@
+# The Plan-Apply Window
+
+One of two questions under [database-concurrency.md](database-concurrency.md), whose Terms section defines the database vocabulary used here.
+
+## Question
+
+Every write command in rekordbox-edit classifies twice. The CLI calls the API with `dry_run=True` to build a preview, blocks on a confirmation prompt, then calls the API again to apply, and the second call re-runs the filter query and the classifier from scratch. What can change between those two passes, and what does each command do when it does?
+
+The question matters most for an interactive run, where the user may leave the prompt unanswered for minutes.
+
+## Hypothesis
+
+An earlier analysis held that a concurrent writer changing rows in that window makes the applied set diverge from the previewed one, silently. That analysis predates the single-writer advisory lock, which now excludes every other rekordbox-edit process for the duration of a command. The remaining writers are Rekordbox itself, which the user may allow past the running-Rekordbox prompt, and anything at all touching the filesystem.
+
+## Method
+
+Three probes isolate the database side, running against plain SQLite for portability. The database mechanics they rest on, and the terms used below, are recorded in [database-concurrency.md](database-concurrency.md). Each mirrors the shape of a real command: one `Session` opened for the whole command, a first query standing in for the preview, an outside writer on a separate connection standing in for Rekordbox, then a second query standing in for the apply pass.
+
+- `scripts/snapshot_probe.py` reads through raw SQL text, isolating SQLite's own visibility rules from the ORM's.
+- `scripts/identity_probe.py` reads through mapped objects, which is how `get_filtered_content` actually reads.
+- `scripts/membership_probe.py` separates the value of a loaded row from the membership of the filtered set.
+
+Output is recorded in `evidence/plan-apply-probes.txt`.
+
+The filesystem side was established by reading the write paths rather than by probe: `api/edit.py`, `api/field_handlers.py`, `api/convert.py`, `api/import_.py`, and their CLI wrappers.
+
+## Findings
+
+### An Outside Writer Is Not Blocked, and Its Commit Is Visible
+
+No read lock is held between statements, because the driver opens no transaction for a `SELECT`. See "The Driver Does Not Open a Transaction for a Read" in [database-concurrency.md](database-concurrency.md). The outside writer committed without waiting, and the second raw read returned the new value. A long confirmation prompt therefore does not hold the database still, and the earlier analysis was correct that the window is real.
+
+### The Identity Map Makes Loaded Rows Stale, Not Fresh
+
+Read through the ORM, the second pass returned the *same objects* as the first, carrying the *old* values, and `apply_pass[0] is preview[0]` held. The outside commit became visible only after an explicit `expire_all()`.
+
+This inverts the practical concern. The apply pass does not silently act on newer column values than the preview showed. It acts on values that may be stale, which is the safer direction and matches what the user approved.
+
+### Membership of the Filtered Set Does Drift
+
+The `WHERE` clause runs in SQLite against live data, and only objects already loaded come from the identity map. A row that did not match during the preview and matches by the time of the apply pass is loaded fresh and joins the operation.
+
+The probe demonstrates this: a preview matching one track applied to two, the second having been renamed underneath by the outside writer. The user approved one edit and would have received two.
+
+Set membership, not column values, is the database-side exposure.
+
+### The Filesystem Is Not Covered by Anything
+
+No lock, session, or transaction constrains the filesystem, and all three commands consult it during classification.
+
+`FolderPathField.validate_track` stats the target, compares its size against the stored `FileSize`, and probes its duration. Between passes a target can appear, vanish, or be replaced, so a track previewed as editable can become `file_not_found`, and a track the preview skipped can silently enter the applied set.
+
+`_classify_convert` checks `os.path.exists(output_path)` and reports `output_file_exists`. A file appearing at that path between passes drops a track from the batch; one disappearing adds a track the preview never showed.
+
+`import`'s `_expand_paths` re-walks every directory argument, and tags are re-read per file. Files created during the confirmation window are imported having never been previewed, and a file retagged in the window lands with metadata the user never saw. Directory arguments are exactly the high-count case, so this is the largest of the three exposures.
+
+### Two Defects Found Along the Way
+
+`cli/edit.py` guards `edit()` against `ValueError` on its preview calls (lines 76, 89, and 105) but not on either apply call (lines 134 and 142). The `--multi` guard raises `ValueError` when more than one op is classified without `multi` set. Since the apply pass reclassifies, a preview of exactly one op can become two, and the resulting `ValueError` reaches `main.py`'s unhandled-exception handler, which tells the user to file a GitHub issue against a routine condition.
+
+`FolderPathField` holds `self._probes`, an instance dictionary keyed by content ID and path, and `FIELD_HANDLERS` binds one instance per field at module scope. That cache outlives a single request and is shared across both passes. It is harmless today because `validate_track` re-runs and overwrites each entry before `apply` reads it, but it is request state living on a process-global object.
+
+## Conclusion
+
+The window is real, and the advisory lock does not close it: Rekordbox and the filesystem both remain outside it.
+
+The exposure is narrower than the original analysis stated, and differently shaped. Column values of rows the preview already saw do not drift, because the identity map returns the same stale objects. What drifts is which rows are in the set, and what the filesystem says about them.
+
+Passing the planned ops into the write call closes the membership half by construction, since the apply pass would no longer run a filter query at all. It does not close the filesystem half, which still requires re-checking each op against disk at apply time. The difference is that such a check produces an explicit outcome rather than a silent one, which argues for a new `SkipReason` reported in the response. That is a change to the `--print json` schema and therefore a change to the public API, which is the decision the design has to settle rather than assume.
+
+The two defects above are independent of that design and can be fixed on their own.

--- a/research/database-concurrency/scripts/block_reservation.py
+++ b/research/database-concurrency/scripts/block_reservation.py
@@ -1,0 +1,77 @@
+"""Two follow-ups to the atomic-increment spike.
+
+1. Block reservation: a commit buffers N changes, so the counter must advance
+   by N in one statement and hand back the block.
+2. The realistic transaction shape: RBE's transaction opens with a read (the
+   filter query), and an outside writer may commit before the counter bump.
+   Does the bump then fail, or silently compute from the current value?
+"""
+
+import shutil
+from pathlib import Path
+
+from pyrekordbox import Rekordbox6Database
+from sqlalchemy import text
+
+FIXTURE = Path("tests/e2e/fixtures/macos/master.6.8.6.db")
+SELECT = text("SELECT int_1 FROM agentRegistry WHERE registry_id = 'localUpdateCount'")
+RESERVE = text(
+    "UPDATE agentRegistry SET int_1 = int_1 + :n "
+    "WHERE registry_id = 'localUpdateCount' RETURNING int_1"
+)
+
+
+def cleanup(path):
+    # WAL mode leaves -wal and -shm beside the file; removing only the .db
+    # would let a later copy inherit a previous run's committed pages.
+    for suffix in ("", "-wal", "-shm"):
+        Path(str(path) + suffix).unlink(missing_ok=True)
+
+
+def copy(label):
+    dst = Path(f"/tmp/usn-spike2-{label}.db")
+    cleanup(dst)
+    shutil.copy(FIXTURE, dst)
+    return dst
+
+
+print("1. Reserving a block of N in one statement")
+path = copy("block")
+db = Rekordbox6Database(path=str(path))
+start = db.session.execute(SELECT).scalar()
+high = db.session.execute(RESERVE, {"n": 7}).scalar()
+db.session.commit()
+print(f"   start {start}, reserved 7, high {high}")
+print(f"   stamps for this commit: {list(range(high - 7 + 1, high + 1))}")
+print(f"   contiguous and ending at the counter: {high == start + 7}")
+db.close()
+path.unlink(missing_ok=True)
+
+print("\n2. Outside writer commits after our transaction opened with a read")
+path = copy("interleave")
+ours = Rekordbox6Database(path=str(path))
+theirs = Rekordbox6Database(path=str(path))
+
+opened_at = ours.session.execute(SELECT).scalar()
+print(f"   our read at transaction open: {opened_at}")
+
+theirs.session.execute(RESERVE, {"n": 3})
+theirs.session.commit()
+after_theirs = theirs.session.execute(SELECT).scalar()
+print(f"   outside writer committed, counter now {after_theirs}")
+
+try:
+    high = ours.session.execute(RESERVE, {"n": 2}).scalar()
+    ours.session.commit()
+    print(f"   our bump succeeded, high {high}")
+    print(f"   computed from the fresh value, not our stale read: {high == after_theirs + 2}")
+except Exception as e:
+    ours.session.rollback()
+    print(f"   our bump RAISED {type(e).__name__}: {str(e)[:90]}")
+
+final = ours.session.execute(SELECT).scalar()
+print(f"   final counter {final}, expected {opened_at + 5} -> "
+      f"{'OK' if final == opened_at + 5 else 'LOST'}")
+ours.close()
+theirs.close()
+path.unlink(missing_ok=True)

--- a/research/database-concurrency/scripts/concurrent_increment.py
+++ b/research/database-concurrency/scripts/concurrent_increment.py
@@ -1,0 +1,104 @@
+"""Spike: can the localUpdateCount read-modify-write be made atomic against a
+concurrent writer, on the real SQLCipher engine pyrekordbox builds?
+
+Two candidate shapes:
+  read-then-write  - what autoincrement_local_update_count does today
+  atomic UPDATE    - `SET int_1 = int_1 + n RETURNING int_1`, one statement
+
+Run against a throwaway copy of the committed e2e fixture.
+"""
+
+import shutil
+import sys
+import threading
+from pathlib import Path
+
+from pyrekordbox import Rekordbox6Database
+from sqlalchemy import text
+
+FIXTURE = Path("tests/e2e/fixtures/macos/master.6.8.6.db")
+BUMPS = 25
+WRITERS = 2
+
+SELECT = text("SELECT int_1 FROM agentRegistry WHERE registry_id = 'localUpdateCount'")
+NAIVE = text(
+    "UPDATE agentRegistry SET int_1 = :v WHERE registry_id = 'localUpdateCount'"
+)
+ATOMIC = text(
+    "UPDATE agentRegistry SET int_1 = int_1 + 1 "
+    "WHERE registry_id = 'localUpdateCount' RETURNING int_1"
+)
+
+
+def cleanup(path):
+    # WAL mode leaves -wal and -shm beside the file; removing only the .db
+    # would let a later copy inherit a previous run's committed pages.
+    for suffix in ("", "-wal", "-shm"):
+        Path(str(path) + suffix).unlink(missing_ok=True)
+
+
+def make_copy(label):
+    dst = Path(f"/tmp/usn-spike-{label}.db")
+    cleanup(dst)
+    shutil.copy(FIXTURE, dst)
+    return dst
+
+
+def writer(path, atomic, errors, stamps):
+    db = Rekordbox6Database(path=str(path))
+    try:
+        for _ in range(BUMPS):
+            try:
+                if atomic:
+                    new = db.session.execute(ATOMIC).scalar()
+                    stamps.append(new)
+                else:
+                    saw = db.session.execute(SELECT).scalar()
+                    db.session.execute(NAIVE, {"v": saw + 1})
+                db.session.commit()
+            except Exception as e:
+                db.session.rollback()
+                errors.append(type(e).__name__)
+    finally:
+        db.close()
+
+
+def run(label, atomic):
+    path = make_copy(label)
+    db = Rekordbox6Database(path=str(path))
+    start = db.session.execute(SELECT).scalar()
+    db.close()
+
+    errors, stamps = [], []
+    threads = [
+        threading.Thread(target=writer, args=(path, atomic, errors, stamps))
+        for _ in range(WRITERS)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    db = Rekordbox6Database(path=str(path))
+    final = db.session.execute(SELECT).scalar()
+    db.close()
+    cleanup(path)
+
+    expected = start + BUMPS * WRITERS
+    lost = expected - final
+    print(f"  {label:<16} {start} -> {final} (expected {expected})")
+    print(f"    {'OK' if lost == 0 else f'{lost} increment(s) LOST'}", end="")
+    print(f", errors: {sorted(set(errors)) or 'none'}", end="")
+    if atomic:
+        dupes = len(stamps) - len(set(stamps))
+        print(f", duplicate stamps handed out: {dupes}")
+    else:
+        print()
+
+
+if not FIXTURE.is_file():
+    sys.exit(f"fixture missing: {FIXTURE}")
+
+print(f"{WRITERS} writers x {BUMPS} increments, real SQLCipher engine:")
+run("read-then-write", atomic=False)
+run("atomic-update", atomic=True)

--- a/research/database-concurrency/scripts/identity_probe.py
+++ b/research/database-concurrency/scripts/identity_probe.py
@@ -1,0 +1,50 @@
+"""Same question, but through the ORM, which is how RBE actually reads rows.
+
+get_filtered_content() returns mapped DjmdContent objects, so what the apply
+pass sees depends on the identity map, not only on what SQLite returns.
+"""
+
+import sqlite3
+from pathlib import Path
+
+from sqlalchemy import String, create_engine, select
+from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class Row(Base):
+    __tablename__ = "t"
+    ID: Mapped[int] = mapped_column(primary_key=True)
+    Title: Mapped[str] = mapped_column(String)
+
+
+db = Path("/tmp/rbe-probe-identity.db")
+db.unlink(missing_ok=True)
+engine = create_engine(f"sqlite:///{db}")
+Base.metadata.create_all(engine)
+
+raw = sqlite3.connect(db)
+raw.execute("INSERT INTO t VALUES (1, 'before')")
+raw.commit()
+raw.close()
+
+session = Session(engine)
+
+preview = session.execute(select(Row)).scalars().all()
+print(f"preview pass: {preview[0].Title!r}")
+
+outside = sqlite3.connect(db, timeout=1)
+outside.execute("UPDATE t SET Title = 'after' WHERE ID = 1")
+outside.commit()
+outside.close()
+
+apply_pass = session.execute(select(Row)).scalars().all()
+print(f"apply pass:   {apply_pass[0].Title!r}")
+print(f"same object as preview: {apply_pass[0] is preview[0]}")
+
+session.expire_all()
+print(f"after expire_all: {session.execute(select(Row)).scalars().first().Title!r}")
+session.close()

--- a/research/database-concurrency/scripts/membership_probe.py
+++ b/research/database-concurrency/scripts/membership_probe.py
@@ -1,0 +1,49 @@
+"""Can the filtered set change even though loaded rows stay stale?
+
+The WHERE clause runs in SQLite against live data; the identity map only
+governs objects already loaded. This separates the two effects.
+"""
+
+import sqlite3
+from pathlib import Path
+
+from sqlalchemy import String, create_engine, select
+from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class Row(Base):
+    __tablename__ = "t"
+    ID: Mapped[int] = mapped_column(primary_key=True)
+    Title: Mapped[str] = mapped_column(String)
+
+
+db = Path("/tmp/rbe-probe-membership.db")
+db.unlink(missing_ok=True)
+engine = create_engine(f"sqlite:///{db}")
+Base.metadata.create_all(engine)
+
+raw = sqlite3.connect(db)
+raw.execute("INSERT INTO t VALUES (1, 'Burial - Archangel')")
+raw.execute("INSERT INTO t VALUES (2, 'something else')")
+raw.commit()
+raw.close()
+
+session = Session(engine)
+stmt = select(Row).where(Row.Title.like("%Burial%"))
+
+preview = session.execute(stmt).scalars().all()
+print(f"preview matched: {[(r.ID, r.Title) for r in preview]}")
+
+# Rekordbox renames row 2 so it now matches the same filter.
+outside = sqlite3.connect(db, timeout=1)
+outside.execute("UPDATE t SET Title = 'Burial - Shell of Light' WHERE ID = 2")
+outside.commit()
+outside.close()
+
+apply_pass = session.execute(stmt).scalars().all()
+print(f"apply matched:   {[(r.ID, r.Title) for r in apply_pass]}")
+session.close()

--- a/research/database-concurrency/scripts/snapshot_probe.py
+++ b/research/database-concurrency/scripts/snapshot_probe.py
@@ -1,0 +1,44 @@
+"""Does a repeat SELECT in one SQLAlchemy Session observe an outside commit?
+
+Mirrors RBE's shape: one Session opened for the whole command, a first query
+(the preview), a wait, then a second query (the apply pass), with a separate
+connection committing in between. Uses plain SQLite in DELETE journal mode,
+which is what pyrekordbox leaves master.db in.
+"""
+
+import sqlite3
+from pathlib import Path
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import Session
+
+db = Path("/tmp/rbe-probe-snapshot.db")
+db.unlink(missing_ok=True)
+
+raw = sqlite3.connect(db)
+raw.execute("CREATE TABLE t (ID INTEGER PRIMARY KEY, Title TEXT)")
+raw.execute("INSERT INTO t VALUES (1, 'before')")
+raw.commit()
+raw.close()
+
+engine = create_engine(f"sqlite:///{db}")
+session = Session(engine)
+
+first = session.execute(text("SELECT Title FROM t WHERE ID = 1")).scalar()
+print(f"preview pass reads: {first!r}")
+
+# An outside writer, standing in for Rekordbox.
+outside = sqlite3.connect(db, timeout=1)
+try:
+    outside.execute("UPDATE t SET Title = 'after' WHERE ID = 1")
+    outside.commit()
+    print("outside writer committed")
+except sqlite3.OperationalError as e:
+    print(f"outside writer BLOCKED: {e}")
+finally:
+    outside.close()
+
+second = session.execute(text("SELECT Title FROM t WHERE ID = 1")).scalar()
+print(f"apply pass reads:   {second!r}")
+print(f"in_transaction between passes: {session.in_transaction()}")
+session.close()

--- a/research/database-concurrency/scripts/wal_snapshot.py
+++ b/research/database-concurrency/scripts/wal_snapshot.py
@@ -1,0 +1,62 @@
+"""Under WAL, does a transaction that has already read fail to upgrade to a
+write after another connection commits (SQLITE_BUSY_SNAPSHOT), or succeed?
+
+The answer decides whether the USN bump needs retry logic. Instrumented with
+in_transaction() so a session that quietly closed its transaction cannot be
+mistaken for one that held a snapshot across the outside commit.
+"""
+
+import shutil
+from pathlib import Path
+
+from pyrekordbox import Rekordbox6Database
+from sqlalchemy import text
+
+FIXTURE = Path("tests/e2e/fixtures/macos/master.6.8.6.db")
+SELECT = text("SELECT int_1 FROM agentRegistry WHERE registry_id = 'localUpdateCount'")
+RESERVE = text(
+    "UPDATE agentRegistry SET int_1 = int_1 + :n "
+    "WHERE registry_id = 'localUpdateCount' RETURNING int_1"
+)
+
+
+def cleanup(path):
+    for suffix in ("", "-wal", "-shm"):
+        Path(str(path) + suffix).unlink(missing_ok=True)
+
+
+path = Path("/tmp/wal-snapshot.db")
+cleanup(path)
+shutil.copy(FIXTURE, path)
+
+ours = Rekordbox6Database(path=str(path))
+theirs = Rekordbox6Database(path=str(path))
+
+# Open our transaction with a real read, as get_filtered_content does.
+tracks = ours.session.execute(text("SELECT ID FROM djmdContent LIMIT 5")).all()
+opened_at = ours.session.execute(SELECT).scalar()
+print(f"ours: read {len(tracks)} rows, counter {opened_at}, "
+      f"in_transaction={ours.session.in_transaction()}")
+
+theirs.session.execute(RESERVE, {"n": 3})
+theirs.session.commit()
+print(f"theirs: committed, counter now "
+      f"{theirs.session.execute(SELECT).scalar()}")
+
+print(f"ours: still in_transaction={ours.session.in_transaction()}")
+
+try:
+    high = ours.session.execute(RESERVE, {"n": 2}).scalar()
+    ours.session.commit()
+    print(f"ours: bump SUCCEEDED, high {high} "
+          f"(fresh value + 2 = {opened_at + 3 + 2})")
+except Exception as e:
+    ours.session.rollback()
+    print(f"ours: bump RAISED {type(e).__name__}: {str(e)[:120]}")
+
+final = Rekordbox6Database(path=str(path))
+print(f"final counter {final.session.execute(SELECT).scalar()}, "
+      f"expected {opened_at + 5}")
+for db in (ours, theirs, final):
+    db.close()
+cleanup(path)

--- a/research/database-concurrency/usn-maintenance.md
+++ b/research/database-concurrency/usn-maintenance.md
@@ -1,0 +1,142 @@
+# Maintaining USNs Safely Alongside a Running Rekordbox
+
+One of two questions under [database-concurrency.md](database-concurrency.md), whose Terms section defines the database vocabulary used here.
+
+## Question
+
+Rekordbox tracks changes with a USN, or unique sequence number: a global counter
+in `agentRegistry.localUpdateCount` and a per-row `rb_local_usn` stamp. Every
+rekordbox-edit write command commits through `db.session.commit()` and maintains
+neither, as recorded in
+`../import-track-row-shape/decisions/commit-semantics-and-usn.md`.
+
+Closing that gap means incrementing a counter that a running Rekordbox may also
+be incrementing. Rekordbox-edit's advisory lock excludes other rekordbox-edit
+processes but has no authority over Rekordbox itself. Can the increment be made
+safe against a concurrent writer, and what does that cost?
+
+## Hypothesis
+
+Read-modify-write of a shared counter is the classic lost-update shape, so
+today's `autoincrement_local_update_count` should lose increments under
+concurrency. The textbook fix is `BEGIN IMMEDIATE`, which takes the write lock
+before the read.
+
+`BEGIN IMMEDIATE` applied to the engine would be costly here, since rekordbox-edit
+opens one session per command and a long dry run would then hold a write lock for
+its whole duration. An expression-form `UPDATE` that never reads into application
+code should be equivalent and far cheaper.
+
+## Method
+
+All probes run against a throwaway copy of the committed e2e fixture,
+`tests/e2e/fixtures/macos/master.6.8.6.db`, through the real SQLCipher engine
+pyrekordbox builds, rather than against plain SQLite. Two `Rekordbox6Database`
+instances stand in for two writers.
+
+- `scripts/concurrent_increment.py` runs both candidate shapes under two
+  concurrent writers.
+- `scripts/block_reservation.py` checks that a whole block of USNs can be
+  reserved in one statement, and what happens when an outside writer commits
+  after ours has already read.
+- `scripts/wal_snapshot.py` repeats the interleaving with `in_transaction()`
+  instrumentation, so a session that quietly closed its transaction cannot be
+  mistaken for one holding a read snapshot across the outside commit.
+
+Output is recorded in `evidence/usn-spikes.txt`.
+
+## Findings
+
+### The Database Is in WAL Mode
+
+`PRAGMA journal_mode` returns `wal`, not the DELETE mode an earlier analysis
+assumed. Readers therefore never block writers, and a long confirmation prompt
+cannot hold Rekordbox still.
+
+This also affects fixture handling. WAL leaves `-wal` and `-shm` sidecars beside
+the file, and an early version of these probes removed only the `.db`, letting a
+later copy inherit the previous run's committed pages. Any script that copies the
+fixture must remove all three.
+
+### The Current Shape Loses Increments Silently
+
+Two writers, 25 increments each, against the real engine:
+
+```
+read-then-write  694 -> 719 (expected 744)
+  25 increment(s) LOST, errors: none
+```
+
+Exactly one writer's work vanished, and nothing raised. Both writers believed
+they had succeeded. This is what `autoincrement_local_update_count` does today,
+which is presumably why `db.commit()` refuses to run while Rekordbox is open.
+
+### An Expression UPDATE Is Exact
+
+```
+atomic-update    694 -> 744 (expected 744)
+  OK, errors: none, duplicate stamps handed out: 0
+```
+
+`UPDATE agentRegistry SET int_1 = int_1 + :n WHERE registry_id =
+'localUpdateCount' RETURNING int_1` never reads the counter into application
+code, so there is no window to lose. `RETURNING` hands back the new high value,
+making the reserved block `high - n + 1 .. high`. SQLCipher reports SQLite
+3.51.1, well above the 3.35 that `RETURNING` requires.
+
+Reserving seven at once produced stamps 695 through 701 with the counter left at
+701: contiguous, and ending exactly at the counter. That matches the shape
+observed in a real library, where 906 imported tracks carried sequential values
+ending exactly at `localUpdateCount`.
+
+### No Retry Logic Is Needed
+
+Under WAL, a transaction that has taken a read snapshot and then tries to write
+after another connection has committed is expected to fail with
+`SQLITE_BUSY_SNAPSHOT`. That would have forced a rollback-and-retry loop around
+every commit.
+
+It does not happen. With `in_transaction()` reporting `True` throughout, an
+outside writer committed and moved the counter from 694 to 697, and our
+subsequent reservation of two still succeeded, returning 699. It computed from
+the fresh value, not from the 694 we had read.
+
+The reason is the pysqlite driver's implicit-BEGIN behavior, which pysqlcipher
+inherits: the driver issues no `BEGIN` for a `SELECT`, only before DML. So
+rekordbox-edit's reads run in autocommit at the SQLite level even while
+SQLAlchemy considers a transaction open, and the `UPDATE` opens the write
+transaction itself, reading the counter as it stands at that moment.
+
+This is the same driver behavior that makes the plan-apply window reachable, and
+it is worth pinning with a test, since it depends on a driver default rather than
+on anything this repository controls.
+
+## Conclusion
+
+The counter can be maintained safely without excluding Rekordbox. Correctness
+comes from the statement being atomic, not from having checked for a process
+beforehand, so the "Rekordbox is running, continue anyway?" affordance can stay
+on its own merits rather than being load-bearing.
+
+The design that follows:
+
+1. Reserve USNs with one expression `UPDATE ... RETURNING`, in the same
+   transaction as the row writes, so the reservation and the rows commit
+   together.
+2. Do not call `autoincrement_local_update_count`. Besides the lost-update
+   shape, it walks `RekordboxAgentRegistry.__update_sequence__`, a class
+   attribute shared by every instance in the process, which rekordbox-edit
+   never clears.
+3. Reserve one USN per row stamped. Rekordbox appears to advance its counter
+   more than once per track, roughly 1.9 times in the sampled library, so this
+   does not reproduce its counting exactly. That is safe: a high-water-mark
+   consumer asks for rows above a value, so over-counting costs nothing while
+   duplicate or reused stamps would break it. Uniqueness and monotonicity are
+   the properties worth guaranteeing.
+4. Keep write transactions short. The reservation holds the WAL write lock from
+   the `UPDATE` until commit, and per-file commits in `convert` already bound
+   that to one file.
+
+The one fragility to record: this rests on the driver deferring `BEGIN` until the
+first DML. Setting `isolation_level=None`, or a driver change, would reintroduce
+the snapshot upgrade failure and with it the need for retry logic.


### PR DESCRIPTION
Records what two design investigations established about `master.db` itself. No application code changes.

## Changes

- Add `research/database-concurrency/`, covering how the database behaves when more than one thing writes to it, with a Terms section defining the database vocabulary the findings use.
- `plan-apply-window.md`: what can change between a command's preview pass and its apply pass.
- `usn-maintenance.md`: whether Rekordbox's USN counter can be maintained safely while Rekordbox may also be writing to it.
- Six read-only probes under `scripts/`, output under `evidence/`.

## Findings Worth Flagging

- `master.db` is in WAL mode, not DELETE. An earlier analysis assumed DELETE and reasoned from it.
- The driver opens no transaction for a `SELECT`, so reads run in autocommit even while SQLAlchemy reports a transaction open. This is why the plan-apply window is reachable, and why writes need no retry logic.
- SQLAlchemy's identity map returns already-loaded rows unchanged, so a second pass sees stale values but a fresh result set. Set membership drifts; column values do not.
- Reading the USN counter and writing it back loses increments silently: 25 of 50 under two writers, no errors raised. An expression `UPDATE ... RETURNING` is exact.
- `PRAGMA busy_timeout = 5000` in `cli/_utils.py` sets the value the driver already applies by default, so it currently does nothing.
- `cli/edit.py` guards `edit()` against `ValueError` on its preview calls but not its apply calls, so the `--multi` guard firing on the apply pass reaches the unhandled-exception handler.
