### PR TITLE
feat(convert): encode files concurrently with a live progress display

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,5 +6,11 @@ coverage:
         target: auto #default
         threshold: 1%
         base: auto
+    patch:
+      default:
+        # basic
+        target: auto
+        threshold: 1%
+        base: auto
 comment:
   require_changes: true

--- a/docs/commands/convert.md
+++ b/docs/commands/convert.md
@@ -25,6 +25,14 @@ All conversions target **16-bit / 44.1 kHz**, with a few nuances:
 - `all` — always delete the original
 - `none` — never delete the original
 
+## Converting Several Files at Once
+
+`convert` operates on four files at a time by default so long as your CPU has the cores to do so. You can customize this by passing `--threads N` (or `-t N`), with your CPU's number of cores as an upper limit.
+
+Depending on your environment and target format, your mileage with more or less threads will vary. MP3 output speeds up close to linearly with more threads due to `libmp3lame` being a single-threaded process, whereas FLAC gains about a 50% with. WAV and AIFF outputs only see minor benefits, as `ffmpeg` already multithreads their decoding, and they don't require any encoding step. As such, you'll likely be limited by I/O speed rather than CPU when converting to WAV/AIFF.
+
+If you're converting across a network (like a mapped drive), more threads will likely only slow you down as each thread competes for network capacity, but if you're converting on a local drive it is likely to improve performance at least somewhat.
+
 ## Interrupted Runs
 
 If a run stops partway, whether from a conversion failure, a full disk, or a Ctrl-C, everything it finished is kept and nothing is left half-converted. `convert` tells you which file it stopped on, how many converted, and how many it never got to. Rerun the same command to pick up where it left off.
@@ -51,9 +59,13 @@ rbe convert --format-out aiff --format flac --print ids --dry-run
 
 # Convert everything a search finds
 rbe search --artist "Lauryn Hill" --print ids | rbe convert --yes
+
+# Max out your CPU to handle a batch of MP3s
+rbe convert --format-out mp3 --playlist "NeedsConverting" --threads 8 --yes
 ```
 
 ### Guardrails
+
 - Without flags, `convert` shows every planned change and asks once before applying. `--interactive` confirms each track individually; `--dry-run` previews without writing; `--yes` confirms the default choice for all prompts without asking.
 - Editing while Rekordbox is open risks corrupting your database. By default `convert` warns and asks for confirmation (defaulting to no, so a `--yes` would exit); in a non-interactive mode (e.g. `--print ids`) it throws an error.
 - Before a large run, walk through the checklist in [What Should I Do Before Converting?](../faqs.md#what-should-i-do-before-converting)

--- a/rekordbox_edit/_click.py
+++ b/rekordbox_edit/_click.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 import click
 
+from rekordbox_edit.models import DEFAULT_THREADS
+
 
 class PrintChoice(Enum):
     SILENT = 0
@@ -185,6 +187,13 @@ convert_click_options = [
         "--overwrite",
         is_flag=True,
         help="Overwrite existing output files instead of skipping them",
+    ),
+    click.option(
+        "--threads",
+        "-t",
+        type=click.IntRange(min=1),
+        default=DEFAULT_THREADS,
+        help=f"How many files to encode at once (default: {DEFAULT_THREADS}).",
     ),
     click.option(
         "--format-out",

--- a/rekordbox_edit/api/convert.py
+++ b/rekordbox_edit/api/convert.py
@@ -653,7 +653,6 @@ def convert(
                 except Exception as e:
                     logger.warning(f"Failed to delete {job.source_path}: {e}")
 
-    logger.info(f"\nConverted {len(converted_ops)} files to {output_format_name}")
     logger.debug(f"convert committed {len(converted_ops)} conversion(s)")
 
     kept = len(converted_ops) - deletable

--- a/rekordbox_edit/api/convert.py
+++ b/rekordbox_edit/api/convert.py
@@ -132,6 +132,12 @@ def _run_ffmpeg(input_path, output_path, output_kwargs: dict, label: str) -> boo
             ffmpeg.input(input_path)
             .output(output_path, **output_kwargs)
             .overwrite_output()
+            # ffmpeg-python leaves the child on the parent's stdin, and ffmpeg
+            # then puts the terminal in non-canonical mode to watch for keys
+            # like "q". Concurrent encodes race on saving and restoring that
+            # state, and the loser restores raw mode, leaving the shell echoing
+            # ^M instead of accepting Enter.
+            .global_args("-nostdin")
             .run(capture_stdout=True, capture_stderr=True)
         )
         logger.debug(f"Conversion to {label} succeeded: {output_path}")

--- a/rekordbox_edit/api/convert.py
+++ b/rekordbox_edit/api/convert.py
@@ -3,6 +3,7 @@
 import logging
 import os
 from collections.abc import Iterable
+from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, NamedTuple, Tuple, cast
@@ -517,75 +518,108 @@ def convert(
 
     jobs = [_job_for(content_map[op.id], op, output_format_name) for op in ops]
 
-    for i, (op, job) in enumerate(zip(ops, jobs), 1):
-        content = content_map[op.id]
-        logger.info(f"[{i}/{len(ops)}] {job.file_name}")
-
-        try:
-            result = _encode_one(job)
-        except BaseException as e:
-            _rollback_session(db)
-            logger.debug(
-                f"convert aborted at {job.source_path} after "
-                f"{len(converted_ops)} committed conversion(s)"
-            )
-            raise ConvertAborted(
-                str(e),
-                failed_path=job.source_path,
-                converted=len(converted_ops),
-                not_attempted=len(ops) - i,
-            ) from e
-
-        if result.skipped:
-            skipped.append(result.skipped)
-            continue
-
-        try:
-            os.replace(job.temp_path, job.output_path)
-            _apply_converted_record(
-                content,
-                cast(ConvertedFileProbe, result.probe),
-                os.path.basename(job.output_path),
-                os.path.dirname(job.output_path),
-                output_format_name,
-            )
-            db.session.commit()
-        except BaseException as e:
-            _remove_temp_file(job.temp_path)
-            _rollback_session(db)
-            logger.debug(
-                f"convert aborted at {job.source_path} after "
-                f"{len(converted_ops)} committed conversion(s)"
-            )
-            raise ConvertAborted(
-                str(e),
-                failed_path=job.source_path,
-                converted=len(converted_ops),
-                not_attempted=len(ops) - i,
-            ) from e
-
-        converted_ops.append(
-            op.model_copy(
-                update={
-                    "source_path": job.source_path,
-                    "output_sample_rate": result.output_sample_rate,
-                }
-            )
+    def _abort(exc: BaseException, job: _EncodeJob, attempted: int) -> ConvertAborted:
+        """Give up on the batch, keeping every conversion already committed."""
+        _rollback_session(db)
+        logger.debug(
+            f"convert aborted at {job.source_path} after "
+            f"{len(converted_ops)} committed conversion(s)"
+        )
+        return ConvertAborted(
+            str(exc),
+            failed_path=job.source_path,
+            converted=len(converted_ops),
+            not_attempted=len(ops) - attempted,
         )
 
-        # Past this point the row is committed, so every failure only warns.
-        try:
-            _update_anlz_paths(db, content, os.path.basename(job.output_path))
-        except Exception as e:
-            logger.warning(f"Failed to update ANLZ path tags for {job.file_name}: {e}")
+    workers = 1
+    futures: dict[int, Future[_EncodeResult]] = {}
 
-        if _deletes_original(args.delete_originals, result.is_lossless):
-            deletable += 1
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+
+        def _submit(index: int) -> None:
+            if index < len(jobs):
+                futures[index] = pool.submit(_encode_one, jobs[index])
+
+        def _discard_outstanding() -> None:
+            """Drop queued work and clean up temps from encodes already done.
+
+            Encoding is the expensive half, so nothing beyond the pool's width
+            is ever queued, and an abort wastes at most that many files.
+            """
+            for future in futures.values():
+                future.cancel()
+            for index, future in futures.items():
+                if future.cancelled() or future.exception() is not None:
+                    continue
+                if future.result().skipped is None:
+                    _remove_temp_file(jobs[index].temp_path)
+            futures.clear()
+
+        # Only `workers` jobs run ahead of the drain point, topped up as each
+        # result lands, so a failure cannot burn the whole batch's CPU first.
+        for index in range(min(workers, len(jobs))):
+            _submit(index)
+
+        # Drained in submission order, not completion order, so converted_ops,
+        # the progress lines, and --print ids stay deterministic.
+        for i, (op, job) in enumerate(zip(ops, jobs), 1):
+            content = content_map[op.id]
+            logger.info(f"[{i}/{len(ops)}] {job.file_name}")
+
             try:
-                os.remove(job.source_path)
-                deleted += 1
+                result = futures.pop(i - 1).result()
+            except BaseException as e:
+                _discard_outstanding()
+                raise _abort(e, job, i) from e
+
+            # Topped up only once this file cleared, so an abort never leaves
+            # work queued that nobody will drain.
+            _submit(i - 1 + workers)
+
+            if result.skipped:
+                skipped.append(result.skipped)
+                continue
+
+            try:
+                os.replace(job.temp_path, job.output_path)
+                _apply_converted_record(
+                    content,
+                    cast(ConvertedFileProbe, result.probe),
+                    os.path.basename(job.output_path),
+                    os.path.dirname(job.output_path),
+                    output_format_name,
+                )
+                db.session.commit()
+            except BaseException as e:
+                _remove_temp_file(job.temp_path)
+                _discard_outstanding()
+                raise _abort(e, job, i) from e
+
+            converted_ops.append(
+                op.model_copy(
+                    update={
+                        "source_path": job.source_path,
+                        "output_sample_rate": result.output_sample_rate,
+                    }
+                )
+            )
+
+            # Past this point the row is committed, so every failure only warns.
+            try:
+                _update_anlz_paths(db, content, os.path.basename(job.output_path))
             except Exception as e:
-                logger.warning(f"Failed to delete {job.source_path}: {e}")
+                logger.warning(
+                    f"Failed to update ANLZ path tags for {job.file_name}: {e}"
+                )
+
+            if _deletes_original(args.delete_originals, result.is_lossless):
+                deletable += 1
+                try:
+                    os.remove(job.source_path)
+                    deleted += 1
+                except Exception as e:
+                    logger.warning(f"Failed to delete {job.source_path}: {e}")
 
     logger.info(f"\nConverted {len(converted_ops)} files to {output_format_name}")
     logger.debug(f"convert committed {len(converted_ops)} conversion(s)")

--- a/rekordbox_edit/api/convert.py
+++ b/rekordbox_edit/api/convert.py
@@ -532,7 +532,7 @@ def convert(
             not_attempted=len(ops) - attempted,
         )
 
-    workers = 1
+    workers = args.threads
     futures: dict[int, Future[_EncodeResult]] = {}
 
     with ThreadPoolExecutor(max_workers=workers) as pool:

--- a/rekordbox_edit/api/convert.py
+++ b/rekordbox_edit/api/convert.py
@@ -3,8 +3,9 @@
 import logging
 import os
 from collections.abc import Iterable
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, NamedTuple, Tuple
+from typing import Literal, NamedTuple, Tuple, cast
 
 import ffmpeg
 from ffmpeg import Error as FfmpegError
@@ -191,6 +192,114 @@ def _apply_converted_record(
         content.OrgFolderPath = converted_db_path
 
     _sync_audio_columns(content, probe.audio_info, file_type, probe.file_size)
+
+
+@dataclass(frozen=True)
+class _EncodeJob:
+    """One conversion's inputs, as plain values.
+
+    Everything the encode needs is copied off the content row here, on the main
+    thread. Nothing in this class may be a `DjmdContent` or hold a reference to
+    one: reading an ORM attribute off the main thread would pull on a session
+    that is not thread-safe.
+    """
+
+    op_id: str
+    source_path: str
+    file_name: str | None
+    file_type: int | None
+    output_path: str
+    temp_path: str
+    output_format: str
+
+
+@dataclass
+class _EncodeResult:
+    """What an encode produced, or why it declined to run.
+
+    `skipped` set means the file was passed over and nothing was written.
+    Otherwise `probe` describes the finished temp file awaiting its move
+    into place.
+    """
+
+    job: _EncodeJob
+    skipped: SkippedTrack | None = None
+    probe: ConvertedFileProbe | None = None
+    is_lossless: bool = False
+    output_sample_rate: int = TARGET_SAMPLE_RATE
+
+
+def _job_for(content: DjmdContent, op: ConvertOp, output_format: str) -> _EncodeJob:
+    """Copy what the encode needs off a content row, on the main thread."""
+    return _EncodeJob(
+        op_id=op.id,
+        source_path=content.FolderPath or "",
+        file_name=content.FileNameL,
+        file_type=content.FileType,
+        output_path=op.output_path,
+        temp_path=_temp_output_path(op.output_path),
+        output_format=output_format,
+    )
+
+
+def _encode_one(job: _EncodeJob) -> _EncodeResult:
+    """Probe, encode, and probe again, touching no database state.
+
+    Runs on a worker thread once encoding is parallel, so it reports a skip
+    rather than mutating shared state, and cleans up its own temp file if the
+    encode fails partway.
+    """
+    if not os.path.exists(job.source_path):
+        # Classification and the encode are separated by a confirmation prompt,
+        # so a source going missing is an expected outcome of that window
+        # rather than a systemic failure worth abandoning the batch.
+        logger.warning(f"Skipping {job.file_name}: {job.source_path} is gone")
+        return _EncodeResult(
+            job, skipped=SkippedTrack(id=job.op_id, reason="file_not_found")
+        )
+
+    audio_info = get_audio_info(job.source_path)
+    if not probe_matches_file_type(
+        job.file_type, audio_info["codec"], audio_info["container"]
+    ):
+        logger.warning(
+            f"Skipping {job.file_name}: probed codec "
+            f"{audio_info['codec']!r} does not match its Rekordbox "
+            f"file type {get_file_type_name(job.file_type)!r}"
+        )
+        return _EncodeResult(
+            job, skipped=SkippedTrack(id=job.op_id, reason="codec_mismatch")
+        )
+
+    if job.output_format == "MP3":
+        # MP3 output always loses information, so it is never lossless.
+        is_lossless = False
+        output_sample_rate = TARGET_SAMPLE_RATE
+        output_kwargs = _mp3_output_kwargs(output_sample_rate)
+        label = "mp3"
+    else:
+        fidelity, output_sample_rate = _classify_fidelity(audio_info)
+        is_lossless = fidelity == "lossless"
+        output_format = OutputFormats(job.output_format.lower())
+        output_kwargs = _hi_res_output_kwargs(output_format, output_sample_rate)
+        label = output_format.value
+
+    try:
+        if not _run_ffmpeg(job.source_path, job.temp_path, output_kwargs, label):
+            raise RuntimeError(f"Conversion failed for {job.source_path}")
+        if not os.path.exists(job.temp_path):
+            raise RuntimeError(f"Output file not created: {job.output_path}")
+        probe = _probe_converted_file(job.temp_path, job.output_format)
+    except BaseException:
+        _remove_temp_file(job.temp_path)
+        raise
+
+    return _EncodeResult(
+        job,
+        probe=probe,
+        is_lossless=is_lossless,
+        output_sample_rate=output_sample_rate,
+    )
 
 
 def _temp_output_path(output_path: str) -> str:
@@ -406,104 +515,77 @@ def convert(
     deletable = 0
     deleted = 0
 
-    for i, op in enumerate(ops, 1):
-        content = content_map[op.id]
-        src = content.FolderPath or ""
-        logger.info(f"[{i}/{len(ops)}] {content.FileNameL}")
+    jobs = [_job_for(content_map[op.id], op, output_format_name) for op in ops]
 
-        if not os.path.exists(src):
-            # Classification and this loop are separated by a confirmation
-            # prompt, so a source going missing is an expected outcome of that
-            # window rather than a systemic failure worth abandoning the batch.
-            logger.warning(f"Skipping {content.FileNameL}: {src} is gone")
-            skipped.append(SkippedTrack(id=op.id, reason="file_not_found"))
+    for i, (op, job) in enumerate(zip(ops, jobs), 1):
+        content = content_map[op.id]
+        logger.info(f"[{i}/{len(ops)}] {job.file_name}")
+
+        try:
+            result = _encode_one(job)
+        except BaseException as e:
+            _rollback_session(db)
+            logger.debug(
+                f"convert aborted at {job.source_path} after "
+                f"{len(converted_ops)} committed conversion(s)"
+            )
+            raise ConvertAborted(
+                str(e),
+                failed_path=job.source_path,
+                converted=len(converted_ops),
+                not_attempted=len(ops) - i,
+            ) from e
+
+        if result.skipped:
+            skipped.append(result.skipped)
             continue
 
-        pending_temp: str | None = None
         try:
-            audio_info = get_audio_info(src)
-            if not probe_matches_file_type(
-                content.FileType, audio_info["codec"], audio_info["container"]
-            ):
-                logger.warning(
-                    f"Skipping {content.FileNameL}: probed codec "
-                    f"{audio_info['codec']!r} does not match its Rekordbox "
-                    f"file type {get_file_type_name(content.FileType)!r}"
-                )
-                skipped.append(SkippedTrack(id=op.id, reason="codec_mismatch"))
-                continue
-
-            pending_temp = _temp_output_path(op.output_path)
-            if output_format_name == "MP3":
-                # MP3 output always loses information, so it is never lossless.
-                is_lossless = False
-                output_sample_rate = TARGET_SAMPLE_RATE
-                success = _run_ffmpeg(
-                    src, pending_temp, _mp3_output_kwargs(output_sample_rate), "mp3"
-                )
-            else:
-                fidelity, output_sample_rate = _classify_fidelity(audio_info)
-                is_lossless = fidelity == "lossless"
-                output_format = OutputFormats(args.format_out.lower())
-                success = _run_ffmpeg(
-                    src,
-                    pending_temp,
-                    _hi_res_output_kwargs(output_format, output_sample_rate),
-                    output_format.value,
-                )
-
-            if not success:
-                raise RuntimeError(f"Conversion failed for {src}")
-            if not os.path.exists(pending_temp):
-                raise RuntimeError(f"Output file not created: {op.output_path}")
-
-            os.replace(pending_temp, op.output_path)
-            pending_temp = None
-
+            os.replace(job.temp_path, job.output_path)
             _apply_converted_record(
                 content,
-                _probe_converted_file(op.output_path, output_format_name),
-                os.path.basename(op.output_path),
-                os.path.dirname(op.output_path),
+                cast(ConvertedFileProbe, result.probe),
+                os.path.basename(job.output_path),
+                os.path.dirname(job.output_path),
                 output_format_name,
             )
             db.session.commit()
         except BaseException as e:
-            if pending_temp:
-                _remove_temp_file(pending_temp)
+            _remove_temp_file(job.temp_path)
             _rollback_session(db)
             logger.debug(
-                f"convert aborted at {src} after {len(converted_ops)} "
-                "committed conversion(s)"
+                f"convert aborted at {job.source_path} after "
+                f"{len(converted_ops)} committed conversion(s)"
             )
             raise ConvertAborted(
                 str(e),
-                failed_path=src,
+                failed_path=job.source_path,
                 converted=len(converted_ops),
                 not_attempted=len(ops) - i,
             ) from e
 
         converted_ops.append(
             op.model_copy(
-                update={"source_path": src, "output_sample_rate": output_sample_rate}
+                update={
+                    "source_path": job.source_path,
+                    "output_sample_rate": result.output_sample_rate,
+                }
             )
         )
 
         # Past this point the row is committed, so every failure only warns.
         try:
-            _update_anlz_paths(db, content, os.path.basename(op.output_path))
+            _update_anlz_paths(db, content, os.path.basename(job.output_path))
         except Exception as e:
-            logger.warning(
-                f"Failed to update ANLZ path tags for {content.FileNameL}: {e}"
-            )
+            logger.warning(f"Failed to update ANLZ path tags for {job.file_name}: {e}")
 
-        if _deletes_original(args.delete_originals, is_lossless):
+        if _deletes_original(args.delete_originals, result.is_lossless):
             deletable += 1
             try:
-                os.remove(src)
+                os.remove(job.source_path)
                 deleted += 1
             except Exception as e:
-                logger.warning(f"Failed to delete {src}: {e}")
+                logger.warning(f"Failed to delete {job.source_path}: {e}")
 
     logger.info(f"\nConverted {len(converted_ops)} files to {output_format_name}")
     logger.debug(f"convert committed {len(converted_ops)} conversion(s)")

--- a/rekordbox_edit/api/convert.py
+++ b/rekordbox_edit/api/convert.py
@@ -230,7 +230,9 @@ class _EncodeResult:
     output_sample_rate: int = TARGET_SAMPLE_RATE
 
 
-def _job_for(content: DjmdContent, op: ConvertOp, output_format: str) -> _EncodeJob:
+def _encode_job_for(
+    content: DjmdContent, op: ConvertOp, output_format: str
+) -> _EncodeJob:
     """Copy what the encode needs off a content row, on the main thread."""
     return _EncodeJob(
         op_id=op.id,
@@ -516,9 +518,11 @@ def convert(
     deletable = 0
     deleted = 0
 
-    jobs = [_job_for(content_map[op.id], op, output_format_name) for op in ops]
+    jobs = [_encode_job_for(content_map[op.id], op, output_format_name) for op in ops]
 
-    def _abort(exc: BaseException, job: _EncodeJob, attempted: int) -> ConvertAborted:
+    def _abort_batch(
+        exc: BaseException, job: _EncodeJob, attempted: int
+    ) -> ConvertAborted:
         """Give up on the batch, keeping every conversion already committed."""
         _rollback_session(db)
         logger.debug(
@@ -532,54 +536,76 @@ def convert(
             not_attempted=len(ops) - attempted,
         )
 
-    workers = args.threads
-    futures: dict[int, Future[_EncodeResult]] = {}
+    # Encoding runs on worker threads; every database touch stays here on the
+    # main thread. `encoding` maps a job's position in `jobs` to the worker
+    # currently handling it.
+    thread_count = args.threads
+    encoding: dict[int, Future[_EncodeResult]] = {}
 
-    with ThreadPoolExecutor(max_workers=workers) as pool:
+    with ThreadPoolExecutor(max_workers=thread_count) as pool:
 
-        def _submit(index: int) -> None:
+        def _start_encode(index: int) -> None:
+            """Hand job `index` to a worker, if the batch runs that far."""
             if index < len(jobs):
-                futures[index] = pool.submit(_encode_one, jobs[index])
+                encoding[index] = pool.submit(_encode_one, jobs[index])
 
-        def _discard_outstanding() -> None:
-            """Drop queued work and clean up temps from encodes already done.
+        def _stop_pending_encodes() -> None:
+            """Give up on everything still in flight, leaving no stray files.
 
-            Encoding is the expensive half, so nothing beyond the pool's width
-            is ever queued, and an abort wastes at most that many files.
+            Cancelling only stops work no worker has picked up yet, so an
+            encode that already finished holds a temp file nobody will move
+            into place. Those are deleted here rather than left for the next
+            run's sweep.
             """
-            for future in futures.values():
+            for future in encoding.values():
                 future.cancel()
-            for index, future in futures.items():
+            for index, future in encoding.items():
                 if future.cancelled() or future.exception() is not None:
                     continue
                 if future.result().skipped is None:
                     _remove_temp_file(jobs[index].temp_path)
-            futures.clear()
+            encoding.clear()
 
-        # Only `workers` jobs run ahead of the drain point, topped up as each
-        # result lands, so a failure cannot burn the whole batch's CPU first.
-        for index in range(min(workers, len(jobs))):
-            _submit(index)
+        # Prime the pool with one file per worker. Nothing more starts until a
+        # result is collected below, so at most `thread_count` files are ever
+        # in flight, and an abort has wasted at most that many encodes.
+        for index in range(min(thread_count, len(jobs))):
+            _start_encode(index)
 
-        # Drained in submission order, not completion order, so converted_ops,
-        # the progress lines, and --print ids stay deterministic.
-        for i, (op, job) in enumerate(zip(ops, jobs), 1):
+        # Collect results in the order the files were listed rather than the
+        # order they happen to finish: waiting on `encoding[index]` blocks
+        # until that particular file is done, so one that finished early simply
+        # waits its turn. `index` walks `jobs`; `position` is the same count
+        # from one, for the progress line. Predictable order matters because
+        # `rbe convert --print ids` feeds other commands.
+        for index, (op, job) in enumerate(zip(ops, jobs)):
+            position = index + 1
             content = content_map[op.id]
-            logger.info(f"[{i}/{len(ops)}] {job.file_name}")
 
             try:
-                result = futures.pop(i - 1).result()
+                result = encoding.pop(index).result()
+            except KeyboardInterrupt as e:
+                _stop_pending_encodes()
+                logger.warning("Interrupted; keeping the files already converted.")
+                raise _abort_batch(e, job, position) from e
             except BaseException as e:
-                _discard_outstanding()
-                raise _abort(e, job, i) from e
+                _stop_pending_encodes()
+                raise _abort_batch(e, job, position) from e
 
-            # Topped up only once this file cleared, so an abort never leaves
-            # work queued that nobody will drain.
-            _submit(i - 1 + workers)
+            # A worker just came free, so give it the next file nobody has
+            # started. Starting one only after a successful collection is what
+            # keeps the in-flight count capped and leaves no queued work behind
+            # on an abort.
+            _start_encode(index + thread_count)
 
             if result.skipped:
                 skipped.append(result.skipped)
                 continue
+
+            # Printed on completion rather than at dispatch: with several
+            # encodes in flight, a line printed at dispatch would name a file
+            # that is not the one being worked on next.
+            logger.info(f"[{position}/{len(ops)}] converted {job.file_name}")
 
             try:
                 os.replace(job.temp_path, job.output_path)
@@ -593,8 +619,8 @@ def convert(
                 db.session.commit()
             except BaseException as e:
                 _remove_temp_file(job.temp_path)
-                _discard_outstanding()
-                raise _abort(e, job, i) from e
+                _stop_pending_encodes()
+                raise _abort_batch(e, job, position) from e
 
             converted_ops.append(
                 op.model_copy(

--- a/rekordbox_edit/api/convert.py
+++ b/rekordbox_edit/api/convert.py
@@ -6,7 +6,7 @@ from collections.abc import Iterable
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, NamedTuple, Tuple, cast
+from typing import Literal, NamedTuple, Protocol, Tuple, cast
 
 import ffmpeg
 from ffmpeg import Error as FfmpegError
@@ -218,6 +218,26 @@ class _EncodeJob:
     output_path: str
     temp_path: str
     output_format: str
+
+
+class ConvertProgress(Protocol):
+    """Reports which files are being encoded, for a caller that wants to show it.
+
+    `convert()` knows when an encode starts and finishes; how that is displayed
+    belongs to the caller. Implementations must tolerate calls from any order
+    of starts and finishes, and must not raise.
+    """
+
+    def batch_size(self, total: int) -> None:
+        """How many files this run will encode, known once classification has
+        dropped the ones it will not touch."""
+
+    def started(self, index: int, file_name: str | None) -> None:
+        """An encode for `index` has been handed to a worker."""
+
+    def finished(self, index: int, converted: bool) -> None:
+        """The encode for `index` was collected. `converted` is False when the
+        file was skipped rather than encoded."""
 
 
 @dataclass
@@ -456,6 +476,7 @@ def convert(
     args: ConvertRequest,
     *,
     dry_run: bool = False,
+    progress: ConvertProgress | None = None,
 ) -> ConvertResponse:
     """Convert audio files to a target format and update the Rekordbox database.
 
@@ -525,6 +546,8 @@ def convert(
     deleted = 0
 
     jobs = [_encode_job_for(content_map[op.id], op, output_format_name) for op in ops]
+    if progress:
+        progress.batch_size(len(jobs))
 
     def _abort_batch(
         exc: BaseException, job: _EncodeJob, attempted: int
@@ -554,6 +577,8 @@ def convert(
             """Hand job `index` to a worker, if the batch runs that far."""
             if index < len(jobs):
                 encoding[index] = pool.submit(_encode_one, jobs[index])
+                if progress:
+                    progress.started(index, jobs[index].file_name)
 
         def _stop_pending_encodes() -> None:
             """Give up on everything still in flight, leaving no stray files.
@@ -603,6 +628,9 @@ def convert(
             # keeps the in-flight count capped and leaves no queued work behind
             # on an abort.
             _start_encode(index + thread_count)
+
+            if progress:
+                progress.finished(index, converted=result.skipped is None)
 
             if result.skipped:
                 skipped.append(result.skipped)

--- a/rekordbox_edit/cli/_progress.py
+++ b/rekordbox_edit/cli/_progress.py
@@ -1,0 +1,98 @@
+"""Live progress display for long-running CLI commands."""
+
+import contextlib
+import logging
+from collections.abc import Iterator
+
+from rich.progress import (
+    BarColumn,
+    MofNCompleteColumn,
+    Progress,
+    SpinnerColumn,
+    TaskID,
+    TaskProgressColumn,
+    TextColumn,
+    TimeRemainingColumn,
+)
+from rich.text import Text
+
+from rekordbox_edit.logger import console
+
+logger = logging.getLogger(__name__)
+
+
+#: Marks the one task that counts files, so the count column can tell it from
+#: the per-file rows. Both can lack a total, so the total cannot distinguish
+#: them: a `--yes` run has no count until convert() has classified the batch.
+_OVERALL = "overall"
+
+
+class _OverallCountColumn(MofNCompleteColumn):
+    """The file count, shown only on the overall task.
+
+    The overall row still reports a bare running count when its total is not yet known.
+    """
+
+    def render(self, task):
+        if not task.fields.get(_OVERALL):
+            return Text("")
+        if task.total is None:
+            return Text(str(int(task.completed)), style="progress.download")
+        return super().render(task)
+
+
+class ConvertProgressDisplay:
+    """A line per file being encoded, above an overall bar.
+
+    Finished files are not kept here. `convert()` already logs a line for each
+    one, and those scroll above the live region on their way to the debug log,
+    which leaves this display showing only what is still in flight.
+    """
+
+    def __init__(self, progress: Progress):
+        self._progress = progress
+        # convert() reports the real count through batch_size() before it
+        # encodes anything, so the bar starts without one rather than trusting
+        # a preview that may no longer describe the run.
+        self._overall = progress.add_task("Converting", total=None, **{_OVERALL: True})
+        self._tasks: dict[int, TaskID] = {}
+
+    def batch_size(self, total: int) -> None:
+        self._progress.update(self._overall, total=total)
+
+    def started(self, index: int, file_name: str | None) -> None:
+        self._tasks[index] = self._progress.add_task(
+            file_name or "", total=None, start=True
+        )
+
+    def finished(self, index: int, converted: bool) -> None:
+        task = self._tasks.pop(index, None)
+        if task is not None:
+            self._progress.remove_task(task)
+        self._progress.advance(self._overall)
+
+
+@contextlib.contextmanager
+def convert_progress(*, enabled: bool) -> Iterator[ConvertProgressDisplay | None]:
+    """A live convert display, or nothing when the terminal cannot host one.
+
+    Yields None when disabled, which `convert()` accepts as "report nothing".
+    """
+    if not enabled or not console.is_terminal:
+        yield None
+        return
+
+    progress = Progress(
+        SpinnerColumn(),
+        # markup=False: a track named "Set [b].wav" would otherwise render as
+        # "Set .wav", the same trap the log handler avoids.
+        TextColumn("{task.description}", markup=False),
+        BarColumn(),
+        TaskProgressColumn(),
+        _OverallCountColumn(),
+        TimeRemainingColumn(),
+        console=console,
+        transient=True,
+    )
+    with progress:
+        yield ConvertProgressDisplay(progress)

--- a/rekordbox_edit/cli/convert.py
+++ b/rekordbox_edit/cli/convert.py
@@ -15,6 +15,7 @@ from rekordbox_edit._click import (
     track_ids_argument,
 )
 from rekordbox_edit.api.convert import ConvertAborted, convert
+from rekordbox_edit.cli._progress import convert_progress
 from rekordbox_edit.cli._utils import (
     SCRIPTING_MODES,
     _build_args,
@@ -76,7 +77,10 @@ def convert_command(db, **kwargs):
     scripting_mode = print_opt in SCRIPTING_MODES
 
     if yes or dry_run:
-        response = _convert_reporting_partials(db, args, dry_run=dry_run)
+        with convert_progress(enabled=not scripting_mode and not dry_run) as progress:
+            response = _convert_reporting_partials(
+                db, args, dry_run=dry_run, progress=progress
+            )
         _report_skips(response.result.skipped)
         _print_convert_result(response, print_opt, scripting_mode, dry_run=dry_run)
         return
@@ -112,7 +116,8 @@ def convert_command(db, **kwargs):
             logger.info("Cancelled.")
             return
         narrowed = _narrow_to_track_ids(args, selected_ids)
-        response = _convert_reporting_partials(db, narrowed)
+        with convert_progress(enabled=True) as progress:
+            response = _convert_reporting_partials(db, narrowed, progress=progress)
     else:
         try:
             if not confirm(
@@ -124,17 +129,18 @@ def convert_command(db, **kwargs):
                 return
         except UserQuit:
             return
-        response = _convert_reporting_partials(db, args)
+        with convert_progress(enabled=True) as progress:
+            response = _convert_reporting_partials(db, args, progress=progress)
 
     _report_skips([s for s in response.result.skipped if s.reason in _LIVE_ONLY_SKIPS])
     _print_convert_result(response, print_opt, scripting_mode, dry_run=False)
 
 
-def _convert_reporting_partials(db, args, *, dry_run: bool = False):
+def _convert_reporting_partials(db, args, *, dry_run: bool = False, progress=None):
     """Convert, reporting a batch that stopped partway as a plain result rather
     than as a crash. The committed conversions are real and are kept."""
     try:
-        return convert(db, args, dry_run=dry_run)
+        return convert(db, args, dry_run=dry_run, progress=progress)
     except ConvertAborted as e:
         logger.error(f"Conversion stopped at {e.failed_path}: {e}")
         logger.error(

--- a/rekordbox_edit/cli/convert.py
+++ b/rekordbox_edit/cli/convert.py
@@ -175,7 +175,7 @@ def _print_convert_result(
 ) -> None:
     if not dry_run:
         logger.info(
-            f"Converted {len(response.result.converted)} files to "
+            f"\nConverted {len(response.result.converted)} files to "
             f"{response.result.format_out.upper()}"
         )
         if response.result.deleted:

--- a/rekordbox_edit/logger.py
+++ b/rekordbox_edit/logger.py
@@ -7,8 +7,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
-import click
 from platformdirs import PlatformDirs
+from rich.console import Console
 
 from rekordbox_edit._click import PrintChoice
 
@@ -22,20 +22,35 @@ _console_handler: Optional["ConsoleLogHandler"] = None
 _debug_file_path: Path = _APP_DIR / LOG_FILE_NAME
 
 
+#: Console for log output. Kept apart from `display.console`, which records
+#: renderables so tables can be copied into the debug log; log lines already
+#: reach that log through the file handler, and recording them again would
+#: duplicate every one of them.
+#:
+#: `soft_wrap` keeps long paths on one line, as the previous click.echo did.
+#: Rich would otherwise wrap them at the terminal width.
+console = Console(soft_wrap=True)
+
+_LEVEL_STYLES = {
+    logging.CRITICAL: "bold red",
+    logging.ERROR: "red",
+    logging.WARNING: "yellow",
+}
+
+
 class ConsoleLogHandler(logging.Handler):
-    """Custom logging handler that outputs to Click with styling."""
+    """Logging handler that writes console output through rich."""
 
     def emit(self, record):
         try:
-            msg = self.format(record)
-            if record.levelno >= logging.CRITICAL:
-                click.echo(click.style(msg, fg="red", bold=True))
-            elif record.levelno >= logging.ERROR:
-                click.echo(click.style(msg, fg="red"))
-            elif record.levelno >= logging.WARNING:
-                click.echo(click.style(msg, fg="yellow"))
-            else:
-                click.echo(msg)
+            style = next(
+                (s for lvl, s in _LEVEL_STYLES.items() if record.levelno >= lvl),
+                None,
+            )
+            # markup=False because rich would read a bracketed run as a style
+            # tag and drop it: a track named "Set [b].wav" would otherwise log
+            # as "Set .wav".
+            console.print(self.format(record), style=style, markup=False)
         except Exception:
             self.handleError(record)
 

--- a/rekordbox_edit/models.py
+++ b/rekordbox_edit/models.py
@@ -25,6 +25,7 @@ Response semantics:
   their contents and order by index;
 """
 
+import os
 from typing import Literal, TypeAlias
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -90,6 +91,9 @@ class EditRequest(FilterArgs):
 
 DeleteOriginalsMode: TypeAlias = Literal["none", "lossless", "all"]
 
+#: Concurrent encodes when the caller does not choose. See ConvertRequest.threads.
+DEFAULT_THREADS = min(4, os.cpu_count() or 1)
+
 
 class ConvertRequest(FilterArgs):
     """Inputs for convert(): the shared track filters plus output format and original-file handling."""
@@ -101,6 +105,11 @@ class ConvertRequest(FilterArgs):
     only when the conversion loses no audio information. Down-sampling to the
     conversion target counts as lossy, as does MP3 output."""
     overwrite: bool = False
+    threads: int = Field(default_factory=lambda: DEFAULT_THREADS, ge=1)
+    """How many files to encode concurrently. Deliberately conservative by
+    default: MP3 and FLAC output scale well across files, while WAV and AIFF
+    output is close to pure I/O and can get slower under concurrency on the
+    external drives DJs tend to keep libraries on."""
 
 
 class ImportRequest(BaseModel):

--- a/rekordbox_edit/models.py
+++ b/rekordbox_edit/models.py
@@ -106,10 +106,7 @@ class ConvertRequest(FilterArgs):
     conversion target counts as lossy, as does MP3 output."""
     overwrite: bool = False
     threads: int = Field(default_factory=lambda: DEFAULT_THREADS, ge=1)
-    """How many files to encode concurrently. Deliberately conservative by
-    default: MP3 and FLAC output scale well across files, while WAV and AIFF
-    output is close to pure I/O and can get slower under concurrency on the
-    external drives DJs tend to keep libraries on."""
+    """How many files to encode concurrently."""
 
 
 class ImportRequest(BaseModel):

--- a/research/README.md
+++ b/research/README.md
@@ -35,6 +35,10 @@ formal and terse, and states findings as the evidence supports them.
   analysis (the `DjmdContent` row, `DjmdCue` rows, and on-disk ANLZ files), why
   re-analysis rather than conversion is what moves a beat grid, and how far the
   analysis drifts across codecs and resolutions.
+- **`convert-thread-scaling/`** — how much each output format gains from
+  converting several files at once, why uncompressed output barely benefits
+  (ffmpeg already threads the decode, so the disk is not the constraint), and
+  what that sets the `--threads` default to.
 - **`convert-export-impact/`** — what `convert` does to a track already on a USB
   export, and why converting a track after export silently breaks re-export and
   sync-back on both legacy PDB and Device Library Plus players.

--- a/research/convert-thread-scaling/convert-thread-scaling.md
+++ b/research/convert-thread-scaling/convert-thread-scaling.md
@@ -1,0 +1,113 @@
+# Why Convert Scales Unevenly Across Output Formats
+
+## Question
+
+`convert` encodes several files at once, bounded by `--threads`. Raising that
+number helps some conversions far more than others. Which, by how much, and why?
+
+The answer sets the flag's default and what the documentation should tell a user
+about raising it.
+
+## Hypothesis
+
+The design notes behind `--threads` asserted that MP3 and FLAC output scale well
+because their encoders are single-threaded per file, while WAV and AIFF output
+is "close to pure I/O" and could get *slower* under concurrency on the external
+and network drives DJs keep libraries on.
+
+The ranking was assumed rather than measured, and the stated mechanism, that
+uncompressed output is bound by writing, was never tested.
+
+## Method
+
+Three probes under `scripts/`, all against synthetic sources built by
+`_sources.py`: eight five-minute pink-noise FLAC files, 182 MB in total. The
+committed e2e audio fixtures are two seconds long, which measures process
+startup rather than conversion. Pink noise compresses to roughly 43%, near the
+50 to 60% a real music library sees, so the FLAC decode does representative work.
+
+- `format_scaling.py` converts to all four supported targets at one thread and
+  at four, reporting wall clock alongside the CPU time the ffmpeg children
+  consumed.
+- `write_cost.py` runs one conversion twice, once writing a real AIFF and once
+  discarding every byte through ffmpeg's null muxer, isolating what writing
+  costs.
+- `shipped_path_scaling.py` repeats the comparison through `_encode_one`, the
+  function `convert()` submits to its pool, confirming the effect survives the
+  code that ships.
+
+Output is recorded in `evidence/thread-scaling.txt`. Measurements come from an
+Apple Silicon machine with internal storage.
+
+## Findings
+
+### Uncompressed Output Is Not Bound by Writing
+
+The hypothesis is wrong. Writing 423 MB costs nothing measurable against
+discarding the same output entirely:
+
+```
+     write AIFF  threads=1   1.65s      discard output  threads=1   1.63s
+     write AIFF  threads=4   1.17s      discard output  threads=4   1.18s
+```
+
+The two are indistinguishable at both widths. Whatever limits AIFF conversion,
+it is not the disk.
+
+### Scaling Tracks How Many Cores One Conversion Already Uses
+
+`format_scaling.py` reports CPU consumed against wall clock. That ratio at one
+thread is how many cores a *single* conversion already occupies, and it predicts
+the speedup exactly:
+
+| target | 1 thread | 4 threads | speedup | cores one file uses |
+| ------ | -------- | --------- | ------- | ------------------- |
+| AIFF   | 1.63s    | 1.18s     | 1.38x   | 3.87                |
+| WAV    | 1.60s    | 1.16s     | 1.38x   | 3.85                |
+| FLAC   | 3.22s    | 1.45s     | 2.22x   | 2.18                |
+| MP3    | 15.02s   | 3.82s     | 3.93x   | 1.26                |
+
+The relationship is inverse and clean. ffmpeg already threads the FLAC decode
+internally. AIFF and WAV output runs no encoder at all, so decoding is
+essentially the whole job, one file already spreads across nearly four cores,
+and a pool of workers has almost nothing left to overlap. libmp3lame is
+single-threaded per file, occupies about 1.26 cores, and so parallelizes almost
+perfectly. FLAC output sits between the two.
+
+### Uncompressed Output Is Far Cheaper to Begin With
+
+The absolute numbers matter more than the ratios. AIFF converts the same eight
+tracks in 1.63 seconds against MP3's 15.02, roughly nine times faster. There is
+little to win from parallelizing work that is already nearly free, which is a
+better reason to leave WAV and AIFF alone than any claim about storage.
+
+### The Effect Survives the Shipped Code Path
+
+Driving `_encode_one` rather than ffmpeg directly reproduces the same split,
+with the fixed overhead of the source probe and the codec check added:
+
+```
+  AIFF        1    2.27s      AIFF        4    1.41s     1.61x
+   MP3        1   15.86s       MP3        4    4.07s     3.90x
+```
+
+## Conclusion
+
+Raising `--threads` is worth it for MP3 output, marginal for FLAC, and close to
+pointless for WAV and AIFF. The practical ranking in the original design notes
+holds; the mechanism given for it does not.
+
+The correct explanation is that ffmpeg already parallelizes the decode, so the
+gain from converting several files at once is roughly the number of spare cores
+divided by the number a single conversion already occupies. Output formats
+without an encoder leave no spare cores to use.
+
+A default of `min(4, os.cpu_count() or 1)` captures nearly all of the MP3 win,
+which is the case where a win exists, and costs nothing in the cases where it
+does not.
+
+Two limits on these numbers. They come from one machine with internal storage,
+so a spinning or network drive could behave differently, though `write_cost.py`
+says writing is not the constraint that would change. And they measure ffmpeg's
+current threading behavior, which is a property of the installed build rather
+than of this repository.

--- a/research/convert-thread-scaling/evidence/thread-scaling.txt
+++ b/research/convert-thread-scaling/evidence/thread-scaling.txt
@@ -1,0 +1,30 @@
+=== format_scaling.py ===
+8 files x 300s
+
+target  threads    wall      cpu  cores used
+  AIFF        1    1.63     6.31       3.86x
+  AIFF        4    1.18    10.58       8.94x
+   WAV        1    1.62     6.17       3.81x
+   WAV        4    1.19    10.68       8.99x
+  FLAC        1    3.23     7.06       2.18x
+  FLAC        4    1.38    12.35       8.96x
+   MP3        1   15.05    19.01       1.26x
+   MP3        4    3.83    21.86       5.71x
+
+=== write_cost.py ===
+     write AIFF  threads=1   1.65s
+     write AIFF  threads=4   1.17s
+ discard output  threads=1   1.63s
+ discard output  threads=4   1.18s
+
+bytes written by the first pair: 423 MB
+
+=== shipped_path_scaling.py ===
+8 files x 300s, through _encode_one
+
+target  threads    wall   speedup
+  AIFF        1    2.27     1.00x
+  AIFF        4    1.41     1.61x
+   MP3        1   15.86     1.00x
+   MP3        4    4.07     3.90x
+

--- a/research/convert-thread-scaling/scripts/_sources.py
+++ b/research/convert-thread-scaling/scripts/_sources.py
@@ -1,0 +1,52 @@
+"""Shared fixture generation for the thread-scaling probes.
+
+The committed e2e audio fixtures are two seconds long, far too short to measure
+anything but process startup. These probes synthesize realistic track lengths
+instead.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+#: Eight five-minute tracks: long enough that per-process startup disappears
+#: into the measurement, small enough to run in seconds.
+COUNT = 8
+SECONDS = 300
+
+
+def make_sources(work: Path) -> list[Path]:
+    """Fresh FLAC sources under `work`, replacing anything already there.
+
+    Pink noise rather than silence or a tone, so the FLAC decode does
+    representative work. These compress to roughly 43%, near the 50 to 60% a
+    real music library sees.
+    """
+    shutil.rmtree(work, ignore_errors=True)
+    (work / "src").mkdir(parents=True)
+    (work / "out").mkdir(parents=True)
+
+    sources = []
+    for i in range(COUNT):
+        dst = work / "src" / f"track{i}.flac"
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-v",
+                "error",
+                "-y",
+                "-f",
+                "lavfi",
+                "-i",
+                f"anoisesrc=d={SECONDS}:c=pink:r=44100",
+                "-ac",
+                "2",
+                "-sample_fmt",
+                "s16",
+                str(dst),
+            ],
+            check=True,
+            capture_output=True,
+        )
+        sources.append(dst)
+    return sources

--- a/research/convert-thread-scaling/scripts/format_scaling.py
+++ b/research/convert-thread-scaling/scripts/format_scaling.py
@@ -1,0 +1,80 @@
+"""How much does each output format gain from converting several files at once?
+
+Reports wall clock alongside the CPU time the ffmpeg children consumed. Their
+ratio at one thread is the quantity that explains everything: it is how many
+cores a *single* conversion already occupies, and therefore how little is left
+for a pool of workers to overlap.
+
+Run from the repository root:
+    uv run python research/convert-thread-scaling/scripts/format_scaling.py
+"""
+
+import resource
+import shutil
+import sys
+import subprocess
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from _sources import COUNT, SECONDS, make_sources
+
+WORK = Path("/tmp/rbe-thread-scaling")
+
+TARGETS = (
+    ("AIFF", "pcm_s16be", ".aiff", []),
+    ("WAV", "pcm_s16le", ".wav", []),
+    ("FLAC", "flac", ".flac", ["-sample_fmt", "s16"]),
+    ("MP3", "libmp3lame", ".mp3", ["-b:a", "320k", "-sample_fmt", "s16p"]),
+)
+
+
+def encode(src: Path, codec: str, ext: str, extra: list[str]) -> None:
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-v",
+            "error",
+            "-y",
+            "-i",
+            str(src),
+            "-acodec",
+            codec,
+            "-ar",
+            "44100",
+            *extra,
+            str(WORK / "out" / f"{src.stem}-{codec}{ext}"),
+        ],
+        check=True,
+        capture_output=True,
+    )
+
+
+def measure(sources, codec, ext, extra, threads) -> tuple[float, float]:
+    before = resource.getrusage(resource.RUSAGE_CHILDREN)
+    start = time.perf_counter()
+    with ThreadPoolExecutor(max_workers=threads) as pool:
+        list(pool.map(lambda s: encode(s, codec, ext, extra), sources))
+    wall = time.perf_counter() - start
+    after = resource.getrusage(resource.RUSAGE_CHILDREN)
+    cpu = (after.ru_utime - before.ru_utime) + (after.ru_stime - before.ru_stime)
+    return wall, cpu
+
+
+def main() -> None:
+    sources = make_sources(WORK)
+    print(f"{COUNT} files x {SECONDS}s\n")
+    print(f"{'target':>6} {'threads':>8} {'wall':>7} {'cpu':>8} {'cores used':>11}")
+    for label, codec, ext, extra in TARGETS:
+        for threads in (1, 4):
+            wall, cpu = measure(sources, codec, ext, extra, threads)
+            print(
+                f"{label:>6} {threads:>8} {wall:>7.2f} {cpu:>8.2f} {cpu / wall:>10.2f}x"
+            )
+    shutil.rmtree(WORK, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/research/convert-thread-scaling/scripts/shipped_path_scaling.py
+++ b/research/convert-thread-scaling/scripts/shipped_path_scaling.py
@@ -1,0 +1,71 @@
+"""Does the scaling hold through the code that actually ships?
+
+The other two probes call ffmpeg directly, isolating its behavior from ours.
+This one drives `_encode_one`, the function `convert()` submits to its pool, so
+it measures the real path including the source probe, the codec check, and the
+probe of the finished file.
+
+Run from the repository root:
+    uv run python research/convert-thread-scaling/scripts/shipped_path_scaling.py
+"""
+
+import shutil
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from _sources import COUNT, SECONDS, make_sources
+
+from rekordbox_edit.api.convert import _EncodeJob, _encode_one
+
+WORK = Path("/tmp/rbe-shipped-scaling")
+
+#: FLAC sources, so the codec check inside _encode_one passes.
+_FLAC_FILE_TYPE = 5
+
+TARGETS = (("AIFF", ".aiff"), ("MP3", ".mp3"))
+
+
+def jobs_for(sources: list[Path], fmt: str, ext: str) -> list[_EncodeJob]:
+    out = WORK / "out"
+    return [
+        _EncodeJob(
+            op_id=str(i),
+            source_path=str(src),
+            file_name=src.name,
+            file_type=_FLAC_FILE_TYPE,
+            output_path=str(out / f"{src.stem}-{fmt}{ext}"),
+            temp_path=str(out / f".rbe-convert-{i}-{src.stem}-{fmt}{ext}"),
+            output_format=fmt,
+        )
+        for i, src in enumerate(sources)
+    ]
+
+
+def main() -> None:
+    sources = make_sources(WORK)
+    print(f"{COUNT} files x {SECONDS}s, through _encode_one\n")
+    print(f"{'target':>6} {'threads':>8} {'wall':>7} {'speedup':>9}")
+    for fmt, ext in TARGETS:
+        baseline = None
+        for threads in (1, 4):
+            jobs = jobs_for(sources, fmt, ext)
+            start = time.perf_counter()
+            with ThreadPoolExecutor(max_workers=threads) as pool:
+                results = list(pool.map(_encode_one, jobs))
+            wall = time.perf_counter() - start
+            skipped = [r.skipped.reason for r in results if r.skipped]
+            assert not skipped, f"unexpected skips: {skipped}"
+            # _encode_one leaves the temp file for the caller to move.
+            for job in jobs:
+                Path(job.temp_path).unlink(missing_ok=True)
+            baseline = baseline or wall
+            print(f"{fmt:>6} {threads:>8} {wall:>7.2f} {baseline / wall:>8.2f}x")
+    shutil.rmtree(WORK, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/research/convert-thread-scaling/scripts/write_cost.py
+++ b/research/convert-thread-scaling/scripts/write_cost.py
@@ -1,0 +1,83 @@
+"""Is uncompressed output bound by the cost of writing it?
+
+Runs the same FLAC decode and PCM conversion twice: once writing a real AIFF,
+once discarding every byte through ffmpeg's null muxer. Any gap between them is
+what writing costs.
+
+Run from the repository root:
+    uv run python research/convert-thread-scaling/scripts/write_cost.py
+"""
+
+import shutil
+import sys
+import subprocess
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from _sources import make_sources
+
+WORK = Path("/tmp/rbe-write-cost")
+
+
+def _ffmpeg(args: list[str]) -> None:
+    subprocess.run(args, check=True, capture_output=True)
+
+
+def to_file(src: Path) -> None:
+    _ffmpeg(
+        [
+            "ffmpeg",
+            "-v",
+            "error",
+            "-y",
+            "-i",
+            str(src),
+            "-acodec",
+            "pcm_s16be",
+            "-ar",
+            "44100",
+            str(WORK / "out" / f"{src.stem}.aiff"),
+        ]
+    )
+
+
+def to_null(src: Path) -> None:
+    _ffmpeg(
+        [
+            "ffmpeg",
+            "-v",
+            "error",
+            "-y",
+            "-i",
+            str(src),
+            "-acodec",
+            "pcm_s16be",
+            "-ar",
+            "44100",
+            "-f",
+            "null",
+            "-",
+        ]
+    )
+
+
+def main() -> None:
+    sources = make_sources(WORK)
+    for label, fn in (("write AIFF", to_file), ("discard output", to_null)):
+        for threads in (1, 4):
+            start = time.perf_counter()
+            with ThreadPoolExecutor(max_workers=threads) as pool:
+                list(pool.map(fn, sources))
+            print(
+                f"{label:>15}  threads={threads}  {time.perf_counter() - start:5.2f}s"
+            )
+    written = sum(f.stat().st_size for f in (WORK / "out").iterdir())
+    print(f"\nbytes written by the first pair: {written / 1e6:.0f} MB")
+    shutil.rmtree(WORK, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/api/test_convert.py
+++ b/tests/api/test_convert.py
@@ -1,4 +1,5 @@
 import os
+from dataclasses import replace
 from unittest.mock import Mock, patch
 
 import ffmpeg
@@ -8,7 +9,10 @@ from rekordbox_edit.api.convert import (
     TEMP_PREFIX,
     ConvertAborted,
     ConvertedFileProbe,
+    _EncodeJob,
     _apply_converted_record,
+    _encode_one,
+    _job_for,
     _classify_convert,
     _classify_fidelity,
     _get_output_path,
@@ -1224,6 +1228,99 @@ class TestConvertRealRun:
 
 
 # ── Helper-function tests (preserved from existing file) ──────────────────
+
+
+class TestEncodeJob:
+    def test_carries_plain_values_off_the_row(self, make_djmd_content_item):
+        # Workers run off the main thread, so the job may hold no ORM object.
+        content = make_djmd_content_item(
+            ID="7", FileType=11, FolderPath="/in.wav", FileNameL="in.wav"
+        )
+        op = ConvertOp(id="7", source_path="/in.wav", output_path="/out.aif")
+
+        job = _job_for(content, op, "AIFF")
+
+        assert (job.op_id, job.source_path, job.file_type) == ("7", "/in.wav", 11)
+        assert job.temp_path == _temp_output_path("/out.aif")
+        assert not any(isinstance(v, type(content)) for v in job.__dict__.values())
+
+
+class TestEncodeOne:
+    """The worker half. Every case here must reach its answer without a session."""
+
+    _BASE = _EncodeJob(
+        op_id="1",
+        source_path="/in.wav",
+        file_name="in.wav",
+        file_type=11,
+        output_path="/out.aif",
+        temp_path="/.rbe-convert-1-out.aif",
+        output_format="AIFF",
+    )
+
+    def _job(self, **overrides) -> _EncodeJob:
+        return replace(self._BASE, **overrides)
+
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=False)
+    def test_a_missing_source_is_reported_as_a_skip(self, _exists):
+        result = _encode_one(self._job())
+
+        assert result.skipped is not None
+        assert result.skipped.reason == "file_not_found"
+        assert result.probe is None
+
+    @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_AAC_M4A)
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
+    def test_a_codec_mismatch_is_reported_as_a_skip(self, _exists, _probe):
+        result = _encode_one(self._job(file_type=11))  # 11 is WAV, probe says aac
+
+        assert result.skipped is not None
+        assert result.skipped.reason == "codec_mismatch"
+
+    @patch("rekordbox_edit.api.convert._remove_temp_file")
+    @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=False)
+    @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
+    def test_a_failed_encode_cleans_up_its_own_temp(
+        self, _exists, _probe, _run, mock_remove
+    ):
+        with pytest.raises(RuntimeError, match="Conversion failed"):
+            _encode_one(self._job())
+
+        mock_remove.assert_called_once_with("/.rbe-convert-1-out.aif")
+
+    @patch("rekordbox_edit.api.convert._probe_converted_file")
+    @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
+    @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_24_96)
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
+    def test_a_hi_res_source_reports_a_lossy_conversion(
+        self, _exists, _probe, mock_run, mock_converted
+    ):
+        result = _encode_one(self._job())
+
+        assert result.skipped is None
+        assert result.is_lossless is False
+        assert result.output_sample_rate == 44100
+        # The encode targets the temp path, never the final one.
+        assert mock_run.call_args.args[1] == "/.rbe-convert-1-out.aif"
+
+    @patch("rekordbox_edit.api.convert._probe_converted_file")
+    @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
+    @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
+    def test_an_at_target_source_reports_a_lossless_conversion(
+        self, _exists, _probe, _run, _converted
+    ):
+        assert _encode_one(self._job()).is_lossless is True
+
+    @patch("rekordbox_edit.api.convert._probe_converted_file")
+    @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
+    @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
+    def test_mp3_output_is_never_lossless(self, _exists, _probe, _run, _converted):
+        result = _encode_one(self._job(output_format="MP3", output_path="/out.mp3"))
+
+        assert result.is_lossless is False
 
 
 class TestConvertPerFileCommits:

--- a/tests/api/test_convert.py
+++ b/tests/api/test_convert.py
@@ -1643,6 +1643,144 @@ class TestConvertParallelEncoding:
         assert mock_remove.called
 
 
+class TestConvertProgressReporting:
+    @pytest.fixture(autouse=True)
+    def _stub_temp_file_moves(self):
+        with (
+            patch("rekordbox_edit.api.convert.os.replace"),
+            patch("rekordbox_edit.api.convert.os.listdir", return_value=[]),
+            patch("rekordbox_edit.api.convert._probe_converted_file"),
+        ):
+            yield
+
+    @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
+    @patch("rekordbox_edit.api.convert._apply_converted_record")
+    @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert._get_output_path")
+    @patch("rekordbox_edit.api.convert.get_file_type_for_format")
+    @patch("rekordbox_edit.api.convert.get_filtered_content")
+    def test_every_file_is_reported_started_then_finished(
+        self,
+        mock_gfc,
+        mock_get_type,
+        mock_get_output,
+        _ffmpeg,
+        _exists,
+        _run,
+        _apply,
+        _probe,
+        mock_db,
+        make_djmd_content_item,
+    ):
+        mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
+            fmt.upper(), 99
+        )
+        mock_get_output.side_effect = lambda content, fmt: (
+            f"/{content.ID}.aif",
+            f"{content.ID}.aif",
+            "/",
+        )
+        events = []
+
+        class _Recorder:
+            def batch_size(self, total):
+                events.append(("batch_size", total))
+
+            def started(self, index, file_name):
+                events.append(("started", index))
+
+            def finished(self, index, converted):
+                events.append(("finished", index, converted))
+
+        contents = [
+            make_djmd_content_item(
+                ID=str(i), FileType=11, FolderPath=f"/in{i}.wav", FileNameL=f"in{i}.wav"
+            )
+            for i in (1, 2, 3)
+        ]
+        _seed_filter(mock_gfc, *contents)
+        _seed_db(mock_db, *contents)
+
+        convert(
+            mock_db,
+            ConvertRequest(format_out="aiff", overwrite=True, threads=1),
+            progress=_Recorder(),
+        )
+
+        assert events[0] == ("batch_size", 3)
+        assert [e for e in events if e[0] == "started"] == [
+            ("started", 0),
+            ("started", 1),
+            ("started", 2),
+        ]
+        assert [e for e in events if e[0] == "finished"] == [
+            ("finished", 0, True),
+            ("finished", 1, True),
+            ("finished", 2, True),
+        ]
+
+    @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
+    @patch("rekordbox_edit.api.convert._apply_converted_record")
+    @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
+    @patch("rekordbox_edit.api.convert.os.path.exists")
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert._get_output_path")
+    @patch("rekordbox_edit.api.convert.get_file_type_for_format")
+    @patch("rekordbox_edit.api.convert.get_filtered_content")
+    def test_a_skipped_file_is_reported_as_not_converted(
+        self,
+        mock_gfc,
+        mock_get_type,
+        mock_get_output,
+        _ffmpeg,
+        mock_exists,
+        _run,
+        _apply,
+        _probe,
+        mock_db,
+        make_djmd_content_item,
+    ):
+        # The overall bar still advances for a skip, so the caller has to be
+        # told the difference rather than inferring it from a missing call.
+        mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
+            fmt.upper(), 99
+        )
+        mock_get_output.side_effect = lambda content, fmt: (
+            f"/{content.ID}.aif",
+            f"{content.ID}.aif",
+            "/",
+        )
+        mock_exists.side_effect = lambda path: path != "/in2.wav"
+        finished = []
+
+        class _Recorder:
+            def batch_size(self, total):
+                pass
+
+            def started(self, index, file_name):
+                pass
+
+            def finished(self, index, converted):
+                finished.append((index, converted))
+
+        contents = [
+            make_djmd_content_item(ID=str(i), FileType=11, FolderPath=f"/in{i}.wav")
+            for i in (1, 2, 3)
+        ]
+        _seed_filter(mock_gfc, *contents)
+        _seed_db(mock_db, *contents)
+
+        convert(
+            mock_db,
+            ConvertRequest(format_out="aiff", overwrite=True, threads=1),
+            progress=_Recorder(),
+        )
+
+        assert finished == [(0, True), (1, False), (2, True)]
+
+
 class TestConvertLogging:
     @pytest.fixture(autouse=True)
     def _stub_temp_file_moves(self):

--- a/tests/api/test_convert.py
+++ b/tests/api/test_convert.py
@@ -1735,18 +1735,27 @@ class TestClassifyFidelity:
 
 
 class TestRunFfmpeg:
+    @pytest.fixture
+    def chain(self):
+        """The mocked ffmpeg builder chain, ending at the object .run() lands on."""
+        with (
+            patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True),
+            patch("rekordbox_edit.api.convert.ffmpeg") as mock_ffmpeg,
+        ):
+            output = Mock()
+            mock_ffmpeg.input.return_value.output.return_value = output
+            output.overwrite_output.return_value = output
+            output.global_args.return_value = output
+            yield mock_ffmpeg, output
+
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=False)
     def test_ffmpeg_not_found_raises(self, _):
         with pytest.raises(Exception, match="FFmpeg not found in PATH"):
             _run_ffmpeg("in.flac", "out.aiff", {"acodec": "pcm_s16be"}, "aiff")
 
-    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
-    @patch("rekordbox_edit.api.convert.ffmpeg")
-    def test_success_passes_kwargs_through(self, mock_ffmpeg, _ffmpeg_in_path):
-        mock_output = Mock()
-        mock_ffmpeg.input.return_value.output.return_value = mock_output
-        mock_output.overwrite_output.return_value = mock_output
-        mock_output.run.return_value = None
+    def test_success_passes_kwargs_through(self, chain):
+        mock_ffmpeg, output = chain
+        output.run.return_value = None
 
         result = _run_ffmpeg(
             "in.flac", "out.wav", {"acodec": "pcm_s16le", "ar": 44100}, "wav"
@@ -1758,33 +1767,32 @@ class TestRunFfmpeg:
             "out.wav", acodec="pcm_s16le", ar=44100
         )
 
-    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
-    @patch("rekordbox_edit.api.convert.ffmpeg")
-    def test_ffmpeg_error_returns_false(self, mock_ffmpeg, _ffmpeg_in_path):
-        mock_output = Mock()
-        mock_ffmpeg.input.return_value.output.return_value = mock_output
-        mock_output.overwrite_output.return_value = mock_output
-        mock_output.run.side_effect = ffmpeg.Error("cmd", b"stdout", b"stderr")
+    def test_the_child_is_kept_off_the_terminal(self, chain):
+        # Without -nostdin, ffmpeg puts the tty in non-canonical mode to watch
+        # for keys like "q". Concurrent encodes race on restoring it and the
+        # loser leaves the shell echoing ^M instead of accepting Enter.
+        _, output = chain
+        output.run.return_value = None
+
+        _run_ffmpeg("in.flac", "out.aiff", {}, "aiff")
+
+        output.global_args.assert_called_once_with("-nostdin")
+
+    def test_ffmpeg_error_returns_false(self, chain):
+        _, output = chain
+        output.run.side_effect = ffmpeg.Error("cmd", b"stdout", b"stderr")
 
         assert _run_ffmpeg("in.flac", "out.aiff", {}, "aiff") is False
 
-    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
-    @patch("rekordbox_edit.api.convert.ffmpeg")
-    def test_ffmpeg_error_no_stderr_returns_false(self, mock_ffmpeg, _ffmpeg_in_path):
-        mock_output = Mock()
-        mock_ffmpeg.input.return_value.output.return_value = mock_output
-        mock_output.overwrite_output.return_value = mock_output
-        mock_output.run.side_effect = ffmpeg.Error("cmd", b"stdout", None)
+    def test_ffmpeg_error_no_stderr_returns_false(self, chain):
+        _, output = chain
+        output.run.side_effect = ffmpeg.Error("cmd", b"stdout", None)
 
         assert _run_ffmpeg("in.flac", "out.aiff", {}, "aiff") is False
 
-    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
-    @patch("rekordbox_edit.api.convert.ffmpeg")
-    def test_unexpected_exception_reraises(self, mock_ffmpeg, _ffmpeg_in_path):
-        mock_output = Mock()
-        mock_ffmpeg.input.return_value.output.return_value = mock_output
-        mock_output.overwrite_output.return_value = mock_output
-        mock_output.run.side_effect = RuntimeError("disk full")
+    def test_unexpected_exception_reraises(self, chain):
+        _, output = chain
+        output.run.side_effect = RuntimeError("disk full")
 
         with pytest.raises(RuntimeError, match="disk full"):
             _run_ffmpeg("in.flac", "out.aiff", {}, "aiff")

--- a/tests/api/test_convert.py
+++ b/tests/api/test_convert.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import threading
 import time
@@ -1640,6 +1641,61 @@ class TestConvertParallelEncoding:
         assert mock_run.call_count <= 3
         # Whatever ran ahead and succeeded had its temp file cleaned up.
         assert mock_remove.called
+
+
+class TestConvertLogging:
+    @pytest.fixture(autouse=True)
+    def _stub_temp_file_moves(self):
+        with (
+            patch("rekordbox_edit.api.convert.os.replace"),
+            patch("rekordbox_edit.api.convert.os.listdir", return_value=[]),
+            patch("rekordbox_edit.api.convert._probe_converted_file"),
+        ):
+            yield
+
+    @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
+    @patch("rekordbox_edit.api.convert._apply_converted_record")
+    @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert._get_output_path")
+    @patch("rekordbox_edit.api.convert.get_file_type_for_format")
+    @patch("rekordbox_edit.api.convert.get_filtered_content")
+    def test_the_api_leaves_the_batch_summary_to_the_caller(
+        self,
+        mock_gfc,
+        mock_get_type,
+        mock_get_output,
+        _ffmpeg,
+        _exists,
+        _run,
+        _apply,
+        _probe,
+        mock_db,
+        make_djmd_content_item,
+        caplog,
+    ):
+        # The CLI prints "Converted N files to X". The API printing it too put
+        # the line on screen twice.
+        mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
+            fmt.upper(), 99
+        )
+        mock_get_output.side_effect = lambda content, fmt: (
+            f"/{content.ID}.aif",
+            f"{content.ID}.aif",
+            "/",
+        )
+        contents = [
+            make_djmd_content_item(ID=str(i), FileType=11, FolderPath=f"/in{i}.wav")
+            for i in (1, 2)
+        ]
+        _seed_filter(mock_gfc, *contents)
+        _seed_db(mock_db, *contents)
+
+        with caplog.at_level(logging.INFO, logger="rekordbox_edit.api.convert"):
+            convert(mock_db, ConvertRequest(format_out="aiff", overwrite=True))
+
+        assert "Converted 2 files" not in caplog.text
 
 
 class TestConvertInterrupt:

--- a/tests/api/test_convert.py
+++ b/tests/api/test_convert.py
@@ -1,4 +1,6 @@
 import os
+import threading
+import time
 from dataclasses import replace
 from unittest.mock import Mock, patch
 
@@ -1373,12 +1375,16 @@ class TestConvertPerFileCommits:
         _seed_filter(mock_gfc, *contents)
 
         with pytest.raises(ConvertAborted) as raised:
-            convert(mock_db, ConvertRequest(format_out="aiff", overwrite=True))
+            convert(
+                mock_db, ConvertRequest(format_out="aiff", overwrite=True, threads=1)
+            )
 
         assert raised.value.converted == 1
         assert raised.value.not_attempted == 1
         assert raised.value.failed_path == "/in2.wav"
         assert mock_db.session.commit.call_count == 1
+        # Nothing beyond the failure was encoded: at one worker the pool never
+        # runs ahead of the drain point.
         assert mock_run.call_count == 2
 
     @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
@@ -1474,6 +1480,166 @@ class TestConvertPerFileCommits:
         assert mock_db.session.commit.call_count == 2
         assert response.result.deleted == 1
         mock_remove.assert_called_once_with("/in1.wav")
+
+
+class TestConvertParallelEncoding:
+    """Properties that only appear once more than one encode is in flight."""
+
+    @pytest.fixture(autouse=True)
+    def _stub_temp_file_moves(self):
+        with (
+            patch("rekordbox_edit.api.convert.os.replace"),
+            patch("rekordbox_edit.api.convert.os.listdir", return_value=[]),
+            patch("rekordbox_edit.api.convert._probe_converted_file"),
+        ):
+            yield
+
+    @staticmethod
+    def _contents(make_djmd_content_item, count):
+        return [
+            make_djmd_content_item(ID=str(i), FileType=11, FolderPath=f"/in{i}.wav")
+            for i in range(1, count + 1)
+        ]
+
+    @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
+    @patch("rekordbox_edit.api.convert._apply_converted_record")
+    @patch("rekordbox_edit.api.convert._run_ffmpeg")
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert._get_output_path")
+    @patch("rekordbox_edit.api.convert.get_file_type_for_format")
+    @patch("rekordbox_edit.api.convert.get_filtered_content")
+    def test_results_follow_submission_order_not_completion_order(
+        self,
+        mock_gfc,
+        mock_get_type,
+        mock_get_output,
+        _ffmpeg,
+        _exists,
+        mock_run,
+        _apply,
+        _probe,
+        mock_db,
+        make_djmd_content_item,
+    ):
+        # rbe convert --print ids feeds pipelines, so the order of the ids it
+        # emits is part of the contract. Finish the encodes backwards.
+        mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
+            fmt.upper(), 99
+        )
+        mock_get_output.side_effect = lambda content, fmt: (
+            f"/{content.ID}.aif",
+            f"{content.ID}.aif",
+            "/",
+        )
+        delays = {"/in1.wav": 0.06, "/in2.wav": 0.03, "/in3.wav": 0.0}
+
+        def _slow(src, *_args, **_kwargs):
+            time.sleep(delays[src])
+            return True
+
+        mock_run.side_effect = _slow
+        contents = self._contents(make_djmd_content_item, 3)
+        _seed_filter(mock_gfc, *contents)
+        _seed_db(mock_db, *contents)
+
+        response = convert(
+            mock_db, ConvertRequest(format_out="aiff", overwrite=True, threads=3)
+        )
+
+        assert [op.id for op in response.result.converted] == ["1", "2", "3"]
+
+    @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
+    @patch("rekordbox_edit.api.convert._apply_converted_record")
+    @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert._get_output_path")
+    @patch("rekordbox_edit.api.convert.get_file_type_for_format")
+    @patch("rekordbox_edit.api.convert.get_filtered_content")
+    def test_no_worker_touches_the_session(
+        self,
+        mock_gfc,
+        mock_get_type,
+        mock_get_output,
+        _ffmpeg,
+        _exists,
+        _run,
+        _apply,
+        _probe,
+        mock_db,
+        make_djmd_content_item,
+    ):
+        # The session is not thread-safe, and USN maintenance will depend on
+        # every database touch staying on the main thread. Record who calls.
+        mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
+            fmt.upper(), 99
+        )
+        mock_get_output.side_effect = lambda content, fmt: (
+            f"/{content.ID}.aif",
+            f"{content.ID}.aif",
+            "/",
+        )
+        main_thread = threading.current_thread().ident
+        callers = []
+        mock_db.session.commit.side_effect = lambda: callers.append(
+            threading.current_thread().ident
+        )
+        contents = self._contents(make_djmd_content_item, 4)
+        _seed_filter(mock_gfc, *contents)
+        _seed_db(mock_db, *contents)
+
+        convert(mock_db, ConvertRequest(format_out="aiff", overwrite=True, threads=4))
+
+        assert callers == [main_thread] * 4
+
+    @patch("rekordbox_edit.api.convert._remove_temp_file")
+    @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
+    @patch("rekordbox_edit.api.convert._apply_converted_record")
+    @patch("rekordbox_edit.api.convert._run_ffmpeg")
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert._get_output_path")
+    @patch("rekordbox_edit.api.convert.get_file_type_for_format")
+    @patch("rekordbox_edit.api.convert.get_filtered_content")
+    def test_an_abort_wastes_at_most_the_pool_width(
+        self,
+        mock_gfc,
+        mock_get_type,
+        mock_get_output,
+        _ffmpeg,
+        _exists,
+        mock_run,
+        _apply,
+        _probe,
+        mock_remove,
+        mock_db,
+        make_djmd_content_item,
+    ):
+        # Ten files, two workers, the second fails: at most two encodes run
+        # ahead of the drain, so the remaining eight are never started.
+        mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
+            fmt.upper(), 99
+        )
+        mock_get_output.side_effect = lambda content, fmt: (
+            f"/{content.ID}.aif",
+            f"{content.ID}.aif",
+            "/",
+        )
+        mock_run.side_effect = lambda src, *a, **k: src != "/in2.wav"
+        contents = self._contents(make_djmd_content_item, 10)
+        _seed_filter(mock_gfc, *contents)
+        _seed_db(mock_db, *contents)
+
+        with pytest.raises(ConvertAborted) as raised:
+            convert(
+                mock_db, ConvertRequest(format_out="aiff", overwrite=True, threads=2)
+            )
+
+        assert raised.value.converted == 1
+        assert mock_run.call_count <= 3
+        # Whatever ran ahead and succeeded had its temp file cleaned up.
+        assert mock_remove.called
 
 
 class TestClassifyFidelity:

--- a/tests/api/test_convert.py
+++ b/tests/api/test_convert.py
@@ -14,7 +14,7 @@ from rekordbox_edit.api.convert import (
     _EncodeJob,
     _apply_converted_record,
     _encode_one,
-    _job_for,
+    _encode_job_for,
     _classify_convert,
     _classify_fidelity,
     _get_output_path,
@@ -1240,7 +1240,7 @@ class TestEncodeJob:
         )
         op = ConvertOp(id="7", source_path="/in.wav", output_path="/out.aif")
 
-        job = _job_for(content, op, "AIFF")
+        job = _encode_job_for(content, op, "AIFF")
 
         assert (job.op_id, job.source_path, job.file_type) == ("7", "/in.wav", 11)
         assert job.temp_path == _temp_output_path("/out.aif")
@@ -1640,6 +1640,70 @@ class TestConvertParallelEncoding:
         assert mock_run.call_count <= 3
         # Whatever ran ahead and succeeded had its temp file cleaned up.
         assert mock_remove.called
+
+
+class TestConvertInterrupt:
+    @pytest.fixture(autouse=True)
+    def _stub_temp_file_moves(self):
+        with (
+            patch("rekordbox_edit.api.convert.os.replace"),
+            patch("rekordbox_edit.api.convert.os.listdir", return_value=[]),
+            patch("rekordbox_edit.api.convert._probe_converted_file"),
+        ):
+            yield
+
+    @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
+    @patch("rekordbox_edit.api.convert._apply_converted_record")
+    @patch("rekordbox_edit.api.convert._run_ffmpeg")
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert._get_output_path")
+    @patch("rekordbox_edit.api.convert.get_file_type_for_format")
+    @patch("rekordbox_edit.api.convert.get_filtered_content")
+    def test_ctrl_c_keeps_the_files_already_converted(
+        self,
+        mock_gfc,
+        mock_get_type,
+        mock_get_output,
+        _ffmpeg,
+        _exists,
+        mock_run,
+        _apply,
+        _probe,
+        mock_db,
+        make_djmd_content_item,
+    ):
+        # Per-file commits make an interrupt cheap: what finished is committed.
+        mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
+            fmt.upper(), 99
+        )
+        mock_get_output.side_effect = lambda content, fmt: (
+            f"/{content.ID}.aif",
+            f"{content.ID}.aif",
+            "/",
+        )
+
+        def _interrupt_on_second(src, *_a, **_k):
+            if src == "/in2.wav":
+                raise KeyboardInterrupt
+            return True
+
+        mock_run.side_effect = _interrupt_on_second
+        contents = [
+            make_djmd_content_item(ID=str(i), FileType=11, FolderPath=f"/in{i}.wav")
+            for i in (1, 2, 3)
+        ]
+        _seed_filter(mock_gfc, *contents)
+        _seed_db(mock_db, *contents)
+
+        with pytest.raises(ConvertAborted) as raised:
+            convert(
+                mock_db, ConvertRequest(format_out="aiff", overwrite=True, threads=1)
+            )
+
+        assert raised.value.converted == 1
+        assert raised.value.not_attempted == 1
+        assert mock_db.session.commit.call_count == 1
 
 
 class TestClassifyFidelity:

--- a/tests/cli/test_convert.py
+++ b/tests/cli/test_convert.py
@@ -8,6 +8,7 @@ from click.testing import CliRunner
 from rekordbox_edit.api.convert import ConvertAborted
 from rekordbox_edit.cli.convert import convert_command
 from rekordbox_edit.models import (
+    DEFAULT_THREADS,
     ConvertOp,
     ConvertResponse,
     ConvertResult,
@@ -354,3 +355,39 @@ class TestMissingSourceReporting:
         assert result.exit_code == 0
         warnings = " ".join(str(c) for c in mock_logger.warning.call_args_list)
         assert "source file is gone" in warnings
+
+
+class TestThreadsFlag:
+    @patch("rekordbox_edit.cli.convert.convert")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None)
+    def test_threads_reaches_the_request(self, _pid, mock_db_class, mock_convert):
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_convert.return_value = _response()
+
+        result = CliRunner().invoke(
+            convert_command, ["--format-out", "aiff", "--threads", "3", "--yes"]
+        )
+
+        assert result.exit_code == 0
+        assert mock_convert.call_args.args[1].threads == 3
+
+    @patch("rekordbox_edit.cli.convert.convert")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None)
+    def test_omitting_threads_uses_the_conservative_default(
+        self, _pid, mock_db_class, mock_convert
+    ):
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_convert.return_value = _response()
+
+        CliRunner().invoke(convert_command, ["--format-out", "aiff", "--yes"])
+
+        assert mock_convert.call_args.args[1].threads == DEFAULT_THREADS
+
+    def test_zero_threads_is_a_usage_error(self):
+        result = CliRunner().invoke(
+            convert_command, ["--format-out", "aiff", "--threads", "0", "--yes"]
+        )
+
+        assert result.exit_code != 0

--- a/tests/cli/test_progress.py
+++ b/tests/cli/test_progress.py
@@ -1,0 +1,118 @@
+"""Tests for the live convert progress display."""
+
+import io
+from unittest.mock import patch
+
+import pytest
+from rich.console import Console
+from rich.progress import Progress
+
+from rekordbox_edit.cli._progress import (
+    ConvertProgressDisplay,
+    _OverallCountColumn,
+    convert_progress,
+)
+
+
+class _Task:
+    def __init__(self, total, overall=False):
+        self.total = total
+        self.completed = 0
+        self.fields = {"overall": overall}
+
+
+class TestOverallCountColumn:
+    def test_renders_n_of_total_for_the_overall_task(self):
+        assert str(_OverallCountColumn().render(_Task(total=9, overall=True))) == "0/9"
+
+    def test_renders_a_bare_count_when_the_batch_size_is_unknown(self):
+        # The --yes path has no count until convert() classifies, but the files
+        # finished so far are still worth showing.
+        task = _Task(total=None, overall=True)
+        task.completed = 3
+
+        assert str(_OverallCountColumn().render(task)) == "3"
+
+    def test_renders_nothing_for_a_file_row(self):
+        # File rows are indeterminate by design, and "0/?" beside a pulsing bar
+        # is noise. They are told apart by the marker, not by the missing
+        # total, which the overall row can also lack.
+        assert str(_OverallCountColumn().render(_Task(total=None))) == ""
+
+
+class TestConvertProgressDisplay:
+    @pytest.fixture
+    def display(self):
+        progress = Progress()
+        return progress, ConvertProgressDisplay(progress)
+
+    def test_a_line_appears_per_file_in_flight(self, display):
+        progress, d = display
+
+        d.started(0, "a.flac")
+        d.started(1, "b.flac")
+
+        descriptions = [t.description for t in progress.tasks]
+        assert "a.flac" in descriptions
+        assert "b.flac" in descriptions
+
+    def test_a_finished_file_gives_up_its_line(self, display):
+        progress, d = display
+        d.started(0, "a.flac")
+        d.started(1, "b.flac")
+
+        d.finished(0, converted=True)
+
+        assert [t.description for t in progress.tasks] == ["Converting", "b.flac"]
+
+    def test_the_overall_bar_advances_on_every_file(self, display):
+        progress, d = display
+        for index in range(3):
+            d.started(index, f"{index}.flac")
+
+        d.finished(0, converted=True)
+        d.finished(1, converted=False)  # a skip still consumes a file
+
+        assert progress.tasks[0].completed == 2
+
+    def test_a_file_with_no_name_does_not_break_the_line(self, display):
+        progress, d = display
+
+        d.started(0, None)
+
+        assert progress.tasks[-1].description == ""
+
+    def test_finishing_an_unknown_index_is_harmless(self, display):
+        progress, d = display
+
+        d.finished(99, converted=True)
+
+        assert progress.tasks[0].completed == 1
+
+
+class TestConvertProgressEnabling:
+    def _console(self, is_terminal):
+        # is_terminal is a read-only property, so swap the console itself for
+        # one built to answer the way this case needs.
+        return patch(
+            "rekordbox_edit.cli._progress.console",
+            Console(file=io.StringIO(), force_terminal=is_terminal),
+        )
+
+    def test_disabled_yields_nothing(self):
+        with self._console(True), convert_progress(enabled=False) as progress:
+            assert progress is None
+
+    def test_a_non_terminal_yields_nothing(self):
+        # Piping into another command must not emit control codes.
+        with self._console(False), convert_progress(enabled=True) as progress:
+            assert progress is None
+
+    def test_it_starts_without_a_target_until_convert_reports_one(self):
+        with self._console(True), convert_progress(enabled=True) as progress:
+            assert isinstance(progress, ConvertProgressDisplay)
+            assert progress._progress.tasks[0].total is None
+
+            progress.batch_size(7)
+
+            assert progress._progress.tasks[0].total == 7

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -73,6 +73,42 @@ class TestSetupLogging:
         assert "from child" in content
 
 
+class TestConsoleOutput:
+    """Console output goes through rich, which reads some text as markup."""
+
+    @pytest.fixture
+    def emit(self, tmp_path, capsys):
+        setup_logging(log_file=str(tmp_path / "test.log"))
+
+        def _emit(message, level=logging.INFO):
+            logging.getLogger("rekordbox_edit.test").log(level, message)
+            return capsys.readouterr().out
+
+        return _emit
+
+    def test_a_bracketed_track_name_survives(self, emit):
+        # Rich would read "[b]" as a request for bold and drop it, logging
+        # "Set .wav". Bracketed titles are common in music libraries.
+        assert "Set [b].wav" in emit("Skipping Set [b].wav")
+
+    def test_a_bracketed_style_word_survives(self, emit):
+        assert "[bold]" in emit("Track [bold]remix.mp3 converted")
+
+    def test_a_long_path_is_not_wrapped(self, emit):
+        path = "/Users/me/Music/" + "Very Long Directory Name/" * 6 + "track.flac"
+
+        out = emit(f"Skipping {path}: source file is gone")
+
+        assert path in out
+        assert out.count("\n") == 1
+
+    @pytest.mark.parametrize(
+        "level", [logging.WARNING, logging.ERROR, logging.CRITICAL]
+    )
+    def test_higher_levels_still_reach_the_console(self, emit, level):
+        assert "attention" in emit("needs attention", level)
+
+
 class TestSetLevel:
     def test_default_console_level_is_info(self):
         """Console handler starts at INFO level."""


### PR DESCRIPTION
Encodes several files at once, with a live display of what is in flight.

## Concurrency

- Snapshot each encode's inputs into a frozen `_EncodeJob` of plain values, copied off the content row on the main thread. Workers never see a `DjmdContent`, so nothing reaches back into a session that is not thread-safe.
- Extract `_encode_one`, the whole filesystem half: source check, probe, codec comparison, ffmpeg into the temp path, and the probe of the result. It reports a skip rather than mutating shared state, and cleans up its own temp file if the encode fails.
- Drain through a `ThreadPoolExecutor` in submission order, not completion order, so `converted_ops`, the progress lines, and `--print ids` stay deterministic.
- Only `--threads` jobs run ahead of the drain point, topped up as each result lands. An abort cancels what is queued and removes temp files from encodes that finished but were never drained.
- Add `--threads` / `-t`, defaulting to `min(4, os.cpu_count() or 1)`, exported as `DEFAULT_THREADS` so the API and CLI share one default.

## Display

- `ConsoleLogHandler` prints through a rich `Console` instead of `click.echo`, so log lines and rich tables share one renderer. Markup is disabled and `soft_wrap` is on; rich highlighting now colors numbers and paths.
- Add `ConvertProgress`, a Protocol the API reports encode starts and finishes against, keeping display code out of `convert()`.
- Add `cli/_progress.py`: a line per file in flight, capped by `--threads`, above an overall bar with percentage, count, and ETA. Finished files scroll out as ordinary log lines rather than being held in the display.
- Suppress the display in scripting modes, when stdout is not a terminal, and for dry runs.

## Fixes

- Pass `-nostdin` to ffmpeg. `ffmpeg-python` leaves children on the parent's stdin, and ffmpeg puts the terminal in non-canonical mode to watch for keys like `q`. Concurrent encodes race on restoring it, and the loser leaves the shell echoing `^M` instead of accepting Enter. Reproduced against a pty: one encode is always fine, four break it every time.
- Print the batch summary once. Both the API and the CLI logged `Converted N files to X`, so an interactive run showed it twice. Predates this branch.

## Notes

Per-file lines spin rather than fill. ffmpeg reports position roughly twice a second and a track encodes in about two seconds, so a per-file percentage would render three or four frames. Measurements are recorded under `research/convert-thread-scaling/`, which also corrects the assumption that uncompressed output is disk-bound: writing is free, and the reason WAV and AIFF barely benefit from more threads is that ffmpeg already spreads their decode across cores.

## Behavior Changes

- The `[i/n] <filename>` line reads `[i/n] converted <filename>` and prints when a file finishes, not when it starts.
- A source file that vanished between the preview and the conversion is skipped rather than aborting the batch.
- Ctrl-C during an encode surfaces as `ConvertAborted` with the counts rather than a bare `KeyboardInterrupt`.
- `--threads 1` reproduces the previous serial behavior.

## Testing

629 unit and CLI tests, every commit green on its own. E2E docker suite passes at 33, running real ffmpeg through the pool. Lint, typecheck, and `mkdocs build --strict` clean.

New cases include: results follow submission order when encodes finish backwards; every `session.commit` happens on the main thread; an abort at `--threads 2` over ten files starts no more than three encodes; a track named `Set [b].wav` still logs intact, which fails without `markup=False`; and the API emits no batch summary of its own.

Measured on the committed audio fixtures with real ffmpeg, four files to MP3: 0.48s at one thread, 0.13s at four.
