### PR TITLE
feat(convert): add a live progress display

### DIFF
--- a/rekordbox_edit/api/convert.py
+++ b/rekordbox_edit/api/convert.py
@@ -6,7 +6,7 @@ from collections.abc import Iterable
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, NamedTuple, Tuple, cast
+from typing import Literal, NamedTuple, Protocol, Tuple, cast
 
 import ffmpeg
 from ffmpeg import Error as FfmpegError
@@ -218,6 +218,22 @@ class _EncodeJob:
     output_path: str
     temp_path: str
     output_format: str
+
+
+class ConvertProgress(Protocol):
+    """Reports which files are being encoded, for a caller that wants to show it.
+
+    `convert()` knows when an encode starts and finishes; how that is displayed
+    belongs to the caller. Implementations must tolerate calls from any order
+    of starts and finishes, and must not raise.
+    """
+
+    def started(self, index: int, file_name: str | None) -> None:
+        """An encode for `index` has been handed to a worker."""
+
+    def finished(self, index: int, converted: bool) -> None:
+        """The encode for `index` was collected. `converted` is False when the
+        file was skipped rather than encoded."""
 
 
 @dataclass
@@ -456,6 +472,7 @@ def convert(
     args: ConvertRequest,
     *,
     dry_run: bool = False,
+    progress: ConvertProgress | None = None,
 ) -> ConvertResponse:
     """Convert audio files to a target format and update the Rekordbox database.
 
@@ -554,6 +571,8 @@ def convert(
             """Hand job `index` to a worker, if the batch runs that far."""
             if index < len(jobs):
                 encoding[index] = pool.submit(_encode_one, jobs[index])
+                if progress:
+                    progress.started(index, jobs[index].file_name)
 
         def _stop_pending_encodes() -> None:
             """Give up on everything still in flight, leaving no stray files.
@@ -603,6 +622,9 @@ def convert(
             # keeps the in-flight count capped and leaves no queued work behind
             # on an abort.
             _start_encode(index + thread_count)
+
+            if progress:
+                progress.finished(index, converted=result.skipped is None)
 
             if result.skipped:
                 skipped.append(result.skipped)

--- a/rekordbox_edit/cli/_progress.py
+++ b/rekordbox_edit/cli/_progress.py
@@ -1,0 +1,91 @@
+"""Live progress display for long-running CLI commands."""
+
+import contextlib
+import logging
+from collections.abc import Iterator
+
+from rich.progress import (
+    BarColumn,
+    MofNCompleteColumn,
+    Progress,
+    SpinnerColumn,
+    TaskID,
+    TaskProgressColumn,
+    TextColumn,
+    TimeRemainingColumn,
+)
+
+from rekordbox_edit.logger import console
+
+logger = logging.getLogger(__name__)
+
+
+class _OverallCountColumn(MofNCompleteColumn):
+    """The n-of-total count, shown only for the overall task.
+
+    Per-file tasks have no total (see ConvertProgressDisplay), and rendering
+    them as "0/?" is noise beside a bar that is already pulsing.
+    """
+
+    def render(self, task):
+        return "" if task.total is None else super().render(task)
+
+
+class ConvertProgressDisplay:
+    """A line per file being encoded, above an overall bar.
+
+    Finished files are not kept here. `convert()` already logs a line for each
+    one, and those scroll above the live region on their way to the debug log,
+    which leaves this display showing only what is still in flight.
+
+    ffmpeg reports its position roughly twice a second and a track encodes in
+    about two seconds, so a per-file percentage would show three or four
+    frames. The per-file lines spin rather than fill for that reason: what is
+    worth knowing is which files are being worked on, not how far into each.
+    """
+
+    def __init__(self, progress: Progress, total: int | None):
+        self._progress = progress
+        self._overall = progress.add_task("Converting", total=total)
+        self._tasks: dict[int, TaskID] = {}
+
+    def started(self, index: int, file_name: str | None) -> None:
+        self._tasks[index] = self._progress.add_task(
+            file_name or "", total=None, start=True
+        )
+
+    def finished(self, index: int, converted: bool) -> None:
+        task = self._tasks.pop(index, None)
+        if task is not None:
+            self._progress.remove_task(task)
+        self._progress.advance(self._overall)
+
+
+@contextlib.contextmanager
+def convert_progress(
+    total: int | None, *, enabled: bool
+) -> Iterator[ConvertProgressDisplay | None]:
+    """A live convert display, or nothing when the terminal cannot host one.
+
+    Yields None when disabled, which `convert()` accepts as "report nothing".
+    A `total` of None leaves the overall bar counting up without a target, for
+    the `--yes` path where nothing has classified the batch yet.
+    """
+    if not enabled or not console.is_terminal or total == 0:
+        yield None
+        return
+
+    progress = Progress(
+        SpinnerColumn(),
+        # markup=False: a track named "Set [b].wav" would otherwise render as
+        # "Set .wav", the same trap the log handler avoids.
+        TextColumn("{task.description}", markup=False),
+        BarColumn(),
+        TaskProgressColumn(),
+        _OverallCountColumn(),
+        TimeRemainingColumn(),
+        console=console,
+        transient=True,
+    )
+    with progress:
+        yield ConvertProgressDisplay(progress, total)

--- a/rekordbox_edit/cli/convert.py
+++ b/rekordbox_edit/cli/convert.py
@@ -15,6 +15,7 @@ from rekordbox_edit._click import (
     track_ids_argument,
 )
 from rekordbox_edit.api.convert import ConvertAborted, convert
+from rekordbox_edit.cli._progress import convert_progress
 from rekordbox_edit.cli._utils import (
     SCRIPTING_MODES,
     _build_args,
@@ -76,7 +77,14 @@ def convert_command(db, **kwargs):
     scripting_mode = print_opt in SCRIPTING_MODES
 
     if yes or dry_run:
-        response = _convert_reporting_partials(db, args, dry_run=dry_run)
+        # A dry run encodes nothing, and the count is unknown until convert
+        # classifies, so the overall bar counts up without a target.
+        with convert_progress(
+            None, enabled=not scripting_mode and not dry_run
+        ) as progress:
+            response = _convert_reporting_partials(
+                db, args, dry_run=dry_run, progress=progress
+            )
         _report_skips(response.result.skipped)
         _print_convert_result(response, print_opt, scripting_mode, dry_run=dry_run)
         return
@@ -112,7 +120,8 @@ def convert_command(db, **kwargs):
             logger.info("Cancelled.")
             return
         narrowed = _narrow_to_track_ids(args, selected_ids)
-        response = _convert_reporting_partials(db, narrowed)
+        with convert_progress(len(selected_ids), enabled=True) as progress:
+            response = _convert_reporting_partials(db, narrowed, progress=progress)
     else:
         try:
             if not confirm(
@@ -124,17 +133,18 @@ def convert_command(db, **kwargs):
                 return
         except UserQuit:
             return
-        response = _convert_reporting_partials(db, args)
+        with convert_progress(len(preview.result.converted), enabled=True) as progress:
+            response = _convert_reporting_partials(db, args, progress=progress)
 
     _report_skips([s for s in response.result.skipped if s.reason in _LIVE_ONLY_SKIPS])
     _print_convert_result(response, print_opt, scripting_mode, dry_run=False)
 
 
-def _convert_reporting_partials(db, args, *, dry_run: bool = False):
+def _convert_reporting_partials(db, args, *, dry_run: bool = False, progress=None):
     """Convert, reporting a batch that stopped partway as a plain result rather
     than as a crash. The committed conversions are real and are kept."""
     try:
-        return convert(db, args, dry_run=dry_run)
+        return convert(db, args, dry_run=dry_run, progress=progress)
     except ConvertAborted as e:
         logger.error(f"Conversion stopped at {e.failed_path}: {e}")
         logger.error(

--- a/rekordbox_edit/logger.py
+++ b/rekordbox_edit/logger.py
@@ -7,8 +7,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
-import click
 from platformdirs import PlatformDirs
+from rich.console import Console
 
 from rekordbox_edit._click import PrintChoice
 
@@ -22,20 +22,35 @@ _console_handler: Optional["ConsoleLogHandler"] = None
 _debug_file_path: Path = _APP_DIR / LOG_FILE_NAME
 
 
+#: Console for log output. Kept apart from `display.console`, which records
+#: renderables so tables can be copied into the debug log; log lines already
+#: reach that log through the file handler, and recording them again would
+#: duplicate every one of them.
+#:
+#: `soft_wrap` keeps long paths on one line, as the previous click.echo did.
+#: Rich would otherwise wrap them at the terminal width.
+console = Console(soft_wrap=True)
+
+_LEVEL_STYLES = {
+    logging.CRITICAL: "bold red",
+    logging.ERROR: "red",
+    logging.WARNING: "yellow",
+}
+
+
 class ConsoleLogHandler(logging.Handler):
-    """Custom logging handler that outputs to Click with styling."""
+    """Logging handler that writes console output through rich."""
 
     def emit(self, record):
         try:
-            msg = self.format(record)
-            if record.levelno >= logging.CRITICAL:
-                click.echo(click.style(msg, fg="red", bold=True))
-            elif record.levelno >= logging.ERROR:
-                click.echo(click.style(msg, fg="red"))
-            elif record.levelno >= logging.WARNING:
-                click.echo(click.style(msg, fg="yellow"))
-            else:
-                click.echo(msg)
+            style = next(
+                (s for lvl, s in _LEVEL_STYLES.items() if record.levelno >= lvl),
+                None,
+            )
+            # markup=False because rich would read a bracketed run as a style
+            # tag and drop it: a track named "Set [b].wav" would otherwise log
+            # as "Set .wav".
+            console.print(self.format(record), style=style, markup=False)
         except Exception:
             self.handleError(record)
 

--- a/tests/api/test_convert.py
+++ b/tests/api/test_convert.py
@@ -1643,6 +1643,137 @@ class TestConvertParallelEncoding:
         assert mock_remove.called
 
 
+class TestConvertProgressReporting:
+    @pytest.fixture(autouse=True)
+    def _stub_temp_file_moves(self):
+        with (
+            patch("rekordbox_edit.api.convert.os.replace"),
+            patch("rekordbox_edit.api.convert.os.listdir", return_value=[]),
+            patch("rekordbox_edit.api.convert._probe_converted_file"),
+        ):
+            yield
+
+    @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
+    @patch("rekordbox_edit.api.convert._apply_converted_record")
+    @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert._get_output_path")
+    @patch("rekordbox_edit.api.convert.get_file_type_for_format")
+    @patch("rekordbox_edit.api.convert.get_filtered_content")
+    def test_every_file_is_reported_started_then_finished(
+        self,
+        mock_gfc,
+        mock_get_type,
+        mock_get_output,
+        _ffmpeg,
+        _exists,
+        _run,
+        _apply,
+        _probe,
+        mock_db,
+        make_djmd_content_item,
+    ):
+        mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
+            fmt.upper(), 99
+        )
+        mock_get_output.side_effect = lambda content, fmt: (
+            f"/{content.ID}.aif",
+            f"{content.ID}.aif",
+            "/",
+        )
+        events = []
+
+        class _Recorder:
+            def started(self, index, file_name):
+                events.append(("started", index))
+
+            def finished(self, index, converted):
+                events.append(("finished", index, converted))
+
+        contents = [
+            make_djmd_content_item(
+                ID=str(i), FileType=11, FolderPath=f"/in{i}.wav", FileNameL=f"in{i}.wav"
+            )
+            for i in (1, 2, 3)
+        ]
+        _seed_filter(mock_gfc, *contents)
+        _seed_db(mock_db, *contents)
+
+        convert(
+            mock_db,
+            ConvertRequest(format_out="aiff", overwrite=True, threads=1),
+            progress=_Recorder(),
+        )
+
+        assert [e for e in events if e[0] == "started"] == [
+            ("started", 0),
+            ("started", 1),
+            ("started", 2),
+        ]
+        assert [e for e in events if e[0] == "finished"] == [
+            ("finished", 0, True),
+            ("finished", 1, True),
+            ("finished", 2, True),
+        ]
+
+    @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
+    @patch("rekordbox_edit.api.convert._apply_converted_record")
+    @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
+    @patch("rekordbox_edit.api.convert.os.path.exists")
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    @patch("rekordbox_edit.api.convert._get_output_path")
+    @patch("rekordbox_edit.api.convert.get_file_type_for_format")
+    @patch("rekordbox_edit.api.convert.get_filtered_content")
+    def test_a_skipped_file_is_reported_as_not_converted(
+        self,
+        mock_gfc,
+        mock_get_type,
+        mock_get_output,
+        _ffmpeg,
+        mock_exists,
+        _run,
+        _apply,
+        _probe,
+        mock_db,
+        make_djmd_content_item,
+    ):
+        # The overall bar still advances for a skip, so the caller has to be
+        # told the difference rather than inferring it from a missing call.
+        mock_get_type.side_effect = lambda fmt: {"AIFF": 1, "MP3": 5, "M4A": 6}.get(
+            fmt.upper(), 99
+        )
+        mock_get_output.side_effect = lambda content, fmt: (
+            f"/{content.ID}.aif",
+            f"{content.ID}.aif",
+            "/",
+        )
+        mock_exists.side_effect = lambda path: path != "/in2.wav"
+        finished = []
+
+        class _Recorder:
+            def started(self, index, file_name):
+                pass
+
+            def finished(self, index, converted):
+                finished.append((index, converted))
+
+        contents = [
+            make_djmd_content_item(ID=str(i), FileType=11, FolderPath=f"/in{i}.wav")
+            for i in (1, 2, 3)
+        ]
+        _seed_filter(mock_gfc, *contents)
+        _seed_db(mock_db, *contents)
+
+        convert(
+            mock_db,
+            ConvertRequest(format_out="aiff", overwrite=True, threads=1),
+            progress=_Recorder(),
+        )
+
+        assert finished == [(0, True), (1, False), (2, True)]
+
+
 class TestConvertLogging:
     @pytest.fixture(autouse=True)
     def _stub_temp_file_moves(self):

--- a/tests/cli/test_progress.py
+++ b/tests/cli/test_progress.py
@@ -1,0 +1,111 @@
+"""Tests for the live convert progress display."""
+
+import io
+from unittest.mock import patch
+
+import pytest
+from rich.console import Console
+from rich.progress import Progress
+
+from rekordbox_edit.cli._progress import (
+    ConvertProgressDisplay,
+    _OverallCountColumn,
+    convert_progress,
+)
+
+
+class _Task:
+    def __init__(self, total):
+        self.total = total
+        self.completed = 0
+
+
+class TestOverallCountColumn:
+    def test_renders_the_count_for_a_task_with_a_total(self):
+        assert str(_OverallCountColumn().render(_Task(total=9))) == "0/9"
+
+    def test_renders_nothing_for_a_file_task(self):
+        # File tasks have no total, and "0/?" beside a pulsing bar is noise.
+        assert _OverallCountColumn().render(_Task(total=None)) == ""
+
+
+class TestConvertProgressDisplay:
+    @pytest.fixture
+    def display(self):
+        progress = Progress()
+        return progress, ConvertProgressDisplay(progress, total=3)
+
+    def test_a_line_appears_per_file_in_flight(self, display):
+        progress, d = display
+
+        d.started(0, "a.flac")
+        d.started(1, "b.flac")
+
+        descriptions = [t.description for t in progress.tasks]
+        assert "a.flac" in descriptions
+        assert "b.flac" in descriptions
+
+    def test_a_finished_file_gives_up_its_line(self, display):
+        progress, d = display
+        d.started(0, "a.flac")
+        d.started(1, "b.flac")
+
+        d.finished(0, converted=True)
+
+        assert [t.description for t in progress.tasks] == ["Converting", "b.flac"]
+
+    def test_the_overall_bar_advances_on_every_file(self, display):
+        progress, d = display
+        for index in range(3):
+            d.started(index, f"{index}.flac")
+
+        d.finished(0, converted=True)
+        d.finished(1, converted=False)  # a skip still consumes a file
+
+        assert progress.tasks[0].completed == 2
+
+    def test_a_file_with_no_name_does_not_break_the_line(self, display):
+        progress, d = display
+
+        d.started(0, None)
+
+        assert progress.tasks[-1].description == ""
+
+    def test_finishing_an_unknown_index_is_harmless(self, display):
+        progress, d = display
+
+        d.finished(99, converted=True)
+
+        assert progress.tasks[0].completed == 1
+
+
+class TestConvertProgressEnabling:
+    def _console(self, is_terminal):
+        # is_terminal is a read-only property, so swap the console itself for
+        # one built to answer the way this case needs.
+        return patch(
+            "rekordbox_edit.cli._progress.console",
+            Console(file=io.StringIO(), force_terminal=is_terminal),
+        )
+
+    def test_disabled_yields_nothing(self):
+        with self._console(True), convert_progress(5, enabled=False) as progress:
+            assert progress is None
+
+    def test_a_non_terminal_yields_nothing(self):
+        # Piping into another command must not emit control codes.
+        with self._console(False), convert_progress(5, enabled=True) as progress:
+            assert progress is None
+
+    def test_an_empty_batch_yields_nothing(self):
+        with self._console(True), convert_progress(0, enabled=True) as progress:
+            assert progress is None
+
+    def test_an_unknown_total_still_displays(self):
+        with self._console(True), convert_progress(None, enabled=True) as progress:
+            assert isinstance(progress, ConvertProgressDisplay)
+
+    def test_a_known_total_gives_the_overall_bar_a_target(self):
+        with self._console(True), convert_progress(5, enabled=True) as progress:
+            assert isinstance(progress, ConvertProgressDisplay)
+            assert progress._progress.tasks[0].total == 5

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -73,6 +73,42 @@ class TestSetupLogging:
         assert "from child" in content
 
 
+class TestConsoleOutput:
+    """Console output goes through rich, which reads some text as markup."""
+
+    @pytest.fixture
+    def emit(self, tmp_path, capsys):
+        setup_logging(log_file=str(tmp_path / "test.log"))
+
+        def _emit(message, level=logging.INFO):
+            logging.getLogger("rekordbox_edit.test").log(level, message)
+            return capsys.readouterr().out
+
+        return _emit
+
+    def test_a_bracketed_track_name_survives(self, emit):
+        # Rich would read "[b]" as a request for bold and drop it, logging
+        # "Set .wav". Bracketed titles are common in music libraries.
+        assert "Set [b].wav" in emit("Skipping Set [b].wav")
+
+    def test_a_bracketed_style_word_survives(self, emit):
+        assert "[bold]" in emit("Track [bold]remix.mp3 converted")
+
+    def test_a_long_path_is_not_wrapped(self, emit):
+        path = "/Users/me/Music/" + "Very Long Directory Name/" * 6 + "track.flac"
+
+        out = emit(f"Skipping {path}: source file is gone")
+
+        assert path in out
+        assert out.count("\n") == 1
+
+    @pytest.mark.parametrize(
+        "level", [logging.WARNING, logging.ERROR, logging.CRITICAL]
+    )
+    def test_higher_levels_still_reach_the_console(self, emit, level):
+        assert "attention" in emit("needs attention", level)
+
+
 class TestSetLevel:
     def test_default_console_level_is_info(self):
         """Console handler starts at INFO level."""


### PR DESCRIPTION
Stacked on #198. Two commits: route console logging through rich, then add a live progress display for `convert`.

## Changes

- `ConsoleLogHandler` prints through a rich `Console` instead of `click.echo`, so log lines and rich tables share one renderer. Markup is disabled and `soft_wrap` is on. Level styling is preserved, and rich highlighting now colors numbers and paths in log lines.
- Add `ConvertProgress`, a Protocol the API reports encode starts and finishes against, so `convert()` stays free of any display code.
- Add `cli/_progress.py`: a line per file in flight, capped by `--threads`, above an overall bar with percentage, count, and ETA. Finished files are not held in the display; the existing per-file log line scrolls above the live region.
- Suppress the display in scripting modes, when stdout is not a terminal, and for dry runs.

## Notes

The log console is kept separate from `display.console`, which records renderables so tables can be copied into the debug log. Log lines already reach that log through the file handler, and recording them again would duplicate every one.
