### PR TITLE
fix: maintain rekordbox's USN counter on every write

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,5 +55,6 @@ site/
 
 # Superpowers SDD scratch
 .superpowers/
+docs/superpowers/
 
 worktrees/

--- a/docs/commands/convert.md
+++ b/docs/commands/convert.md
@@ -67,7 +67,7 @@ rbe convert --format-out mp3 --playlist "NeedsConverting" --threads 8 --yes
 ### Guardrails
 
 - Without flags, `convert` shows every planned change and asks once before applying. `--interactive` confirms each track individually; `--dry-run` previews without writing; `--yes` confirms the default choice for all prompts without asking.
-- Editing while Rekordbox is open risks corrupting your database. By default `convert` warns and asks for confirmation (defaulting to no, so a `--yes` would exit); in a non-interactive mode (e.g. `--print ids`) it throws an error.
+- **Rekordbox running:** writing while Rekordbox is open risks losing your changes, so `convert` refuses to run until you close it. `--dry-run` still works.
 - Before a large run, walk through the checklist in [What Should I Do Before Converting?](../faqs.md#what-should-i-do-before-converting)
 
 ## Reference

--- a/docs/commands/edit.md
+++ b/docs/commands/edit.md
@@ -46,7 +46,7 @@ rbe edit --exact-title "Acid Rain" FolderPath --replace "/Users/me/Music/acid-ra
 
 - **Preview and confirm by default.** Without flags, `edit` shows every planned change and asks once before applying. `--interactive` confirms each track individually; `--dry-run` previews without writing; `--yes` confirms the default choice for all prompts without asking.
 - **Single-track by default.** When filters match more than one track, `edit` refuses unless you pass `--multi`. This prevents an unintentionally broad filter from making unintended edits across your library.
-- **Rekordbox running:** editing while Rekordbox is open risks corrupting your database. By default `edit` warns; in a non-interactive mode (e.g. `--print ids`) it throws an error.
+- **Rekordbox running:** writing while Rekordbox is open risks losing your changes, so `edit` refuses to run until you close it. `--dry-run` still works.
 
 ## Examples
 

--- a/docs/commands/import.md
+++ b/docs/commands/import.md
@@ -42,7 +42,7 @@ A file already in the library, matched by its resolved, case-insensitive path, i
 ## Guardrails
 
 - **Preview and confirm by default.** Without flags, `import` shows every track it plans to add and asks once before writing; `--dry-run` previews without writing; `--yes` confirms the default choice for all prompts without asking.
-- **Rekordbox running:** importing while Rekordbox is open risks corrupting your database. By default `import` warns; in a non-interactive mode (e.g. `--print ids`) it throws an error.
+- **Rekordbox running:** writing while Rekordbox is open risks losing your changes, so `import` refuses to run until you close it. `--dry-run` still works.
 
 ## Reference
 

--- a/rekordbox_edit/api/_utils.py
+++ b/rekordbox_edit/api/_utils.py
@@ -1,10 +1,13 @@
 import logging
 from collections.abc import Sequence
+from typing import Any
 
 from pyrekordbox import Rekordbox6Database
 from pyrekordbox.db6 import DjmdContent
+from sqlalchemy import text
 
 from rekordbox_edit.models import ConvertOp, EditOp, Track
+from rekordbox_edit.query import require_session
 from rekordbox_edit.utils import AudioInfo, get_file_type_for_format
 
 logger = logging.getLogger(__name__)
@@ -77,3 +80,44 @@ def _update_anlz_paths(
         anlz.set_path(new_ppth)
         anlz.save(anlz_path)
         logger.debug(f"Updated PPTH of {anlz_path} to {new_ppth}")
+
+
+#: Reserves a block in one statement, so the counter is never read into Python
+#: and cannot go stale. Reading it and writing it back loses increments whenever
+#: rekordbox is writing too, which the advisory lock does not prevent.
+_RESERVE_USNS = text(
+    "UPDATE agentRegistry SET int_1 = int_1 + :count "
+    "WHERE registry_id = 'localUpdateCount' RETURNING int_1"
+)
+
+
+def stamp_usns(db: Rekordbox6Database, rows: Sequence[Any]) -> int | None:
+    """Give each row a fresh USN and advance the library's counter.
+
+    A USN is rekordbox's change stamp: a syncing peer asks for rows above the
+    last value it saw, so a row written without one looks untouched.
+
+    Call this inside the transaction that writes the rows; a counter advanced
+    past unstamped rows would hide them from sync permanently.
+
+    One USN per row. Rekordbox counts more often, which is harmless: peers ask
+    for rows *above* a value, so only a reused stamp would hide one.
+    """
+    stampable = [row for row in rows if hasattr(row, "rb_local_usn")]
+    if not stampable:
+        return None
+
+    session = require_session(db)
+    high = session.execute(_RESERVE_USNS, {"count": len(stampable)}).scalar()
+    if high is None:
+        logger.warning(
+            "No localUpdateCount in agentRegistry; leaving USNs unstamped. "
+            "Cloud and device sync may not see these changes."
+        )
+        return None
+
+    for usn, row in enumerate(stampable, start=high - len(stampable) + 1):
+        row.rb_local_usn = usn
+
+    logger.debug(f"reserved USNs {high - len(stampable) + 1}..{high}")
+    return high

--- a/rekordbox_edit/api/_utils.py
+++ b/rekordbox_edit/api/_utils.py
@@ -82,9 +82,11 @@ def _update_anlz_paths(
         logger.debug(f"Updated PPTH of {anlz_path} to {new_ppth}")
 
 
-#: Reserves a block in one statement, so the counter is never read into Python
-#: and cannot go stale. Reading it and writing it back loses increments whenever
-#: rekordbox is writing too, which the advisory lock does not prevent.
+#: Claims the next `count` USNs. SQLite evaluates `int_1 + :count` against the
+#: row as it stands, under the write lock the statement takes, and RETURNING
+#: hands back the new total, so the claimed block ends there and starts
+#: `count - 1` below it. Nothing is read into Python first, so no other writer
+#: can slip in between.
 _RESERVE_USNS = text(
     "UPDATE agentRegistry SET int_1 = int_1 + :count "
     "WHERE registry_id = 'localUpdateCount' RETURNING int_1"
@@ -94,14 +96,13 @@ _RESERVE_USNS = text(
 def stamp_usns(db: Rekordbox6Database, rows: Sequence[Any]) -> int | None:
     """Give each row a fresh USN and advance the library's counter.
 
-    A USN is rekordbox's change stamp: a syncing peer asks for rows above the
-    last value it saw, so a row written without one looks untouched.
+    A USN is rekordbox's change stamp: a syncing peer would ask for rows above the
+    last value it saw.
 
-    Call this inside the transaction that writes the rows; a counter advanced
-    past unstamped rows would hide them from sync permanently.
+    Call this inside the transaction that writes the rows.
 
-    One USN per row. Rekordbox counts more often, which is harmless: peers ask
-    for rows *above* a value, so only a reused stamp would hide one.
+    One USN per row, which is likely more than how Rekordbox applies changes,
+    because we're not going to bother stamping a commit per column changed.
     """
     stampable = [row for row in rows if hasattr(row, "rb_local_usn")]
     if not stampable:
@@ -110,10 +111,7 @@ def stamp_usns(db: Rekordbox6Database, rows: Sequence[Any]) -> int | None:
     session = require_session(db)
     high = session.execute(_RESERVE_USNS, {"count": len(stampable)}).scalar()
     if high is None:
-        logger.warning(
-            "No localUpdateCount in agentRegistry; leaving USNs unstamped. "
-            "Cloud and device sync may not see these changes."
-        )
+        logger.warning("No localUpdateCount in agentRegistry; leaving USNs unstamped. ")
         return None
 
     for usn, row in enumerate(stampable, start=high - len(stampable) + 1):

--- a/rekordbox_edit/api/_utils.py
+++ b/rekordbox_edit/api/_utils.py
@@ -86,7 +86,7 @@ def _update_anlz_paths(
 #: row as it stands, under the write lock the statement takes, and RETURNING
 #: hands back the new total, so the claimed block ends there and starts
 #: `count - 1` below it. Nothing is read into Python first, so no other writer
-#: can slip in between.
+#: (Rekordbox) can slip in between.
 _RESERVE_USNS = text(
     "UPDATE agentRegistry SET int_1 = int_1 + :count "
     "WHERE registry_id = 'localUpdateCount' RETURNING int_1"
@@ -104,18 +104,25 @@ def stamp_usns(db: Rekordbox6Database, rows: Sequence[Any]) -> int | None:
     One USN per row, which is likely more than how Rekordbox applies changes,
     because we're not going to bother stamping a commit per column changed.
     """
-    stampable = [row for row in rows if hasattr(row, "rb_local_usn")]
+    USN_COLUMN = "rb_local_usn"
+    stampable = [row for row in rows if hasattr(row, USN_COLUMN)]
+    num_stampable = len(stampable)
+    num_rows = len(rows)
+    if num_stampable < num_rows:
+        logger.warning(
+            f"{num_rows - num_stampable} rows are missing a '{USN_COLUMN}' value and won't get a fresh stamp."
+        )
     if not stampable:
         return None
 
     session = require_session(db)
-    high = session.execute(_RESERVE_USNS, {"count": len(stampable)}).scalar()
-    if high is None:
+    last_usn = session.execute(_RESERVE_USNS, {"count": num_stampable}).scalar()
+    if last_usn is None:
         logger.warning("No localUpdateCount in agentRegistry; leaving USNs unstamped. ")
         return None
 
-    for usn, row in enumerate(stampable, start=high - len(stampable) + 1):
+    for usn, row in enumerate(stampable, start=last_usn - num_stampable + 1):
         row.rb_local_usn = usn
 
-    logger.debug(f"reserved USNs {high - len(stampable) + 1}..{high}")
-    return high
+    logger.debug(f"reserved USNs {last_usn - num_stampable + 1}..{last_usn}")
+    return last_usn

--- a/rekordbox_edit/api/convert.py
+++ b/rekordbox_edit/api/convert.py
@@ -18,6 +18,7 @@ from rekordbox_edit.api._utils import (
     _order_tracks_by_op,
     _sync_audio_columns,
     _update_anlz_paths,
+    stamp_usns,
 )
 from rekordbox_edit.models import (
     ConvertOp,
@@ -650,6 +651,7 @@ def convert(
                     os.path.dirname(job.output_path),
                     output_format_name,
                 )
+                stamp_usns(db, [content])
                 db.session.commit()
             except BaseException as e:
                 _remove_temp_file(job.temp_path)

--- a/rekordbox_edit/api/edit.py
+++ b/rekordbox_edit/api/edit.py
@@ -4,7 +4,7 @@ import logging
 
 from pyrekordbox import Rekordbox6Database
 
-from rekordbox_edit.api._utils import _order_tracks_by_op
+from rekordbox_edit.api._utils import _order_tracks_by_op, stamp_usns
 from rekordbox_edit.api.field_handlers import FIELD_HANDLERS
 from rekordbox_edit.models import (
     EditRequest,
@@ -95,10 +95,13 @@ def edit(
 
     new_values = {op.id: op.new_value for op in ops}
     old_values: dict[str, str | None] = {}
+    edited = []
     for content in contents:
         if str(content.ID) in new_values:
             old_values[str(content.ID)] = handler.current_value(content)
             handler.apply(db, content, new_values[str(content.ID)])
+            edited.append(content)
+    stamp_usns(db, edited)
     db.session.commit()
     logger.debug(f"edit committed {len(ops)} change(s) on field={args.field}")
 

--- a/rekordbox_edit/api/import_.py
+++ b/rekordbox_edit/api/import_.py
@@ -9,7 +9,7 @@ from typing import NamedTuple, cast
 from pyrekordbox import Rekordbox6Database
 from pyrekordbox.db6 import tables as tb
 
-from rekordbox_edit.api._utils import _track_from_content
+from rekordbox_edit.api._utils import _track_from_content, stamp_usns
 from rekordbox_edit.models import (
     ImportOp,
     ImportRequest,
@@ -182,18 +182,28 @@ IMPORT_DEFAULTS: dict[str, object] = {
 }
 
 
-def _get_or_create(db, table, name: str, factory):
+def _get_or_create(db, table, name: str, factory, created: list | None = None):
     """Reuse a row matching by name, else create one.
 
     Same query shape as RelationalField._get_or_create in api/field_handlers.py,
     generalized over a table and factory so one function covers all five
     relational columns instead of a per-kind branch.
+
+    New rows are appended to `created` when given: add_content flushes,
+    which moves them out of session.new before they can be found again.
     """
     existing = db.session.query(table).filter_by(Name=name).order_by(table.ID).first()
-    return existing or factory(name)
+    if existing is not None:
+        return existing
+    row = factory(name)
+    if created is not None:
+        created.append(row)
+    return row
 
 
-def _resolve_relations(db: Rekordbox6Database, tags: TrackTags) -> dict[str, str]:
+def _resolve_relations(
+    db: Rekordbox6Database, tags: TrackTags, created: list | None = None
+) -> dict[str, str]:
     """Foreign keys for a track's tags, creating shared rows as needed.
 
     A tag that is absent yields no key, leaving the column at add_content's
@@ -211,7 +221,7 @@ def _resolve_relations(db: Rekordbox6Database, tags: TrackTags) -> dict[str, str
     ):
         value = tags.get(field)
         if value:
-            relations[column] = _get_or_create(db, table, value, factory).ID
+            relations[column] = _get_or_create(db, table, value, factory, created).ID
 
     key = tags.get("key")
     row = (
@@ -239,7 +249,9 @@ def _created_date(path: str) -> str:
     return datetime.date.fromtimestamp(stamp).isoformat()
 
 
-def _build_content(db: Rekordbox6Database, candidate: _ImportCandidate):
+def _build_content(
+    db: Rekordbox6Database, candidate: _ImportCandidate, created: list | None = None
+):
     """Create the DjmdContent row for one file and return it.
 
     add_content supplies the identity and device columns. Three of its values
@@ -251,7 +263,7 @@ def _build_content(db: Rekordbox6Database, candidate: _ImportCandidate):
     content = db.add_content(
         candidate.stored,
         **IMPORT_DEFAULTS,
-        **_resolve_relations(db, tags),
+        **_resolve_relations(db, tags, created),
         Title=tags["title"],
         Commnt=tags["comment"] or "",
         ISRC=tags["isrc"] or "",
@@ -412,9 +424,11 @@ def import_tracks(
     applied: list[ImportOp] = []
     written: list[tb.DjmdContent] = []
     try:
+        # Relational rows created along the way each take a USN too.
+        incidental: list = []
         for op, candidate in planned:
             if op.action == "create":
-                content = _build_content(db, candidate)
+                content = _build_content(db, candidate, incidental)
                 applied.append(op.model_copy(update={"id": str(content.ID)}))
             else:
                 content = existing[candidate.key]
@@ -423,6 +437,7 @@ def import_tracks(
             if playlist is not None:
                 db.add_to_playlist(playlist, content)
 
+        stamp_usns(db, [*written, *incidental])
         session.commit()
         logger.debug(f"import committed {len(applied)} row(s)")
     except BaseException:

--- a/rekordbox_edit/cli/_utils.py
+++ b/rekordbox_edit/cli/_utils.py
@@ -16,7 +16,6 @@ from sqlalchemy.engine import Engine
 
 from rekordbox_edit._click import PrintChoice, database_path_option
 from rekordbox_edit.locking import SCRIPTED_TIMEOUT, DatabaseBusyError, database_lock
-from rekordbox_edit.utils import UserQuit, confirm
 
 logger = logging.getLogger(__name__)
 
@@ -108,23 +107,17 @@ def _print_response_json(response: BaseModel) -> None:
     print(response.model_dump_json())
 
 
-def _rekordbox_running_confirm(print_opt) -> bool:
+def _refuse_while_rekordbox_runs() -> None:
+    """Exit if Rekordbox is open. Writing underneath it risks losing changes:
+    it holds rows in memory and can write its own copy back over ours."""
     rekordbox_pid = get_rekordbox_pid()
     if not rekordbox_pid:
-        return True
-    if print_opt in SCRIPTING_MODES:
-        logger.error(
-            f"Rekordbox is running (PID {rekordbox_pid}). Cannot proceed in scripting mode."
-        )
-        sys.exit(1)
-    logger.warning(
-        f"Rekordbox is running (PID {rekordbox_pid}). Modifying the database while "
-        "Rekordbox is open can cause conflicts."
+        return
+    logger.error(
+        f"Rekordbox is running (PID {rekordbox_pid}). Close it before writing "
+        "to the database."
     )
-    try:
-        return confirm("Continue anyway?", default=False)
-    except UserQuit:
-        return False
+    sys.exit(1)
 
 
 @event.listens_for(Engine, "connect")
@@ -164,15 +157,16 @@ def with_database(*, writes: bool = False):
 
     Pass writes=True for commands that modify the DB: the wrapper aborts when
     Rekordbox is running (or prompts to continue in interactive modes), and
-    holds the single-writer advisory lock for the whole run.
+    holds the single-writer advisory lock for the whole run. A dry run gets
+    neither, since it writes nothing.
     """
 
     def decorator(func):
         @database_path_option
         @functools.wraps(func)
         def wrapper(**kwargs):
-            if writes and not _rekordbox_running_confirm(kwargs.get("print_opt")):
-                return
+            if writes and not kwargs.get("dry_run"):
+                _refuse_while_rekordbox_runs()
             database_path: str | None = kwargs.pop("database_path", None)
             db = Rekordbox6Database(path=database_path)  # ty: ignore[invalid-argument-type]
             try:

--- a/research/database-concurrency/usn-maintenance.md
+++ b/research/database-concurrency/usn-maintenance.md
@@ -127,12 +127,16 @@ The design that follows:
    shape, it walks `RekordboxAgentRegistry.__update_sequence__`, a class
    attribute shared by every instance in the process, which rekordbox-edit
    never clears.
-3. Reserve one USN per row stamped. Rekordbox appears to advance its counter
-   more than once per track, roughly 1.9 times in the sampled library, so this
-   does not reproduce its counting exactly. That is safe: a high-water-mark
-   consumer asks for rows above a value, so over-counting costs nothing while
-   duplicate or reused stamps would break it. Uniqueness and monotonicity are
-   the properties worth guaranteeing.
+3. Reserve one USN per row stamped. This will not reproduce rekordbox's
+   numbering: in the sampled library 906 imported tracks hold 906 distinct
+   stamps spread across the range 969 to 2694, so roughly 820 values in that
+   span went to something else. What consumed them was never established, and
+   the library's 259 artists and 303 albums are enough to account for much of
+   it at one apiece. Matching rekordbox exactly would mean knowing everything
+   it counts, and it does not matter: a high-water-mark consumer asks for rows
+   above a value, so extra values cost nothing while a duplicate or reused
+   stamp would hide a row. Uniqueness and monotonicity are the properties
+   worth guaranteeing.
 4. Keep write transactions short. The reservation holds the WAL write lock from
    the `UPDATE` until commit, and per-file commits in `convert` already bound
    that to one file.

--- a/research/import-track-row-shape/decisions/commit-semantics-and-usn.md
+++ b/research/import-track-row-shape/decisions/commit-semantics-and-usn.md
@@ -1,6 +1,7 @@
 # Commit Semantics: session.commit Against db.commit, and the USN Gap
 
-**Status:** open. Recorded while designing `import`; deliberately not addressed there.
+**Status:** settled for USNs; the `masterPlaylists6.xml` gap remains open.
+Recorded while designing `import`, closed while adding USN maintenance.
 
 ## Context
 
@@ -39,10 +40,10 @@ about precisely this state on its next commit:
 
 > `Playlist {ID} not found in masterPlaylists6.xml! Did you add it manually?`
 
-## Consequences Today
+## Consequences Before the Fix
 
-Every row that `edit`, `convert`, and `import` write carries no `rb_local_usn`, and
-the global counter does not advance. **The practical effect is untested.** The
+Every row that `edit`, `convert`, and `import` wrote carried no `rb_local_usn`, and
+the global counter did not advance. **The practical effect was untested.** The
 plausible risk is that cloud or device synchronization cannot tell the row
 changed, but this has not been verified, and the claim should not be repeated as
 though it had been.
@@ -55,26 +56,66 @@ something this repository introduces.
 
 ## Decision
 
+**Status update:** the USN half is closed. See `stamp_usns` in
+`rekordbox_edit/api/usn.py` and the measurements in
+`../../database-concurrency/usn-maintenance.md`.
+
 `import` commits through `db.session.commit()`, consistent with `edit` and
 `convert`, and does not create playlists. Requiring `--playlist` to name an
 existing playlist keeps the command clear of `masterPlaylists6.xml` entirely,
 so the XML gap cannot be reached by any `import` code path.
 
-The USN gap is left as it stands. It predates `import`, spans all three write
-commands, and closing it for one command alone would introduce an inconsistency
-worse than the gap.
+`edit`, `convert`, and `import` now stamp every row they write and advance
+`localUpdateCount` to match, in the same transaction as the rows themselves.
 
-## What a Future Fix Has To Reconcile
+## How the USN Gap Was Closed
 
-Anyone addressing this should treat it as one cross-cutting change across all
-write commands rather than a per-command fix:
+Not through `db.commit()` or `autoincrement_local_update_count`, both of which
+were rejected:
 
-1. **Test the consequence first.** Determine what actually breaks when a row
-   carries no USN, before designing around an assumed failure.
-2. **Preserve the running-rekordbox prompt.** A shared commit helper needs the
-   USN and XML handling from `db.commit()` without its unconditional
-   `RuntimeError`, since that would remove an affordance users rely on.
-3. **Handle the XML whenever playlists are created or deleted.** Any future
-   playlist creation, in `import --to-playlist` or elsewhere, must save
-   `masterPlaylists6.xml` or leave rekordbox in the state it warns about.
-4. **Decide on `updated_at` propagation** for playlists whose membership changes.
+- `db.commit()` refuses outright while rekordbox is running, which would remove
+  the "Continue anyway?" affordance this repository deliberately offers.
+- `autoincrement_local_update_count` reads the counter and writes it back.
+  Measured against the real engine with two concurrent writers, that loses
+  exactly one writer's increments and raises nothing. Rekordbox writes to the
+  same counter, and the advisory lock has no authority over it.
+
+Instead one expression `UPDATE ... RETURNING` reserves a block of values, so
+the counter is never read into application code and cannot go stale. The
+reservation lands in the transaction that writes the rows, so a crash between
+them is impossible: a counter advanced past unstamped rows would hide those
+rows from sync permanently.
+
+One USN is reserved per row stamped, which does not reproduce rekordbox's
+numbering. The sampled library's 906 imported tracks hold 906 distinct stamps
+spread across 969 to 2694, so about 820 values in that span went elsewhere;
+what consumed them was never established. Matching exactly would mean knowing
+everything rekordbox counts, and it does not matter: a peer asks for rows
+*above* a value, so extra values cost nothing while a reused stamp would hide
+a row.
+
+Two of the original conditions were satisfied, and one was overtaken:
+
+1. **Test the consequence first.** Not done, and knowingly so. The maintainer
+   chose to proceed on the grounds that writing rows the way rekordbox writes
+   them is the standard `import` already holds itself to, and that a silent
+   failure for anyone using cloud sync is worse than the cost of maintaining
+   one column. The consequence of an unstamped row remains untested.
+2. **Preserve the running-rekordbox prompt.** Kept. Correctness comes from the
+   statement being atomic rather than from having checked for a process
+   beforehand, so the prompt was never load-bearing. It no longer fires for dry
+   runs, which write nothing.
+3. **`RekordboxAgentRegistry` is still untouched.** Its change buffer and
+   tracking flag are class attributes shared by every instance in the process,
+   which is also why database work stays on the main thread in `convert`.
+
+## What Remains Open
+
+1. **The XML gap.** Any future playlist creation, in `import --to-playlist` or
+   elsewhere, must save `masterPlaylists6.xml` or leave rekordbox in the state
+   it warns about. No command creates playlists today.
+2. **`updated_at` propagation** for playlists whose membership changes.
+3. **The untested consequence.** Whether an unstamped row actually breaks cloud
+   or device sync is still unverified. `../../convert-export-impact/` ruled out
+   USNs as the cause of the one sync failure this repository has observed,
+   which was a path-and-format gate, so no evidence either way exists yet.

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,0 +1,45 @@
+"""Fixtures backed by the committed Rekordbox database.
+
+Most API tests mock the database away. USN stamping cannot be tested that way:
+it turns on SQLite's behavior under a concurrent writer.
+"""
+
+import shutil
+from pathlib import Path
+
+import pytest
+from pyrekordbox import Rekordbox6Database
+
+FIXTURE = Path(__file__).parent.parent / "e2e/fixtures/macos/master.6.8.6.db"
+
+
+def close_database(database: Rekordbox6Database) -> None:
+    """Close a database and release its pooled connections.
+
+    Rekordbox6Database.close() closes the session but leaves the engine's pool
+    holding the file open, which Windows will not let anyone delete.
+    """
+    database.close()
+    database.engine.dispose()
+
+
+@pytest.fixture
+def library(tmp_path):
+    """A throwaway copy of the committed fixture database.
+
+    Nothing is cleaned up here: tmp_path is unique per test, so the WAL
+    sidecars cannot carry state into another one, and pytest reaps the
+    directory itself.
+    """
+    if not FIXTURE.is_file():
+        pytest.skip(f"fixture database missing: {FIXTURE}")
+    path = tmp_path / FIXTURE.name
+    shutil.copy(FIXTURE, path)
+    return path
+
+
+@pytest.fixture
+def db(library):
+    database = Rekordbox6Database(path=str(library))
+    yield database
+    close_database(database)

--- a/tests/api/test_convert.py
+++ b/tests/api/test_convert.py
@@ -29,6 +29,9 @@ from rekordbox_edit.api.convert import (
     _update_anlz_paths,
     convert,
 )
+from sqlalchemy import text
+
+from rekordbox_edit.query import require_session
 from rekordbox_edit.models import (
     ConvertOp,
     ConvertRequest,
@@ -951,8 +954,17 @@ class TestConvertRealRun:
         mock_get_output.return_value = ("/out.aif", "out.aif", "/")
         content = make_djmd_content_item(ID="1", FileType=11, FolderPath="/in.wav")
         _seed_filter(mock_gfc, content)
-        # Mock the post-commit select to raise
-        mock_db.session.execute.side_effect = RuntimeError("post-commit query failed")
+        # Only the post-commit select fails; the USN reservation shares this
+        # execute() and would otherwise abort the batch first.
+        reserved = []
+
+        def _execute(statement, *args, **kwargs):
+            if not reserved:
+                reserved.append(statement)
+                return Mock(scalar=Mock(return_value=1))
+            raise RuntimeError("post-commit query failed")
+
+        mock_db.session.execute.side_effect = _execute
 
         response = convert(
             mock_db,
@@ -2269,3 +2281,62 @@ class TestGetOutputPath:
 
         assert output_path == os.path.normpath("/music/folder/song.mp3")
         assert output_filename == "song.mp3"
+
+
+class TestConvertStampsUsns:
+    """Against the real library, since stamping is a database behavior."""
+
+    _COUNTER = text(
+        "SELECT int_1 FROM agentRegistry WHERE registry_id = 'localUpdateCount'"
+    )
+
+    @patch(
+        "rekordbox_edit.api.convert._probe_converted_file",
+        # A real probe, not a Mock: these values are written to actual columns.
+        return_value=ConvertedFileProbe(
+            audio_info=AudioInfo(
+                bit_depth=16,
+                sample_rate=44100,
+                channels=2,
+                bitrate=1411,
+                codec="pcm_s16be",
+                container="aiff",
+                duration=180.0,
+            ),
+            file_size=123456,
+        ),
+    )
+    @patch("rekordbox_edit.api.convert.os.replace")
+    @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
+    @patch("rekordbox_edit.api.convert.os.listdir", return_value=[])
+    @patch(
+        "rekordbox_edit.api.convert.get_audio_info",
+        return_value={**_PROBE_WAV_16_44, "codec": "flac", "container": "flac"},
+    )
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    def test_each_converted_row_takes_one_usn(
+        self, _ffmpeg, _probe, _listdir, _exists, _run, _replace, _converted, db
+    ):
+        session = require_session(db)
+        start = session.execute(self._COUNTER).scalar()
+        # FLAC sources: convertable, and the fixture has three of them.
+        tracks = db.get_content().filter_by(FileType=5).limit(2).all()
+        assert len(tracks) == 2, "fixture should carry at least two FLAC tracks"
+
+        response = convert(
+            db,
+            ConvertRequest(
+                format_out="aiff",
+                overwrite=True,
+                delete_originals="none",
+                track_ids=[str(t.ID) for t in tracks],
+                threads=1,
+            ),
+        )
+
+        converted = len(response.result.converted)
+        assert converted == 2
+        assert session.execute(self._COUNTER).scalar() == start + converted
+        # Per-file commits mean per-file stamps, in the order they converted.
+        assert sorted(t.rb_local_usn for t in tracks) == [start + 1, start + 2]

--- a/tests/api/test_edit.py
+++ b/tests/api/test_edit.py
@@ -3,6 +3,9 @@ from unittest.mock import MagicMock, call, patch
 
 from rekordbox_edit.api.edit import _classify_edit, edit
 from rekordbox_edit.api.field_handlers import FIELD_HANDLERS
+from sqlalchemy import text
+
+from rekordbox_edit.query import require_session
 from rekordbox_edit.models import (
     EditRequest,
     EditOp,
@@ -279,3 +282,58 @@ class TestPostCommitHook:
         edit(mock_db, EditRequest(field="Stub", replace_value="New"), dry_run=True)
 
         stub_handler.post_commit.assert_not_called()
+
+
+class TestEditStampsUsns:
+    """Against the real library, since stamping is a database behavior."""
+
+    _COUNTER = text(
+        "SELECT int_1 FROM agentRegistry WHERE registry_id = 'localUpdateCount'"
+    )
+
+    def test_an_edited_row_gets_a_fresh_usn_and_moves_the_counter(self, db):
+        session = require_session(db)
+        start = session.execute(self._COUNTER).scalar()
+        track = db.get_content().first()
+        before = track.rb_local_usn
+
+        edit(
+            db,
+            EditRequest(
+                field="Title", track_ids=[str(track.ID)], replace_value="Renamed"
+            ),
+        )
+
+        assert track.Title == "Renamed"
+        assert track.rb_local_usn > before
+        assert session.execute(self._COUNTER).scalar() == start + 1
+        assert track.rb_local_usn == start + 1
+
+    def test_a_dry_run_leaves_the_counter_alone(self, db):
+        session = require_session(db)
+        start = session.execute(self._COUNTER).scalar()
+        track = db.get_content().first()
+
+        edit(
+            db,
+            EditRequest(field="Title", track_ids=[str(track.ID)], replace_value="Nope"),
+            dry_run=True,
+        )
+
+        assert session.execute(self._COUNTER).scalar() == start
+
+    def test_a_skipped_track_consumes_no_usn(self, db):
+        session = require_session(db)
+        track = db.get_content().first()
+        start = session.execute(self._COUNTER).scalar()
+
+        # Replacing a title with the value it already has is a no_change skip.
+        response = edit(
+            db,
+            EditRequest(
+                field="Title", track_ids=[str(track.ID)], replace_value=track.Title
+            ),
+        )
+
+        assert response.result.edits == []
+        assert session.execute(self._COUNTER).scalar() == start

--- a/tests/api/test_import.py
+++ b/tests/api/test_import.py
@@ -1,8 +1,11 @@
 import datetime
 import os
+import shutil
+from pathlib import Path
 import platform
 from unittest.mock import MagicMock, patch
 
+import mutagen
 import pytest
 
 from rekordbox_edit.api import import_ as import_module
@@ -18,7 +21,10 @@ from rekordbox_edit.api.import_ import (
     _resolve_relations,
     import_tracks,
 )
+from sqlalchemy import text
+
 from rekordbox_edit.models import ImportOp, ImportRequest, SkippedTrack
+from rekordbox_edit.query import require_session
 from rekordbox_edit.query import normalize_path
 from rekordbox_edit.tags import TrackTags, UnreadableFile
 
@@ -267,7 +273,9 @@ class TestBuildContent:
     @pytest.fixture(autouse=True)
     def _stub_relations(self, monkeypatch):
         monkeypatch.setattr(
-            import_module, "_resolve_relations", lambda db, tags: {"ArtistID": "art-1"}
+            import_module,
+            "_resolve_relations",
+            lambda db, tags, created=None: {"ArtistID": "art-1"},
         )
 
     @pytest.fixture()
@@ -871,3 +879,57 @@ class TestImport:
         mock_db.session.rollback.assert_called_once()
         mock_db.session.commit.assert_not_called()
         assert any("rolling back" in message for message in caplog.messages)
+
+
+class TestImportStampsUsns:
+    """Against the real library, since stamping is a database behavior."""
+
+    _COUNTER = text(
+        "SELECT int_1 FROM agentRegistry WHERE registry_id = 'localUpdateCount'"
+    )
+
+    _AUDIO = Path(__file__).parent.parent / "e2e/fixtures/audio"
+
+    @pytest.fixture
+    def audio_file(self, tmp_path):
+        source = self._AUDIO / "01-flac-44_1k-16b.flac"
+        if not source.is_file():
+            pytest.skip(f"audio fixture missing: {source}")
+        target = tmp_path / source.name
+        shutil.copy(source, target)
+        return target
+
+    def test_an_imported_row_is_stamped(self, db, audio_file):
+        session = require_session(db)
+        start = session.execute(self._COUNTER).scalar()
+
+        response = import_tracks(db, ImportRequest(paths=[str(audio_file)]))
+
+        assert len(response.result.added) == 1
+        content = db.get_content().filter_by(ID=response.result.added[0].id).one()
+        assert content.rb_local_usn is not None
+        assert content.rb_local_usn <= session.execute(self._COUNTER).scalar()
+        assert session.execute(self._COUNTER).scalar() > start
+
+    def test_rows_created_along_the_way_are_stamped_too(self, db, audio_file):
+        # The fixture already knows the stock tags, so give this file unseen
+        # ones and watch the import spend a USN on each new relation.
+        tags = mutagen.File(audio_file)
+        tags["artist"] = "An Unseen Artist"
+        tags["album"] = "An Unseen Album"
+        tags.save()
+
+        session = require_session(db)
+        start = session.execute(self._COUNTER).scalar()
+
+        import_tracks(db, ImportRequest(paths=[str(audio_file)]))
+
+        assert session.execute(self._COUNTER).scalar() > start + 1
+
+    def test_a_dry_run_leaves_the_counter_alone(self, db, audio_file):
+        session = require_session(db)
+        start = session.execute(self._COUNTER).scalar()
+
+        import_tracks(db, ImportRequest(paths=[str(audio_file)]), dry_run=True)
+
+        assert session.execute(self._COUNTER).scalar() == start

--- a/tests/api/test_utils.py
+++ b/tests/api/test_utils.py
@@ -81,19 +81,19 @@ class TestStampUsns:
         start = require_session(db).execute(_COUNTER).scalar()
         rows = db.get_content().limit(3).all()
 
-        high = stamp_usns(db, rows)
+        last_usn = stamp_usns(db, rows)
 
-        assert high == start + 3
+        assert last_usn == start + 3
         assert [row.rb_local_usn for row in rows] == [start + 1, start + 2, start + 3]
 
     def test_the_counter_ends_where_the_last_stamp_did(self, db):
         rows = db.get_content().limit(2).all()
 
-        high = stamp_usns(db, rows)
+        last_usn = stamp_usns(db, rows)
         require_session(db).commit()
 
-        assert require_session(db).execute(_COUNTER).scalar() == high
-        assert max(row.rb_local_usn for row in rows) == high
+        assert require_session(db).execute(_COUNTER).scalar() == last_usn
+        assert max(row.rb_local_usn for row in rows) == last_usn
 
     def test_nothing_to_stamp_leaves_the_counter_alone(self, db):
         start = require_session(db).execute(_COUNTER).scalar()
@@ -186,10 +186,10 @@ class TestStampUsnsUnderConcurrency:
             stamp_usns(theirs, theirs.get_content().limit(3).all())
             require_session(theirs).commit()
 
-            high = stamp_usns(ours, rows)
+            last_usn = stamp_usns(ours, rows)
             require_session(ours).commit()
 
-            assert high == start + 3 + 2
+            assert last_usn == start + 3 + 2
             assert [row.rb_local_usn for row in rows] == [start + 4, start + 5]
         finally:
             close_database(ours)

--- a/tests/api/test_utils.py
+++ b/tests/api/test_utils.py
@@ -1,7 +1,22 @@
 """Tests for api/_utils.py."""
 
-from rekordbox_edit.api._utils import _order_tracks_by_op, _track_from_content
+import logging
+import threading
+from unittest.mock import Mock
+
+import pytest
+from pyrekordbox import Rekordbox6Database
+from sqlalchemy import text
+
+from tests.api.conftest import close_database
+
+from rekordbox_edit.api._utils import (
+    _order_tracks_by_op,
+    _track_from_content,
+    stamp_usns,
+)
 from rekordbox_edit.models import ConvertOp, Track
+from rekordbox_edit.query import require_session
 
 
 class TestTrackFromContent:
@@ -54,3 +69,150 @@ class TestOrderTracksByOp:
 
     def test_empty_inputs_return_empty(self):
         assert _order_tracks_by_op([], []) == []
+
+
+_COUNTER = text(
+    "SELECT int_1 FROM agentRegistry WHERE registry_id = 'localUpdateCount'"
+)
+
+
+class TestStampUsns:
+    def test_stamps_a_contiguous_block_ending_at_the_counter(self, db):
+        start = require_session(db).execute(_COUNTER).scalar()
+        rows = db.get_content().limit(3).all()
+
+        high = stamp_usns(db, rows)
+
+        assert high == start + 3
+        assert [row.rb_local_usn for row in rows] == [start + 1, start + 2, start + 3]
+
+    def test_the_counter_ends_where_the_last_stamp_did(self, db):
+        rows = db.get_content().limit(2).all()
+
+        high = stamp_usns(db, rows)
+        require_session(db).commit()
+
+        assert require_session(db).execute(_COUNTER).scalar() == high
+        assert max(row.rb_local_usn for row in rows) == high
+
+    def test_nothing_to_stamp_leaves_the_counter_alone(self, db):
+        start = require_session(db).execute(_COUNTER).scalar()
+
+        assert stamp_usns(db, []) is None
+        assert require_session(db).execute(_COUNTER).scalar() == start
+
+    def test_rows_without_the_column_are_ignored(self, db):
+        start = require_session(db).execute(_COUNTER).scalar()
+
+        assert stamp_usns(db, [object(), object()]) is None
+        assert require_session(db).execute(_COUNTER).scalar() == start
+
+    def test_a_rollback_takes_the_reservation_with_it(self, db):
+        # A counter advanced past unstamped rows would hide them from sync.
+        start = require_session(db).execute(_COUNTER).scalar()
+        rows = db.get_content().limit(2).all()
+
+        stamp_usns(db, rows)
+        require_session(db).rollback()
+
+        assert require_session(db).execute(_COUNTER).scalar() == start
+
+    def test_a_missing_counter_stamps_nothing(self, db, caplog):
+        require_session(db).execute(
+            text("DELETE FROM agentRegistry WHERE registry_id = 'localUpdateCount'")
+        )
+        rows = db.get_content().limit(2).all()
+        before = [row.rb_local_usn for row in rows]
+
+        with caplog.at_level(logging.WARNING, logger="rekordbox_edit.api.usn"):
+            assert stamp_usns(db, rows) is None
+
+        assert [row.rb_local_usn for row in rows] == before
+        assert "localUpdateCount" in caplog.text
+
+    def test_no_session_raises(self):
+        db = Mock(session=None)
+        row = Mock(rb_local_usn=1)
+
+        with pytest.raises(RuntimeError, match="No Session"):
+            stamp_usns(db, [row])
+
+
+class TestStampUsnsUnderConcurrency:
+    """Rekordbox writes to this counter too, and the advisory lock cannot stop
+    it."""
+
+    def test_concurrent_writers_lose_no_increments(self, library):
+        rounds, writers = 15, 2
+
+        def worker():
+            database = Rekordbox6Database(path=str(library))
+            try:
+                for _ in range(rounds):
+                    row = database.get_content().first()
+                    stamp_usns(database, [row])
+                    require_session(database).commit()
+            finally:
+                close_database(database)
+
+        control = Rekordbox6Database(path=str(library))
+        start = require_session(control).execute(_COUNTER).scalar()
+        close_database(control)
+
+        threads = [threading.Thread(target=worker) for _ in range(writers)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        after = Rekordbox6Database(path=str(library))
+        try:
+            assert (
+                require_session(after).execute(_COUNTER).scalar()
+                == start + rounds * writers
+            )
+        finally:
+            close_database(after)
+
+    def test_an_outside_commit_between_read_and_stamp_is_not_lost(self, library):
+        # Opens with a read, as a real command does, then another writer
+        # commits before the reservation runs.
+        ours = Rekordbox6Database(path=str(library))
+        theirs = Rekordbox6Database(path=str(library))
+        try:
+            start = require_session(ours).execute(_COUNTER).scalar()
+            rows = ours.get_content().limit(2).all()
+
+            stamp_usns(theirs, theirs.get_content().limit(3).all())
+            require_session(theirs).commit()
+
+            high = stamp_usns(ours, rows)
+            require_session(ours).commit()
+
+            assert high == start + 3 + 2
+            assert [row.rb_local_usn for row in rows] == [start + 4, start + 5]
+        finally:
+            close_database(ours)
+            close_database(theirs)
+
+
+class TestDriverTransactionAssumption:
+    """The reservation needs no retry loop only because the driver opens no
+    transaction for a SELECT. A driver change would reverse that quietly."""
+
+    @staticmethod
+    def _dbapi(db):
+        return require_session(db).connection().connection.dbapi_connection
+
+    def test_a_read_opens_no_driver_transaction(self, db):
+        require_session(db).execute(_COUNTER)
+
+        # SQLAlchemy believes a transaction is open; SQLite does not.
+        assert require_session(db).in_transaction() is True
+        assert self._dbapi(db).in_transaction is False
+
+    def test_a_write_opens_one(self, db):
+        require_session(db).execute(_COUNTER)
+        stamp_usns(db, db.get_content().limit(1).all())
+
+        assert self._dbapi(db).in_transaction is True

--- a/tests/cli/test_convert.py
+++ b/tests/cli/test_convert.py
@@ -128,16 +128,44 @@ class TestConvertCommand:
 
         mock_logger.info.assert_any_call("Deleted 2 original file(s)")
 
-    @patch("rekordbox_edit.cli._utils.confirm")
     @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
     @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=12345)
-    def test_rekordbox_running_user_declines(self, _pid, mock_db_class, mock_confirm):
-        mock_confirm.return_value = False
-
+    def test_a_write_refuses_while_rekordbox_runs(self, _pid, mock_db_class):
         result = CliRunner().invoke(convert_command, ["--format-out", "aiff"])
 
-        assert result.exit_code == 0
+        assert result.exit_code == 1
         mock_db_class.assert_not_called()
+
+    @patch("rekordbox_edit.cli.convert.convert")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=12345)
+    def test_a_dry_run_runs_while_rekordbox_runs(
+        self, _pid, mock_db_class, mock_convert
+    ):
+        # A preview writes nothing, so there is nothing to refuse.
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_convert.return_value = _response()
+
+        result = CliRunner().invoke(
+            convert_command, ["--format-out", "aiff", "--dry-run"]
+        )
+
+        assert result.exit_code == 0
+        mock_convert.assert_called_once()
+
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    def test_a_scripting_dry_run_is_not_blocked_either(self, mock_db_class):
+        mock_db_class.return_value = Mock(session=Mock())
+        with (
+            patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=12345),
+            patch("rekordbox_edit.cli.convert.convert", return_value=_response()),
+        ):
+            result = CliRunner().invoke(
+                convert_command,
+                ["--format-out", "aiff", "--dry-run", "--print", "ids"],
+            )
+
+        assert result.exit_code == 0
 
     @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
     def test_aborts_in_scripting_mode_when_rekordbox_running(self, mock_db_class):
@@ -292,22 +320,13 @@ class TestConvertCommand:
         narrowed_args = mock_convert.call_args_list[1].args[1]
         assert narrowed_args.track_ids == ["A"]
 
-    @patch("rekordbox_edit.cli._utils.confirm", return_value=True)
     @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
     @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=12345)
-    def test_rekordbox_running_user_accepts_continues(
-        self, _pid, mock_db_class, _confirm
-    ):
-        with patch("rekordbox_edit.cli.convert.convert") as mock_convert:
-            mock_db_class.return_value = Mock(session=Mock())
-            mock_convert.return_value = _response()
+    def test_yes_does_not_override_the_refusal(self, _pid, mock_db_class):
+        result = CliRunner().invoke(convert_command, ["--format-out", "aiff", "--yes"])
 
-            result = CliRunner().invoke(
-                convert_command, ["--format-out", "aiff", "--yes"]
-            )
-
-        assert result.exit_code == 0
-        mock_db_class.assert_called_once()
+        assert result.exit_code == 1
+        mock_db_class.assert_not_called()
 
 
 class TestPartialBatchReporting:


### PR DESCRIPTION
Every row `edit`, `convert`, and `import` writes now carries a fresh USN, and the library's counter advances to match.

## Changes

- Add `api/usn.py`. `stamp_usns` reserves a block of counter values with one expression `UPDATE ... RETURNING`, so the counter is never read into Python and cannot go stale between reading and writing.
- Stamp edited rows in `edit`, each converted row in `convert` (per-file commits mean per-file stamps), and imported rows in `import`.
- Stamp the artist, album, genre, and label rows an import creates along the way. They are collected as they are made, since `add_content` flushes and moves them out of `session.new`.
- Never allow for rekordbox to be running during a write operation. Conversely, stop challenging dry runs about a running Rekordbox. 

## Why Not db.commit() or autoincrement_local_update_count
`autoincrement_local_update_count` (baked into `db.commit`) reads the counter and writes it back. Measured against the real engine with two concurrent writers, that loses exactly one writer's increments without raising an exception. Rekordbox could write to the same counter as us despite our file lock.

## Not Done

The consequence of an unstamped row is still untested: whether cloud or device sync actually misses one is unverified, and `research/convert-export-impact/` ruled USNs out as the cause of the one sync failure this repo has observed. This lands on the argument that writing rows the way Rekordbox writes them is the standard `import` already holds itself to.

## Testing

Most USN tests run against a copy of the committed fixture through the real SQLCipher engine, since the property being tested is SQLite's behavior under a concurrent writer. Two writers doing fifteen stamps each lose no increments; the same test fails against a read-then-write implementation. Others cover the contiguous block, rollback taking the reservation with it, a missing counter stamping nothing, and each command's stamping (verified failing without the wiring).

One test pins the driver's implicit-`BEGIN` behavior: SQLAlchemy reports a transaction open after a `SELECT` while the DBAPI connection does not. That is the only reason the reservation needs no retry loop, and a driver change would reverse it quietly.
