### PR TITLE
feat: apply the ops the user approved

### DIFF
--- a/docs/commands/convert.md
+++ b/docs/commands/convert.md
@@ -64,10 +64,11 @@ rbe search --artist "Lauryn Hill" --print ids | rbe convert --yes
 rbe convert --format-out mp3 --playlist "NeedsConverting" --threads 8 --yes
 ```
 
-### Guardrails
+### Checks
 
 - Without flags, `convert` shows every planned change and asks once before applying. `--interactive` confirms each track individually; `--dry-run` previews without writing; `--yes` confirms the default choice for all prompts without asking.
-- **Rekordbox running:** writing while Rekordbox is open risks losing your changes, so `convert` refuses to run until you close it. `--dry-run` still works.
+- `convert` will encode exactly the tracks the preview showed. If in between the time you're prompted and later confirm a new track that matches your filters lands in your library, it won't be included.
+- **Rekordbox running:** Writing while Rekordbox is open risks losing your changes, so `convert` refuses to run until you close it. `--dry-run` still works.
 - Before a large run, walk through the checklist in [What Should I Do Before Converting?](../faqs.md#what-should-i-do-before-converting)
 
 ## Reference

--- a/docs/commands/edit.md
+++ b/docs/commands/edit.md
@@ -42,10 +42,11 @@ rbe edit FolderPath --match "/Volumes/OldDrive/Music" --replace "/Volumes/NewDri
 rbe edit --exact-title "Acid Rain" FolderPath --replace "/Users/me/Music/acid-rain-remaster.flac"
 ```
 
-## Guardrails
+## Checks
 
-- **Preview and confirm by default.** Without flags, `edit` shows every planned change and asks once before applying. `--interactive` confirms each track individually; `--dry-run` previews without writing; `--yes` confirms the default choice for all prompts without asking.
-- **Single-track by default.** When filters match more than one track, `edit` refuses unless you pass `--multi`. This prevents an unintentionally broad filter from making unintended edits across your library.
+- Without flags, `edit` shows every planned change and asks once before applying. `--interactive` confirms each track individually; `--dry-run` previews without writing; `--yes` confirms the default choice for all prompts without asking.
+- `edit` writes exactly the tracks the preview showed. If in between the time you're prompted and later confirm a new track that matches your filters lands in your library, it won't be included. A track whose file changed in that window is skipped rather than written with stale metadata.
+- When filters match more than one track, `edit` refuses unless you pass `--multi`. This prevents an mistakenly broad filter from making unintended edits across your library.
 - **Rekordbox running:** writing while Rekordbox is open risks losing your changes, so `edit` refuses to run until you close it. `--dry-run` still works.
 
 ## Examples

--- a/docs/commands/import.md
+++ b/docs/commands/import.md
@@ -35,13 +35,15 @@ A file that already has a row in the library but is missing from the named playl
 
 A directory argument is walked recursively for audio files. Ran interactively, `import` reports how many files it found and asks you to confirm before continuing. `--yes` skips this prompt, and is required when providing a non-interactive `--print` mode and a directory argument.
 
+The walk happens once, before the preview. A file dropped into the directory while you are answering the prompt is not imported, since `import` writes exactly the files it showed you.
+
 ## Skipped Files
 
-A file already in the library, matched by its resolved, case-insensitive path, is skipped rather than duplicated. One that cannot be read as audio, or that is not an audio file at all, is skipped with a warning, and the rest of the batch continues.
+A file already in the library, matched by its resolved, case-insensitive path, is skipped rather than duplicated. One that cannot be read as audio, or that is not an audio file at all, is skipped with a warning, and the rest of the batch continues. A file that disappears between the preview and the write is skipped too.
 
-## Guardrails
+## Checks
 
-- **Preview and confirm by default.** Without flags, `import` shows every track it plans to add and asks once before writing; `--dry-run` previews without writing; `--yes` confirms the default choice for all prompts without asking.
+- Without flags, `import` shows every track it plans to add and asks once before writing; `--dry-run` previews without writing; `--yes` confirms the default choice for all prompts without asking.
 - **Rekordbox running:** writing while Rekordbox is open risks losing your changes, so `import` refuses to run until you close it. `--dry-run` still works.
 
 ## Reference

--- a/rekordbox_edit/api/convert.py
+++ b/rekordbox_edit/api/convert.py
@@ -27,7 +27,7 @@ from rekordbox_edit.models import (
     ConvertResult,
     SkippedTrack,
 )
-from rekordbox_edit.query import get_filtered_content
+from rekordbox_edit.query import find_content_by_ids, get_filtered_content
 from rekordbox_edit.utils import (
     FILE_TYPES,
     AudioInfo,
@@ -462,6 +462,27 @@ def _classify_convert(content, args: ConvertRequest) -> ConvertOp | SkippedTrack
     )
 
 
+def _recheck_convert(op: ConvertOp, args: ConvertRequest) -> ConvertOp | SkippedTrack:
+    """Confirm an already-approved conversion still holds.
+
+    The op cleared classification during the preview, so a path that reads
+    differently now changed while the user was deciding.
+    """
+    if not os.path.exists(op.source_path):
+        logger.debug(
+            f"skip convert id={op.id} reason=db_or_fs_changed "
+            f"source_gone={op.source_path}"
+        )
+        return SkippedTrack(id=op.id, reason="db_or_fs_changed")
+    if not args.overwrite and os.path.exists(op.output_path):
+        logger.debug(
+            f"skip convert id={op.id} reason=db_or_fs_changed "
+            f"output_appeared={op.output_path}"
+        )
+        return SkippedTrack(id=op.id, reason="db_or_fs_changed")
+    return op
+
+
 def _deletes_original(mode: str, is_lossless: bool) -> bool:
     """Whether this conversion's original should be deleted under `mode`."""
     if mode == "all":
@@ -478,6 +499,7 @@ def convert(
     *,
     dry_run: bool = False,
     progress: ConvertProgress | None = None,
+    ops: list[ConvertOp] | None = None,
 ) -> ConvertResponse:
     """Convert audio files to a target format and update the Rekordbox database.
 
@@ -488,6 +510,11 @@ def convert(
     ConvertAborted with the files already converted left committed. Only the
     failing file rolls back, and its post-commit work (the ANLZ path update and
     the original deletion) only warns.
+
+    Pass `ops` to convert an already-approved plan. No filter runs, so a track
+    that started matching since the plan was made cannot join the batch; each
+    op's paths are re-checked and reported as `db_or_fs_changed` if they no
+    longer hold.
     """
     from rekordbox_edit.utils import ffmpeg_in_path, get_ffmpeg_directions
 
@@ -499,18 +526,39 @@ def convert(
             f"FFmpeg is required but not found in PATH.{get_ffmpeg_directions()}"
         )
 
-    contents = get_filtered_content(db, args).scalars().all()
-    logger.debug(f"convert fetched {len(contents)} candidate(s) from filter")
-
-    ops: list[ConvertOp] = []
+    planned: list[ConvertOp] = []
     skipped: list[SkippedTrack] = []
-    for c in contents:
-        result = _classify_convert(c, args)
-        if isinstance(result, ConvertOp):
-            ops.append(result)
-        else:
-            skipped.append(result)
-    logger.debug(f"convert classified ops={len(ops)} skipped={len(skipped)}")
+
+    if ops is None:
+        contents = get_filtered_content(db, args).scalars().all()
+        logger.debug(f"convert fetched {len(contents)} candidate(s) from filter")
+        for c in contents:
+            result = _classify_convert(c, args)
+            if isinstance(result, ConvertOp):
+                planned.append(result)
+            else:
+                skipped.append(result)
+        logger.debug(f"convert classified ops={len(planned)} skipped={len(skipped)}")
+    else:
+        rows = find_content_by_ids(db, [op.id for op in ops])
+        contents = []
+        for op in ops:
+            content = rows.get(op.id)
+            if content is None:
+                logger.debug(
+                    f"skip convert id={op.id} reason=db_or_fs_changed row_gone"
+                )
+                skipped.append(SkippedTrack(id=op.id, reason="db_or_fs_changed"))
+                continue
+            result = _recheck_convert(op, args)
+            if isinstance(result, ConvertOp):
+                planned.append(result)
+                contents.append(content)
+            else:
+                skipped.append(result)
+        logger.debug(f"convert re-checked ops={len(planned)} skipped={len(skipped)}")
+
+    ops = planned
 
     if dry_run:
         logger.debug(f"convert dry-run return with {len(ops)} planned conversion(s)")

--- a/rekordbox_edit/api/edit.py
+++ b/rekordbox_edit/api/edit.py
@@ -13,7 +13,7 @@ from rekordbox_edit.models import (
     EditResult,
     SkippedTrack,
 )
-from rekordbox_edit.query import get_filtered_content
+from rekordbox_edit.query import find_content_by_ids, get_filtered_content
 
 logger = logging.getLogger(__name__)
 
@@ -41,16 +41,38 @@ def _classify_edit(
     return EditOp(id=str(content.ID), new_value=str(new_value))
 
 
+def _recheck_edit(
+    db: Rekordbox6Database, content, op: EditOp, args: EditRequest
+) -> EditOp | SkippedTrack:
+    """Confirm an already-approved edit still holds.
+
+    The op cleared validation during the preview, so a check that fails now
+    means the file it named changed while the user was deciding.
+    """
+    handler = FIELD_HANDLERS[args.field]
+    reason = handler.validate_track(db, content, op.new_value, args)
+    if reason is not None:
+        logger.debug(f"skip edit id={op.id} reason=db_or_fs_changed was={reason}")
+        return SkippedTrack(id=op.id, reason="db_or_fs_changed")
+    return op
+
+
 def edit(
     db: Rekordbox6Database,
     args: EditRequest,
     *,
     dry_run: bool = False,
+    ops: list[EditOp] | None = None,
 ) -> EditResponse:
     """Apply a metadata edit across tracks matching the filter args.
 
     With `dry_run=True`, returns the planned edits without any DB writes.
     With `dry_run=False` (default), commits the changes.
+
+    Pass `ops` to apply an already-approved plan. No filter runs, so a row
+    that started matching since the plan was made cannot join the edit; each
+    op is re-checked against the filesystem and reported as
+    `db_or_fs_changed` if it no longer holds.
     """
     logger.debug(f"edit start field={args.field} dry_run={dry_run}")
     handler = FIELD_HANDLERS.get(args.field)
@@ -58,25 +80,44 @@ def edit(
         raise ValueError(f"Unknown field: {args.field!r}")
     handler.validate_request(args)
 
-    contents = get_filtered_content(db, args).scalars().all()
-    logger.debug(f"edit fetched {len(contents)} candidate(s) from filter")
-
-    ops: list[EditOp] = []
+    planned: list[EditOp] = []
     skipped: list[SkippedTrack] = []
-    for c in contents:
-        result = _classify_edit(db, c, args)
-        if isinstance(result, EditOp):
-            ops.append(result)
-        else:
-            skipped.append(result)
-    logger.debug(f"edit classified ops={len(ops)} skipped={len(skipped)}")
 
-    if len(ops) > 1 and not args.multi:
-        logger.debug(f"edit aborted on multi guard with {len(ops)} ops")
-        raise ValueError(
-            f"Found {len(ops)} tracks that would be edited. "
-            "Refine your filters, use dry_run to inspect, or pass multi=True to edit all."
-        )
+    if ops is None:
+        contents = get_filtered_content(db, args).scalars().all()
+        logger.debug(f"edit fetched {len(contents)} candidate(s) from filter")
+        for c in contents:
+            result = _classify_edit(db, c, args)
+            if isinstance(result, EditOp):
+                planned.append(result)
+            else:
+                skipped.append(result)
+        logger.debug(f"edit classified ops={len(planned)} skipped={len(skipped)}")
+
+        if len(planned) > 1 and not args.multi:
+            logger.debug(f"edit aborted on multi guard with {len(planned)} ops")
+            raise ValueError(
+                f"Found {len(planned)} tracks that would be edited. "
+                "Refine your filters, use dry_run to inspect, or pass multi=True to edit all."
+            )
+    else:
+        rows = find_content_by_ids(db, [op.id for op in ops])
+        contents = []
+        for op in ops:
+            content = rows.get(op.id)
+            if content is None:
+                logger.debug(f"skip edit id={op.id} reason=db_or_fs_changed row_gone")
+                skipped.append(SkippedTrack(id=op.id, reason="db_or_fs_changed"))
+                continue
+            result = _recheck_edit(db, content, op, args)
+            if isinstance(result, EditOp):
+                planned.append(result)
+                contents.append(content)
+            else:
+                skipped.append(result)
+        logger.debug(f"edit re-checked ops={len(planned)} skipped={len(skipped)}")
+
+    ops = planned
 
     if dry_run:
         logger.debug(f"edit dry-run return with {len(ops)} planned edit(s)")

--- a/rekordbox_edit/api/field_handlers.py
+++ b/rekordbox_edit/api/field_handlers.py
@@ -226,6 +226,11 @@ class FolderPathField(FieldHandler):
     def __init__(self):
         self._probes: dict[tuple[str, str], AudioInfo] = {}
 
+    def validate_request(self, args):
+        # This handler is a module-scope singleton in FIELD_HANDLERS, so probes
+        # from an earlier request would otherwise outlive it.
+        self._probes.clear()
+
     def current_value(self, content):
         return content.FolderPath
 

--- a/rekordbox_edit/api/import_.py
+++ b/rekordbox_edit/api/import_.py
@@ -368,16 +368,35 @@ def import_tracks(
     args: ImportRequest,
     *,
     dry_run: bool = False,
+    ops: list[ImportOp] | None = None,
 ) -> ImportResponse:
     """Create database rows for audio files Rekordbox does not yet know about.
 
     With `dry_run=True`, returns the planned adds without any DB writes.
+
+    Pass `ops` to import an already-approved plan. The requested directories
+    are not walked again, so a file created since the plan was made cannot be
+    imported unpreviewed; an op whose file is gone is reported as
+    `db_or_fs_changed`.
     """
     logger.debug(f"import start paths={len(args.paths)} dry_run={dry_run}")
 
-    candidates, directories, rejected = _expand_paths(args.paths)
-    if directories and not args.recurse:
-        raise DirectoryConfirmationRequired(len(directories), len(candidates))
+    skipped: list[SkippedTrack] = []
+    if ops is None:
+        candidates, directories, rejected = _expand_paths(args.paths)
+        if directories and not args.recurse:
+            raise DirectoryConfirmationRequired(len(directories), len(candidates))
+        for path in rejected:
+            logger.warning(f"Skipping {path}: not an audio file RBE recognizes")
+            skipped.append(SkippedTrack(id="", reason="unsupported_file_type"))
+    else:
+        candidates = []
+        for op in ops:
+            if not os.path.exists(op.path):
+                logger.debug(f"skip import reason=db_or_fs_changed path={op.path}")
+                skipped.append(SkippedTrack(id=op.id, reason="db_or_fs_changed"))
+                continue
+            candidates.append(_ImportCandidate.of(op.path))
 
     session = require_session(db)
 
@@ -392,11 +411,6 @@ def import_tracks(
         }
 
     existing = find_content_by_key(db, [c.key for c in candidates])
-
-    skipped: list[SkippedTrack] = []
-    for path in rejected:
-        logger.warning(f"Skipping {path}: not an audio file RBE recognizes")
-        skipped.append(SkippedTrack(id="", reason="unsupported_file_type"))
 
     # Paired so the write and dry-run phases reach a candidate's resolved path
     # and tags without looking either up again by string.

--- a/rekordbox_edit/cli/_utils.py
+++ b/rekordbox_edit/cli/_utils.py
@@ -1,10 +1,9 @@
-"""CLI-private helpers: stdin handling, scripting guards, args narrowing, print emitters."""
+"""CLI-private helpers: stdin handling, scripting guards, print emitters."""
 
 import contextlib
 import functools
 import logging
 import sys
-from copy import copy
 from typing import TypeVar
 
 import click
@@ -61,40 +60,6 @@ def _validate_scripting_preconditions(
         )
     if piped_stdin and not confirmed:
         raise click.UsageError("Piping track IDs requires --dry-run or --yes")
-
-
-def _narrow_to_track_ids(args, ids: list[str]):
-    """Return a new args of the same type with track_ids=ids and all other
-    FilterArgs criteria cleared, preserving command-specific fields.
-
-    Used when the CLI's interactive mode has trimmed the planned operation
-    to a user-selected subset. The narrowed args is passed to the real-run
-    call so the second pass only considers the chosen track IDs.
-    """
-    narrowed = copy(args)
-    for field_name in (
-        "track_id",
-        "track_ids",
-        "title",
-        "exact_title",
-        "playlist",
-        "exact_playlist",
-        "artist",
-        "exact_artist",
-        "album",
-        "exact_album",
-        "path",
-        "resolved_path",
-        "format",
-    ):
-        if hasattr(narrowed, field_name):
-            setattr(narrowed, field_name, [])
-    narrowed.track_ids = list(ids)
-    narrowed.match_all = False
-    narrowed.match_any = False
-    narrowed.first = None
-    narrowed.last = None
-    return narrowed
 
 
 def _print_response_ids(response) -> None:

--- a/rekordbox_edit/cli/convert.py
+++ b/rekordbox_edit/cli/convert.py
@@ -20,7 +20,6 @@ from rekordbox_edit.cli._utils import (
     SCRIPTING_MODES,
     _build_args,
     _handle_stdin,
-    _narrow_to_track_ids,
     _print_response_ids,
     _print_response_json,
     _validate_scripting_preconditions,
@@ -35,7 +34,7 @@ logger = logging.getLogger(__name__)
 
 # Skips a dry run cannot predict: it neither probes a source nor re-stats one,
 # so these surface only from the live pass.
-_LIVE_ONLY_SKIPS = frozenset({"codec_mismatch", "file_not_found"})
+_LIVE_ONLY_SKIPS = frozenset({"codec_mismatch", "file_not_found", "db_or_fs_changed"})
 
 
 @click.command(
@@ -115,9 +114,12 @@ def convert_command(db, **kwargs):
         if not selected_ids:
             logger.info("Cancelled.")
             return
-        narrowed = _narrow_to_track_ids(args, selected_ids)
+        chosen = set(selected_ids)
+        selected = [op for op in preview.result.converted if op.id in chosen]
         with convert_progress(enabled=True) as progress:
-            response = _convert_reporting_partials(db, narrowed, progress=progress)
+            response = _convert_reporting_partials(
+                db, args, ops=selected, progress=progress
+            )
     else:
         try:
             if not confirm(
@@ -130,17 +132,21 @@ def convert_command(db, **kwargs):
         except UserQuit:
             return
         with convert_progress(enabled=True) as progress:
-            response = _convert_reporting_partials(db, args, progress=progress)
+            response = _convert_reporting_partials(
+                db, args, ops=preview.result.converted, progress=progress
+            )
 
     _report_skips([s for s in response.result.skipped if s.reason in _LIVE_ONLY_SKIPS])
     _print_convert_result(response, print_opt, scripting_mode, dry_run=False)
 
 
-def _convert_reporting_partials(db, args, *, dry_run: bool = False, progress=None):
+def _convert_reporting_partials(
+    db, args, *, dry_run: bool = False, progress=None, ops=None
+):
     """Convert, reporting a batch that stopped partway as a plain result rather
     than as a crash. The committed conversions are real and are kept."""
     try:
-        return convert(db, args, dry_run=dry_run, progress=progress)
+        return convert(db, args, dry_run=dry_run, progress=progress, ops=ops)
     except ConvertAborted as e:
         logger.error(f"Conversion stopped at {e.failed_path}: {e}")
         logger.error(
@@ -156,6 +162,7 @@ def _report_skips(skipped) -> None:
     conflicts = sum(1 for s in skipped if s.reason == "output_file_exists")
     mismatches = sum(1 for s in skipped if s.reason == "codec_mismatch")
     missing = sum(1 for s in skipped if s.reason == "file_not_found")
+    drifted = sum(1 for s in skipped if s.reason == "db_or_fs_changed")
     if already_target:
         logger.warning(f"Skipping {already_target} file(s): already in target format")
     if unsupported:
@@ -174,6 +181,8 @@ def _report_skips(skipped) -> None:
         )
     if missing:
         logger.warning(f"Skipping {missing} file(s): source file is gone")
+    if drifted:
+        logger.warning(f"Skipping {drifted} file(s): changed since the preview")
 
 
 def _print_convert_result(

--- a/rekordbox_edit/cli/edit.py
+++ b/rekordbox_edit/cli/edit.py
@@ -19,7 +19,6 @@ from rekordbox_edit.cli._utils import (
     SCRIPTING_MODES,
     _build_args,
     _handle_stdin,
-    _narrow_to_track_ids,
     _print_response_ids,
     _print_response_json,
     _validate_scripting_preconditions,
@@ -127,9 +126,10 @@ def edit_command(db, **kwargs):
         if not selected_ids:
             logger.info("Cancelled.")
             return
-        narrowed = _narrow_to_track_ids(args, selected_ids)
+        chosen = set(selected_ids)
+        selected = [op for op in preview.result.edits if op.id in chosen]
         try:
-            response = edit(db, narrowed)
+            response = edit(db, args, ops=selected)
         except ValueError as e:
             raise click.UsageError(str(e)) from e
     else:
@@ -140,7 +140,7 @@ def edit_command(db, **kwargs):
         except UserQuit:
             return
         try:
-            response = edit(db, args)
+            response = edit(db, args, ops=preview.result.edits)
         except ValueError as e:
             raise click.UsageError(str(e)) from e
 

--- a/rekordbox_edit/cli/edit.py
+++ b/rekordbox_edit/cli/edit.py
@@ -128,7 +128,10 @@ def edit_command(db, **kwargs):
             logger.info("Cancelled.")
             return
         narrowed = _narrow_to_track_ids(args, selected_ids)
-        response = edit(db, narrowed)
+        try:
+            response = edit(db, narrowed)
+        except ValueError as e:
+            raise click.UsageError(str(e)) from e
     else:
         try:
             if not confirm(f"Apply {len(preview.result.edits)} edit(s)?", default=True):
@@ -136,7 +139,10 @@ def edit_command(db, **kwargs):
                 return
         except UserQuit:
             return
-        response = edit(db, args)
+        try:
+            response = edit(db, args)
+        except ValueError as e:
+            raise click.UsageError(str(e)) from e
 
     _print_edit_result(response, print_opt, dry_run=False)
 

--- a/rekordbox_edit/cli/import_.py
+++ b/rekordbox_edit/cli/import_.py
@@ -131,9 +131,10 @@ def import_command(db, **kwargs):
     except UserQuit:
         return
 
-    response, _ = _import_confirming_walk(confirmed_args)
-    if response is None:
-        return
+    # Passing the previewed ops means no second directory walk, so a file
+    # created during the prompt cannot be imported unseen, and the directory
+    # gate cannot fire again.
+    response = _attempt_import(confirmed_args, ops=preview.result.added)
     _print_import_result(response, print_opt, dry_run=False)
 
 

--- a/rekordbox_edit/models.py
+++ b/rekordbox_edit/models.py
@@ -173,6 +173,9 @@ SkipReason: TypeAlias = Literal[
     "already_exists",
     "unsupported_file_type",
     "unreadable_file",
+    # Approved during the preview, then its file or its database row changed
+    # before the write ran.
+    "db_or_fs_changed",
 ]
 
 

--- a/rekordbox_edit/query.py
+++ b/rekordbox_edit/query.py
@@ -367,6 +367,21 @@ def find_content_by_key(
     return found
 
 
+def find_content_by_ids(
+    db: Rekordbox6Database, ids: Collection[str]
+) -> dict[str, DjmdContent]:
+    """Rows for `ids`, keyed by ID as a string. IDs with no row are absent."""
+    if not ids:
+        return {}
+    session = require_session(db)
+    rows = session.execute(
+        select(DjmdContent).where(DjmdContent.ID.in_(list(ids)))
+    ).scalars()
+    found = {str(row.ID): row for row in rows}
+    logger.debug(f"id lookup matched {len(found)} of {len(set(ids))} requested row(s)")
+    return found
+
+
 def find_playlists_by_name(db: Rekordbox6Database, name: str) -> list[DjmdPlaylist]:
     """Normal playlists whose name matches case-insensitively.
 

--- a/tests/api/test_convert.py
+++ b/tests/api/test_convert.py
@@ -22,6 +22,7 @@ from rekordbox_edit.api.convert import (
     _hi_res_output_kwargs,
     _mp3_output_kwargs,
     _probe_converted_file,
+    _recheck_convert,
     _rollback_session,
     _run_ffmpeg,
     _sweep_orphan_temp_files,
@@ -385,6 +386,130 @@ class TestSweepOrphanTempFiles:
 
     def test_an_unreadable_directory_does_not_raise(self, tmp_path):
         _sweep_orphan_temp_files([str(tmp_path / "absent" / "song.aiff")])
+
+
+def _op(id="A", source="/A.wav", output="/A.aif"):
+    return ConvertOp(
+        id=id,
+        source_path=source,
+        output_path=output,
+        source_file_type="WAV",
+        output_file_type="AIFF",
+    )
+
+
+class TestRecheckConvert:
+    """Every op here passed classification during the preview, so a path that
+    reads differently now changed while the user was deciding."""
+
+    @patch("rekordbox_edit.api.convert.os.path.exists")
+    def test_unchanged_paths_keep_the_op(self, mock_exists):
+        op = _op()
+        mock_exists.side_effect = lambda path: path == op.source_path
+
+        assert _recheck_convert(op, ConvertRequest(format_out="aiff")) is op
+
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=False)
+    def test_a_vanished_source_is_db_or_fs_changed(self, _exists):
+        result = _recheck_convert(_op(), ConvertRequest(format_out="aiff"))
+
+        assert result == SkippedTrack(id="A", reason="db_or_fs_changed")
+
+    @patch("rekordbox_edit.api.convert.os.path.exists")
+    def test_an_output_that_appeared_is_db_or_fs_changed(self, mock_exists):
+        mock_exists.side_effect = lambda path: True  # source and output both there
+
+        result = _recheck_convert(_op(), ConvertRequest(format_out="aiff"))
+
+        assert result == SkippedTrack(id="A", reason="db_or_fs_changed")
+
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=True)
+    def test_overwrite_tolerates_an_output_that_appeared(self, _exists):
+        op = _op()
+        assert (
+            _recheck_convert(op, ConvertRequest(format_out="aiff", overwrite=True))
+            is op
+        )
+
+
+class TestConvertFromApprovedOps:
+    @patch("rekordbox_edit.api.convert.find_content_by_ids")
+    @patch("rekordbox_edit.api.convert.get_filtered_content")
+    @patch("rekordbox_edit.api.convert.os.path.exists", return_value=False)
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    def test_a_vanished_source_never_reaches_ffmpeg(
+        self, _ffmpeg, _exists, mock_gfc, mock_by_ids, mock_db, make_djmd_content_item
+    ):
+        mock_by_ids.return_value = {"A": make_djmd_content_item(ID="A")}
+
+        response = convert(mock_db, ConvertRequest(format_out="aiff"), ops=[_op()])
+
+        mock_gfc.assert_not_called()
+        assert response.result.converted == []
+        assert response.result.skipped == [
+            SkippedTrack(id="A", reason="db_or_fs_changed")
+        ]
+        mock_db.session.commit.assert_not_called()
+
+    @pytest.fixture(autouse=True)
+    def _stub_temp_file_moves(self):
+        with (
+            patch("rekordbox_edit.api.convert.os.replace"),
+            patch("rekordbox_edit.api.convert.os.listdir", return_value=[]),
+            patch("rekordbox_edit.api.convert._probe_converted_file"),
+        ):
+            yield
+
+    @patch("rekordbox_edit.api.convert.get_audio_info", return_value=_PROBE_WAV_16_44)
+    @patch("rekordbox_edit.api.convert._apply_converted_record")
+    @patch("rekordbox_edit.api.convert._run_ffmpeg", return_value=True)
+    @patch("rekordbox_edit.api.convert.find_content_by_ids")
+    @patch("rekordbox_edit.api.convert.get_filtered_content")
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    def test_an_op_that_still_holds_is_converted_and_committed(
+        self,
+        _ffmpeg,
+        mock_gfc,
+        mock_by_ids,
+        mock_run,
+        mock_apply,
+        _probe,
+        mock_db,
+        make_djmd_content_item,
+    ):
+        content = make_djmd_content_item(ID="A", FileType=11, FolderPath="/A.wav")
+        mock_by_ids.return_value = {"A": content}
+        _seed_db(mock_db, content)
+        op = _op(source="/A.wav", output="/A.aif")
+
+        with patch(
+            "rekordbox_edit.api.convert.os.path.exists",
+            side_effect=lambda path: path != op.output_path,
+        ):
+            response = convert(
+                mock_db,
+                ConvertRequest(format_out="aiff", delete_originals="none"),
+                ops=[op],
+            )
+
+        mock_gfc.assert_not_called()
+        assert [o.id for o in response.result.converted] == ["A"]
+        assert [t.ID for t in response.tracks] == ["A"]
+        assert response.result.skipped == []
+        mock_run.assert_called_once()
+        mock_apply.assert_called_once()
+        mock_db.session.commit.assert_called_once()
+
+    @patch("rekordbox_edit.api.convert.find_content_by_ids", return_value={})
+    @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
+    def test_a_row_deleted_since_the_preview_is_db_or_fs_changed(
+        self, _ffmpeg, _by_ids, mock_db
+    ):
+        response = convert(mock_db, ConvertRequest(format_out="aiff"), ops=[_op()])
+
+        assert response.result.skipped == [
+            SkippedTrack(id="A", reason="db_or_fs_changed")
+        ]
 
 
 class TestConvertRealRun:

--- a/tests/api/test_edit.py
+++ b/tests/api/test_edit.py
@@ -228,6 +228,84 @@ class TestEditRealRun:
             edit(mock_db, EditRequest(field="Nope", replace_value="x"))
 
 
+class TestEditFromApprovedOps:
+    """The apply pass runs no filter, so nothing can join the edit late."""
+
+    @patch("rekordbox_edit.api.edit.find_content_by_ids")
+    @patch("rekordbox_edit.api.edit.get_filtered_content")
+    def test_a_row_that_starts_matching_does_not_join(
+        self, mock_gfc, mock_by_ids, mock_db, make_djmd_content_item
+    ):
+        approved = make_djmd_content_item(ID="1", Title="Old")
+        latecomer = make_djmd_content_item(ID="2", Title="Old")
+        mock_by_ids.return_value = {"1": approved, "2": latecomer}
+
+        response = edit(
+            mock_db,
+            EditRequest(field="Title", replace_value="New"),
+            ops=[EditOp(id="1", new_value="New")],
+        )
+
+        mock_gfc.assert_not_called()
+        assert [op.id for op in response.result.edits] == ["1"]
+        assert latecomer.Title == "Old"
+
+    @patch("rekordbox_edit.api.edit.find_content_by_ids")
+    def test_an_op_that_stopped_validating_is_db_or_fs_changed(
+        self, mock_by_ids, mock_db, make_djmd_content_item, stub_handler
+    ):
+        content = make_djmd_content_item(ID="1")
+        mock_by_ids.return_value = {"1": content}
+        stub_handler.validate_track.return_value = "file_not_found"
+
+        response = edit(
+            mock_db,
+            EditRequest(field="Stub", replace_value="New"),
+            ops=[EditOp(id="1", new_value="New")],
+        )
+
+        assert response.result.edits == []
+        assert response.result.skipped == [
+            SkippedTrack(id="1", reason="db_or_fs_changed")
+        ]
+        stub_handler.apply.assert_not_called()
+
+    @patch("rekordbox_edit.api.edit.find_content_by_ids")
+    def test_a_row_deleted_since_the_preview_is_db_or_fs_changed(
+        self, mock_by_ids, mock_db
+    ):
+        mock_by_ids.return_value = {}
+
+        response = edit(
+            mock_db,
+            EditRequest(field="Title", replace_value="New"),
+            ops=[EditOp(id="1", new_value="New")],
+        )
+
+        assert response.result.skipped == [
+            SkippedTrack(id="1", reason="db_or_fs_changed")
+        ]
+        mock_db.session.commit.assert_not_called()
+
+    @patch("rekordbox_edit.api.edit.find_content_by_ids")
+    def test_ops_bypass_the_multi_guard_the_user_already_answered(
+        self, mock_by_ids, mock_db, make_djmd_content_item
+    ):
+        rows = {
+            "1": make_djmd_content_item(ID="1", Title="Old"),
+            "2": make_djmd_content_item(ID="2", Title="Old"),
+        }
+        mock_by_ids.return_value = rows
+
+        response = edit(
+            mock_db,
+            EditRequest(field="Title", replace_value="New"),
+            ops=[EditOp(id="1", new_value="New"), EditOp(id="2", new_value="New")],
+        )
+
+        assert len(response.result.edits) == 2
+
+
 class TestValidateTrackHook:
     def test_skip_reason_from_handler(
         self, mock_db, make_djmd_content_item, stub_handler

--- a/tests/api/test_field_handlers.py
+++ b/tests/api/test_field_handlers.py
@@ -311,6 +311,17 @@ class TestFolderPathField:
         assert isinstance(handler, FolderPathField)
         assert handler.supports_match is True
 
+    def test_validate_request_drops_probes_from_an_earlier_run(self):
+        # FIELD_HANDLERS holds one instance for the life of the process.
+        handler = _folder_handler()
+        handler._probes[("1", "/new/song.wav")] = _probe()
+
+        handler.validate_request(
+            EditRequest(field="FolderPath", replace_value="/new/song.wav")
+        )
+
+        assert handler._probes == {}
+
     def test_current_value_reads_folder_path(self, make_djmd_content_item):
         content = make_djmd_content_item(ID="1", FolderPath="/old/song.wav")
         assert _folder_handler().current_value(content) == "/old/song.wav"

--- a/tests/api/test_import.py
+++ b/tests/api/test_import.py
@@ -881,6 +881,63 @@ class TestImport:
         assert any("rolling back" in message for message in caplog.messages)
 
 
+class TestImportFromApprovedOps:
+    """The write pass walks no directories, so nothing joins the batch late."""
+
+    def test_a_file_created_during_the_prompt_is_not_imported(
+        self, mock_db, tmp_path, stub_tags
+    ):
+        crate = tmp_path / "crate"
+        crate.mkdir()
+        previewed = crate / "a.flac"
+        previewed.write_bytes(b"")
+        latecomer = crate / "b.flac"
+        latecomer.write_bytes(b"")
+        approved = [ImportOp(id="", path=str(previewed), action="create")]
+
+        with patch("rekordbox_edit.api.import_.find_content_by_key", return_value={}):
+            response = import_tracks(
+                mock_db,
+                ImportRequest(paths=[str(crate)], recurse=True),
+                dry_run=True,
+                ops=approved,
+            )
+
+        assert [op.path for op in response.result.added] == [str(previewed)]
+
+    def test_a_vanished_file_is_db_or_fs_changed(self, mock_db, tmp_path, stub_tags):
+        gone = str(tmp_path / "gone.flac")
+        approved = [ImportOp(id="", path=gone, action="create")]
+
+        with patch("rekordbox_edit.api.import_.find_content_by_key", return_value={}):
+            response = import_tracks(
+                mock_db, ImportRequest(paths=[gone]), dry_run=True, ops=approved
+            )
+
+        assert response.result.added == []
+        assert response.result.skipped == [
+            SkippedTrack(id="", reason="db_or_fs_changed")
+        ]
+
+    def test_ops_skip_the_directory_gate(self, mock_db, tmp_path, stub_tags):
+        # _expand_paths never runs, so an unconfirmed directory cannot raise.
+        crate = tmp_path / "crate"
+        crate.mkdir()
+        track = crate / "a.flac"
+        track.write_bytes(b"")
+        approved = [ImportOp(id="", path=str(track), action="create")]
+
+        with patch("rekordbox_edit.api.import_.find_content_by_key", return_value={}):
+            response = import_tracks(
+                mock_db,
+                ImportRequest(paths=[str(crate)]),
+                dry_run=True,
+                ops=approved,
+            )
+
+        assert len(response.result.added) == 1
+
+
 class TestImportStampsUsns:
     """Against the real library, since stamping is a database behavior."""
 

--- a/tests/cli/test_convert.py
+++ b/tests/cli/test_convert.py
@@ -317,8 +317,55 @@ class TestConvertCommand:
 
         assert result.exit_code == 0
         assert mock_convert.call_count == 2
-        narrowed_args = mock_convert.call_args_list[1].args[1]
-        assert narrowed_args.track_ids == ["A"]
+        applied = mock_convert.call_args_list[1].kwargs["ops"]
+        assert [op.id for op in applied] == ["A"]
+
+    @patch("rekordbox_edit.cli.convert.print_track_info")
+    @patch("rekordbox_edit.cli.convert.confirm")
+    @patch("rekordbox_edit.cli.convert.convert")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None)
+    def test_quitting_mid_prompt_converts_only_what_was_confirmed(
+        self, _pid, mock_db_class, mock_convert, mock_confirm, _print
+    ):
+        mock_db_class.return_value = Mock(session=Mock())
+        tracks = [
+            Track(ID="A", FileNameL="a.aiff", FolderPath="/a.aiff"),
+            Track(ID="B", FileNameL="b.aiff", FolderPath="/b.aiff"),
+        ]
+        ops = [
+            ConvertOp(id="A", source_path="/a.wav", output_path="/a.aiff"),
+            ConvertOp(id="B", source_path="/b.wav", output_path="/b.aiff"),
+        ]
+        mock_convert.return_value = _response(tracks=tracks, converted=ops)
+        # Confirm A, then quit before answering for B.
+        mock_confirm.side_effect = [True, UserQuit]
+
+        result = CliRunner().invoke(
+            convert_command, ["--format-out", "aiff", "--interactive"]
+        )
+
+        assert result.exit_code == 0
+        applied = mock_convert.call_args_list[1].kwargs["ops"]
+        assert [op.id for op in applied] == ["A"]
+
+    @patch("rekordbox_edit.cli.convert.print_track_info")
+    @patch("rekordbox_edit.cli.convert.confirm", side_effect=UserQuit)
+    @patch("rekordbox_edit.cli.convert.convert")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None)
+    def test_quitting_before_confirming_anything_converts_nothing(
+        self, _pid, mock_db_class, mock_convert, _confirm, _print
+    ):
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_convert.return_value = _response()
+
+        result = CliRunner().invoke(
+            convert_command, ["--format-out", "aiff", "--interactive"]
+        )
+
+        assert result.exit_code == 0
+        mock_convert.assert_called_once()  # preview only
 
     @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
     @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=12345)
@@ -374,6 +421,30 @@ class TestMissingSourceReporting:
         assert result.exit_code == 0
         warnings = " ".join(str(c) for c in mock_logger.warning.call_args_list)
         assert "source file is gone" in warnings
+
+
+class TestDriftReporting:
+    @patch("rekordbox_edit.cli.convert.print_track_info")
+    @patch("rekordbox_edit.cli.convert.confirm", return_value=True)
+    @patch("rekordbox_edit.cli.convert.convert")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None)
+    def test_a_file_that_changed_during_the_prompt_is_reported(
+        self, _pid, mock_db_class, mock_convert, _confirm, _print, mock_logger
+    ):
+        # Only the live pass can see this, so it has to survive the filter
+        # that drops skips the preview already reported.
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_convert.side_effect = [
+            _response(),
+            _response(skipped=[SkippedTrack(id="9", reason="db_or_fs_changed")]),
+        ]
+
+        result = CliRunner().invoke(convert_command, ["--format-out", "aiff"])
+
+        assert result.exit_code == 0
+        warnings = " ".join(str(c) for c in mock_logger.warning.call_args_list)
+        assert "changed since the preview" in warnings
 
 
 class TestThreadsFlag:

--- a/tests/cli/test_edit.py
+++ b/tests/cli/test_edit.py
@@ -101,6 +101,45 @@ class TestEditCommand:
         assert result.exit_code != 0
         assert "Error" in result.output
 
+    @patch("rekordbox_edit.cli.edit.print_track_info")
+    @patch("rekordbox_edit.cli.edit.confirm", return_value=True)
+    @patch("rekordbox_edit.cli.edit.edit")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    def test_apply_pass_value_error_becomes_usage_error(
+        self, mock_db_class, mock_edit, _confirm, _print
+    ):
+        # The preview passes the --multi guard and the apply pass does not.
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_edit.side_effect = [
+            _response(),
+            ValueError("Found 2 tracks that would be edited"),
+        ]
+
+        result = CliRunner().invoke(edit_command, ["Title", "--replace", "New"])
+
+        assert result.exit_code != 0
+        assert "Error" in result.output
+
+    @patch("rekordbox_edit.cli.edit.print_track_info")
+    @patch("rekordbox_edit.cli.edit.confirm", return_value=True)
+    @patch("rekordbox_edit.cli.edit.edit")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    def test_interactive_apply_value_error_becomes_usage_error(
+        self, mock_db_class, mock_edit, _confirm, _print
+    ):
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_edit.side_effect = [
+            _response(),
+            ValueError("Found 2 tracks that would be edited"),
+        ]
+
+        result = CliRunner().invoke(
+            edit_command, ["Title", "--replace", "New", "--interactive"]
+        )
+
+        assert result.exit_code != 0
+        assert "Error" in result.output
+
     @patch("rekordbox_edit.cli.edit.edit")
     @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
     def test_print_ids_outputs_ids(self, mock_db_class, mock_edit):

--- a/tests/cli/test_edit.py
+++ b/tests/cli/test_edit.py
@@ -267,8 +267,8 @@ class TestEditCommand:
 
         assert result.exit_code == 0
         assert mock_edit.call_count == 2
-        narrowed_args = mock_edit.call_args_list[1].args[1]
-        assert narrowed_args.track_ids == ["A"]
+        applied = mock_edit.call_args_list[1].kwargs["ops"]
+        assert [op.id for op in applied] == ["A"]
 
     @patch("rekordbox_edit.cli.edit.print_track_info")
     @patch("rekordbox_edit.cli.edit.confirm", side_effect=UserQuit)

--- a/tests/cli/test_import.py
+++ b/tests/cli/test_import.py
@@ -335,32 +335,24 @@ class TestImportCommand:
         assert mock_import.call_args.kwargs["dry_run"] is True
 
     @patch("rekordbox_edit.cli.import_.print_track_info")
+    @patch("rekordbox_edit.cli.import_.confirm", return_value=True)
     @patch("rekordbox_edit.cli.import_.import_tracks")
     @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
-    def test_quitting_the_directory_prompt_on_the_write_pass_skips_it(
-        self, mock_db_class, mock_import, _print
+    def test_the_write_pass_applies_the_previewed_ops(
+        self, mock_db_class, mock_import, _confirm, _print
     ):
-        # The confirmed write is a second import_tracks call, so it hits the
-        # recurse gate again; quitting there must not fall through to
-        # printing a result that never happened.
+        # Passing ops means no second directory walk, so the recurse gate
+        # cannot fire again and nothing created during the prompt joins in.
         mock_db_class.return_value = Mock(session=Mock())
-        mock_import.side_effect = [
-            _response(),
-            DirectoryConfirmationRequired(1, 3),
-        ]
-        answers = iter([True])
+        preview = _response()
+        mock_import.side_effect = [preview, _response()]
 
-        def _confirm(*_args, **_kwargs):
-            try:
-                return next(answers)
-            except StopIteration:
-                raise UserQuit from None
-
-        with patch("rekordbox_edit.cli.import_.confirm", side_effect=_confirm):
-            result = CliRunner().invoke(import_command, ["/m/crate"])
+        result = CliRunner().invoke(import_command, ["/m/crate"])
 
         assert result.exit_code == 0
         assert mock_import.call_count == 2
+        assert mock_import.call_args.kwargs["ops"] == preview.result.added
+        assert "dry_run" not in mock_import.call_args.kwargs
 
     def test_add_summary_leads_with_creates_when_a_batch_does_both(self):
         assert _add_summary(2, 3) == (

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -6,21 +6,17 @@ import pytest
 from rekordbox_edit._click import PrintChoice
 from rekordbox_edit.cli._utils import (
     _handle_stdin,
-    _narrow_to_track_ids,
     _print_response_ids,
     _print_response_json,
     _validate_scripting_preconditions,
 )
 from rekordbox_edit.models import (
     ConvertOp,
-    ConvertRequest,
     ConvertResponse,
     ConvertResult,
     EditOp,
-    EditRequest,
     EditResponse,
     EditResult,
-    SearchRequest,
     SearchResponse,
     Track,
 )
@@ -97,69 +93,6 @@ class TestValidateScriptingPreconditions:
         _validate_scripting_preconditions(
             None, piped_stdin=True, dry_run=False, yes=True
         )
-
-
-class TestNarrowToTrackIds:
-    def test_clears_other_filter_criteria(self):
-        args = ConvertRequest(
-            artist=["X"],
-            format=["flac"],
-            format_out="aiff",
-            overwrite=True,
-            delete_originals="all",
-        )
-
-        narrowed = _narrow_to_track_ids(args, ["a", "b"])
-
-        assert narrowed.track_ids == ["a", "b"]
-        assert narrowed.artist == []
-        assert narrowed.format == []
-        # Convert-specific fields preserved
-        assert narrowed.format_out == "aiff"
-        assert narrowed.overwrite is True
-        assert narrowed.delete_originals == "all"
-
-    def test_works_for_edit_args(self):
-        args = EditRequest(
-            artist=["X"],
-            field="Title",
-            replace_value="N",
-            match_pattern="O",
-            multi=True,
-        )
-
-        narrowed = _narrow_to_track_ids(args, ["a"])
-
-        assert narrowed.track_ids == ["a"]
-        assert narrowed.artist == []
-        # Edit-specific fields preserved
-        assert narrowed.field == "Title"
-        assert narrowed.replace_value == "N"
-        assert narrowed.match_pattern == "O"
-        assert narrowed.multi is True
-
-    def test_clears_first(self):
-        args = SearchRequest(first=2)
-
-        narrowed = _narrow_to_track_ids(args, ["a", "b", "c"])
-
-        assert narrowed.first is None
-        assert narrowed.track_ids == ["a", "b", "c"]
-
-    def test_clears_last(self):
-        args = SearchRequest(last=2)
-
-        narrowed = _narrow_to_track_ids(args, ["a"])
-
-        assert narrowed.last is None
-
-    def test_clears_match_modes(self):
-        args = SearchRequest(match_any=True)
-
-        narrowed = _narrow_to_track_ids(args, ["a"])
-
-        assert narrowed.match_all is False
-        assert narrowed.match_any is False
 
 
 class TestPrintResponseIds:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -12,6 +12,7 @@ from sqlalchemy import ColumnElement
 from rekordbox_edit.models import FilterArgs
 from rekordbox_edit.query import (
     CollectionQuery,
+    find_content_by_ids,
     find_content_by_key,
     find_playlists_by_name,
     get_filtered_content,
@@ -1011,3 +1012,29 @@ class TestFindPlaylistsByName:
 
         with pytest.raises(RuntimeError, match="No Session"):
             find_playlists_by_name(mock_db, "Crate")
+
+
+class TestFindContentByIds:
+    @staticmethod
+    def _db(*ids):
+        db = MagicMock()
+        db.session = MagicMock()
+        rows = [MagicMock(ID=i) for i in ids]
+        db.session.execute.return_value.scalars.return_value = rows
+        return db, rows
+
+    def test_keys_rows_by_id_as_a_string(self):
+        db, rows = self._db(1, 2)
+
+        assert find_content_by_ids(db, ["1", "2"]) == {"1": rows[0], "2": rows[1]}
+
+    def test_an_id_with_no_row_is_absent(self):
+        db, rows = self._db("A")
+
+        assert find_content_by_ids(db, ["A", "B"]) == {"A": rows[0]}
+
+    def test_no_ids_queries_nothing(self):
+        db, _ = self._db()
+
+        assert find_content_by_ids(db, []) == {}
+        db.session.execute.assert_not_called()


### PR DESCRIPTION
The write pass now applies the ops the preview showed, instead of re-running the filter and classifier against live data.

## Changes

- Add an `ops` keyword to `edit`, `convert`, and `import_tracks`. Given ops, no filter query runs, so a row that starts matching during the confirmation prompt cannot join the operation.
- Add `find_content_by_ids` to load exactly the approved rows.
- Add a `db_or_fs_changed` skip reason. Every op reaching the write pass passed its checks during the preview, so a check that fails now means the file moved, vanished, or changed while the user was deciding. `edit` re-runs `validate_track`, `convert` re-checks its source and output paths, `import` checks the file is still there.
- `import` no longer re-walks its directory arguments on the write pass, which is what let a file dropped in during the prompt be imported unpreviewed. The second directory-confirmation gate goes with it.
- Guard `edit`'s two apply calls against `ValueError`. The `--multi` guard could reach `main.py`'s unhandled-exception handler and tell the user to file an issue.
- Clear `FolderPathField`'s probe cache in `validate_request`. It is a module-scope singleton, so probes outlived their request.
- Drop `_narrow_to_track_ids`, unused now that interactive selection filters the op list directly.

