### PR TITLE
refactor: make the CLI and API layers hold up on their own

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -17,6 +17,44 @@ Different filter kinds — `artist` and `format` above — AND together by defau
 
 `--print json` on any CLI command emits exactly these response envelopes, so the models below also document the JSON you get when scripting.
 
+## Writing Safely
+
+`edit`, `convert`, and `import_tracks` guard their own writes. Each one refuses to run while Rekordbox is open, raising
+[`RekordboxRunningError`][rekordbox_edit.errors.RekordboxRunningError], and holds a single-writer advisory lock for the
+duration of the write. A `dry_run=True` call reaches neither check, because it writes nothing.
+
+That per-call lock does not span two calls. Planning and then applying is two calls, and between them the lock is free, so
+another process can change a row you are about to write. Hold the lock yourself across the pair:
+
+```python
+from rekordbox_edit.api import edit
+from rekordbox_edit.locking import SCRIPTED_TIMEOUT, database_lock
+from rekordbox_edit.models import EditRequest
+
+args = EditRequest(field="Title", replace_value="Take 2", artist=["Alpha"], multi=True)
+
+with database_lock(db.db_directory, command="edit", timeout=SCRIPTED_TIMEOUT):
+    preview = edit(db, args, dry_run=True)
+    # ... decide which ops to keep ...
+    response = edit(db, args, ops=preview.result.edits)
+```
+
+The lock is re-entrant within a process, so the one each call takes nests inside yours at no cost. A lock held by another
+process raises [`DatabaseBusyError`][rekordbox_edit.errors.DatabaseBusyError].
+
+Without the outer lock the plan is still re-checked at apply time: an op whose row or file changed in the meantime is
+reported as a `db_or_fs_changed` skip rather than applied blindly.
+
+## Errors
+
+Every error these functions raise on purpose descends from
+[`RekordboxEditError`][rekordbox_edit.errors.RekordboxEditError], so one `except` clause covers them.
+[`InputError`][rekordbox_edit.errors.InputError] also subclasses `ValueError`.
+
+::: rekordbox_edit.errors
+options:
+heading_level: 3
+
 ## Functions
 
 ::: rekordbox_edit.api.search

--- a/docs/api.md
+++ b/docs/api.md
@@ -19,31 +19,9 @@ Different filter kinds — `artist` and `format` above — AND together by defau
 
 ## Writing Safely
 
-`edit`, `convert`, and `import_tracks` guard their own writes. Each one refuses to run while Rekordbox is open, raising
-[`RekordboxRunningError`][rekordbox_edit.errors.RekordboxRunningError], and holds a single-writer advisory lock for the
-duration of the write. A `dry_run=True` call reaches neither check, because it writes nothing.
-
-That per-call lock does not span two calls. Planning and then applying is two calls, and between them the lock is free, so
-another process can change a row you are about to write. Hold the lock yourself across the pair:
-
-```python
-from rekordbox_edit.api import edit
-from rekordbox_edit.locking import SCRIPTED_TIMEOUT, database_lock
-from rekordbox_edit.models import EditRequest
-
-args = EditRequest(field="Title", replace_value="Take 2", artist=["Alpha"], multi=True)
-
-with database_lock(db.db_directory, command="edit", timeout=SCRIPTED_TIMEOUT):
-    preview = edit(db, args, dry_run=True)
-    # ... decide which ops to keep ...
-    response = edit(db, args, ops=preview.result.edits)
-```
-
-The lock is re-entrant within a process, so the one each call takes nests inside yours at no cost. A lock held by another
-process raises [`DatabaseBusyError`][rekordbox_edit.errors.DatabaseBusyError].
-
-Without the outer lock the plan is still re-checked at apply time: an op whose row or file changed in the meantime is
-reported as a `db_or_fs_changed` skip rather than applied blindly.
+`edit`, `convert`, and `import_tracks` each have checks against concurrent writes. They will refuse to run while Rekordbox is open, raising
+[`RekordboxRunningError`][rekordbox_edit.errors.RekordboxRunningError], and each will grab a single-writer advisory lock for the
+duration of the write to prevent concurrent writes by other rekordbox-edit processes.
 
 ## Errors
 

--- a/docs/commands/convert.md
+++ b/docs/commands/convert.md
@@ -68,7 +68,7 @@ rbe convert --format-out mp3 --playlist "NeedsConverting" --threads 8 --yes
 
 - Without flags, `convert` shows every planned change and asks once before applying. `--interactive` confirms each track individually; `--dry-run` previews without writing; `--yes` confirms the default choice for all prompts without asking. `--interactive` cannot be combined with `--yes` or `--dry-run`.
 - `convert` will encode exactly the tracks the preview showed. If in between the time you're prompted and later confirm a new track that matches your filters lands in your library, it won't be included.
-- **Rekordbox running:** Writing while Rekordbox is open risks losing your changes, so `convert` refuses at the point it would write. The preview still runs, so an interactive run reports the refusal after you confirm. `--dry-run` is unaffected.
+- **Rekordbox running:** Writing while Rekordbox is open risks losing your changes, so `convert` will refuse to perform any writes. `--dry-run` is unaffected.
 - Before a large run, walk through the checklist in [What Should I Do Before Converting?](../faqs.md#what-should-i-do-before-converting)
 
 ## Reference

--- a/docs/commands/convert.md
+++ b/docs/commands/convert.md
@@ -66,9 +66,9 @@ rbe convert --format-out mp3 --playlist "NeedsConverting" --threads 8 --yes
 
 ### Checks
 
-- Without flags, `convert` shows every planned change and asks once before applying. `--interactive` confirms each track individually; `--dry-run` previews without writing; `--yes` confirms the default choice for all prompts without asking.
+- Without flags, `convert` shows every planned change and asks once before applying. `--interactive` confirms each track individually; `--dry-run` previews without writing; `--yes` confirms the default choice for all prompts without asking. `--interactive` cannot be combined with `--yes` or `--dry-run`.
 - `convert` will encode exactly the tracks the preview showed. If in between the time you're prompted and later confirm a new track that matches your filters lands in your library, it won't be included.
-- **Rekordbox running:** Writing while Rekordbox is open risks losing your changes, so `convert` refuses to run until you close it. `--dry-run` still works.
+- **Rekordbox running:** Writing while Rekordbox is open risks losing your changes, so `convert` refuses at the point it would write. The preview still runs, so an interactive run reports the refusal after you confirm. `--dry-run` is unaffected.
 - Before a large run, walk through the checklist in [What Should I Do Before Converting?](../faqs.md#what-should-i-do-before-converting)
 
 ## Reference

--- a/docs/commands/edit.md
+++ b/docs/commands/edit.md
@@ -15,7 +15,7 @@ rbe edit [OPTIONS] [TRACK-IDS]... FIELD
 rbe edit --exact-title "Untitled 3" Title --replace "Acid Rain"
 
 # Fix a typo across many titles (substring replacement)
-rbe edit --title "Teh" Title --match "Teh" --replace "The" --multi
+rbe edit --title "Teh" Title --match "Teh" --replace "The"
 ```
 
 ## FolderPath
@@ -36,7 +36,7 @@ By default edits will be skipped in the following cases:
 
 ```bash
 # Relocate a library folder in bulk
-rbe edit FolderPath --match "/Volumes/OldDrive/Music" --replace "/Volumes/NewDrive/Music" --multi
+rbe edit FolderPath --match "/Volumes/OldDrive/Music" --replace "/Volumes/NewDrive/Music"
 
 # Point one track at a replacement file
 rbe edit --exact-title "Acid Rain" FolderPath --replace "/Users/me/Music/acid-rain-remaster.flac"
@@ -44,19 +44,19 @@ rbe edit --exact-title "Acid Rain" FolderPath --replace "/Users/me/Music/acid-ra
 
 ## Checks
 
-- Without flags, `edit` shows every planned change and asks once before applying. `--interactive` confirms each track individually; `--dry-run` previews without writing; `--yes` confirms the default choice for all prompts without asking.
+- Without flags, `edit` shows every planned change and asks once before applying. `--interactive` confirms each track individually; `--dry-run` previews without writing; `--yes` confirms the default choice for all prompts without asking. `--interactive` cannot be combined with `--yes` or `--dry-run`.
 - `edit` writes exactly the tracks the preview showed. If in between the time you're prompted and later confirm a new track that matches your filters lands in your library, it won't be included. A track whose file changed in that window is skipped rather than written with stale metadata.
-- When filters match more than one track, `edit` refuses unless you pass `--multi`. This prevents an mistakenly broad filter from making unintended edits across your library.
-- **Rekordbox running:** writing while Rekordbox is open risks losing your changes, so `edit` refuses to run until you close it. `--dry-run` still works.
+- When filters match more than one track, an unattended run refuses unless you pass `--multi`. This prevents a mistakenly broad filter from editing across your library with nobody watching. A run that shows you the tracks and waits for an answer does not need the flag, so `--dry-run` and `--interactive` are unaffected.
+- **Rekordbox running:** writing while Rekordbox is open risks losing your changes, so `edit` refuses at the point it would write. The preview still runs, so an interactive run reports the refusal after you confirm. `--dry-run` is unaffected.
 
 ## Examples
 
 ```bash
 # Preview a cleanup without touching the database
-rbe edit --title "(Original Mix)" Title --match " (Original Mix)" --replace "" --multi --dry-run
+rbe edit --title "(Original Mix)" Title --match " (Original Mix)" --replace "" --dry-run
 
 # Apply it, confirming each track
-rbe edit --title "(Original Mix)" Title --match " (Original Mix)" --replace "" --multi --interactive
+rbe edit --title "(Original Mix)" Title --match " (Original Mix)" --replace "" --interactive
 
 # Pipe a search result in and edit those exact tracks
 rbe search --playlist "Mislabeled" --print ids | rbe edit Title --match "  " --replace " " --multi --yes

--- a/docs/commands/edit.md
+++ b/docs/commands/edit.md
@@ -45,10 +45,9 @@ rbe edit --exact-title "Acid Rain" FolderPath --replace "/Users/me/Music/acid-ra
 ## Checks
 
 - Without flags, `edit` shows every planned change and asks once before applying. `--interactive` confirms each track individually; `--dry-run` previews without writing; `--yes` confirms the default choice for all prompts without asking. `--interactive` cannot be combined with `--yes` or `--dry-run`.
-- Tracks your filters matched but `edit` did not touch are reported with the reason, so a filter matching 30 tracks and editing 4 does not look like it found 4.
-- `edit` writes exactly the tracks the preview showed. If in between the time you're prompted and later confirm a new track that matches your filters lands in your library, it won't be included. A track whose file changed in that window is skipped rather than written with stale metadata.
-- When filters match more than one track, an unattended run refuses unless you pass `--multi`. This prevents a mistakenly broad filter from editing across your library with nobody watching. A run that shows you the tracks and waits for an answer does not need the flag, so `--dry-run` and `--interactive` are unaffected.
-- **Rekordbox running:** writing while Rekordbox is open risks losing your changes, so `edit` refuses at the point it would write. The preview still runs, so an interactive run reports the refusal after you confirm. `--dry-run` is unaffected.
+- `edit` writes exactly the tracks the preview showed. If in between the time you're prompted and later confirm a new track lands in your library that matches your filters, it won't be included. A track whose file changed in that window is skipped rather than written with stale metadata.
+- When filters match more than one track, an unattended run (i.e. `--yes`) refuses unless you pass `--multi`. This prevents a mistakenly broad filter from editing across many tracks mistakenly. `--dry-run` and `--interactive` are unaffected.
+- **Rekordbox running:** writing while Rekordbox is open risks losing your changes, so `edit` will refuse to perform any writes. `--dry-run` is unaffected.
 
 ## Examples
 

--- a/docs/commands/edit.md
+++ b/docs/commands/edit.md
@@ -45,6 +45,7 @@ rbe edit --exact-title "Acid Rain" FolderPath --replace "/Users/me/Music/acid-ra
 ## Checks
 
 - Without flags, `edit` shows every planned change and asks once before applying. `--interactive` confirms each track individually; `--dry-run` previews without writing; `--yes` confirms the default choice for all prompts without asking. `--interactive` cannot be combined with `--yes` or `--dry-run`.
+- Tracks your filters matched but `edit` did not touch are reported with the reason, so a filter matching 30 tracks and editing 4 does not look like it found 4.
 - `edit` writes exactly the tracks the preview showed. If in between the time you're prompted and later confirm a new track that matches your filters lands in your library, it won't be included. A track whose file changed in that window is skipped rather than written with stale metadata.
 - When filters match more than one track, an unattended run refuses unless you pass `--multi`. This prevents a mistakenly broad filter from editing across your library with nobody watching. A run that shows you the tracks and waits for an answer does not need the flag, so `--dry-run` and `--interactive` are unaffected.
 - **Rekordbox running:** writing while Rekordbox is open risks losing your changes, so `edit` refuses at the point it would write. The preview still runs, so an interactive run reports the refusal after you confirm. `--dry-run` is unaffected.

--- a/docs/commands/import.md
+++ b/docs/commands/import.md
@@ -33,7 +33,7 @@ A file that already has a row in the library but is missing from the named playl
 
 ## Directories
 
-A directory argument is walked recursively for audio files. Ran interactively, `import` reports how many files it found and asks you to confirm before continuing. `--yes` skips this prompt, and is required when providing a non-interactive `--print` mode and a directory argument.
+A directory argument is walked recursively for audio files. Ran interactively, `import` reports how many files it found and asks you to confirm before continuing. `--yes` authorizes the walk outright, and is required when providing a non-interactive `--print` mode and a directory argument. `--dry-run` also walks without asking, since it writes nothing and previewing is how you inspect what a walk covers.
 
 The walk happens once, before the preview. A file dropped into the directory while you are answering the prompt is not imported, since `import` writes exactly the files it showed you.
 
@@ -43,8 +43,8 @@ A file already in the library, matched by its resolved, case-insensitive path, i
 
 ## Checks
 
-- Without flags, `import` shows every track it plans to add and asks once before writing; `--dry-run` previews without writing; `--yes` confirms the default choice for all prompts without asking.
-- **Rekordbox running:** writing while Rekordbox is open risks losing your changes, so `import` refuses to run until you close it. `--dry-run` still works.
+- Without flags, `import` shows every track it plans to add and asks once before writing; `--interactive` asks about each file separately; `--dry-run` previews without writing; `--yes` confirms the default choice for all prompts without asking. `--interactive` cannot be combined with `--yes` or `--dry-run`.
+- **Rekordbox running:** writing while Rekordbox is open risks losing your changes, so `import` refuses at the point it would write. The preview still runs, so an interactive run reports the refusal after you confirm. `--dry-run` is unaffected.
 
 ## Reference
 

--- a/docs/commands/import.md
+++ b/docs/commands/import.md
@@ -31,12 +31,6 @@ It does not analyze audio. `SampleRate`, `BitDepth`, and `BPM` read as `0` on a 
 
 A file that already has a row in the library but is missing from the named playlist is added to that playlist rather than skipped outright.
 
-## Directories
-
-A directory argument is walked recursively for audio files. Ran interactively, `import` reports how many files it found and asks you to confirm before continuing. `--yes` authorizes the walk outright, and is required when providing a non-interactive `--print` mode and a directory argument. `--dry-run` also walks without asking, since it writes nothing and previewing is how you inspect what a walk covers.
-
-The walk happens once, before the preview. A file dropped into the directory while you are answering the prompt is not imported, since `import` writes exactly the files it showed you.
-
 ## Skipped Files
 
 A file already in the library, matched by its resolved, case-insensitive path, is skipped rather than duplicated. One that cannot be read as audio, or that is not an audio file at all, is skipped with a warning, and the rest of the batch continues. A file that disappears between the preview and the write is skipped too.
@@ -44,7 +38,8 @@ A file already in the library, matched by its resolved, case-insensitive path, i
 ## Checks
 
 - Without flags, `import` shows every track it plans to add and asks once before writing; `--interactive` asks about each file separately; `--dry-run` previews without writing; `--yes` confirms the default choice for all prompts without asking. `--interactive` cannot be combined with `--yes` or `--dry-run`.
-- **Rekordbox running:** writing while Rekordbox is open risks losing your changes, so `import` refuses at the point it would write. The preview still runs, so an interactive run reports the refusal after you confirm. `--dry-run` is unaffected.
+- A directory argument is walked recursively for audio files. Ran interactively, `import` reports how many files it found and asks before continuing. `--yes` authorizes the walk outright, and is required alongside a non-interactive `--print` mode. `--dry-run` walks without asking, since it writes nothing.
+- **Rekordbox running:** writing while Rekordbox is open risks losing your changes, so `import` will refuse to perform any writes. `--dry-run` is unaffected.
 
 ## Reference
 

--- a/rekordbox_edit/__init__.py
+++ b/rekordbox_edit/__init__.py
@@ -4,6 +4,6 @@ __version__ = "0.1.0"
 __author__ = "James Viall"
 __email__ = "jamesviall@pm.me"
 
-from rekordbox_edit.api import convert, edit, search
+from rekordbox_edit.api import convert, edit, import_tracks, search
 
-__all__ = ["search", "edit", "convert"]
+__all__ = ["search", "edit", "convert", "import_tracks"]

--- a/rekordbox_edit/api/_utils.py
+++ b/rekordbox_edit/api/_utils.py
@@ -1,11 +1,15 @@
 import logging
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
 from typing import Any
 
 from pyrekordbox import Rekordbox6Database
 from pyrekordbox.db6 import DjmdContent
+from pyrekordbox.utils import get_rekordbox_pid
 from sqlalchemy import text
 
+from rekordbox_edit.errors import RekordboxRunningError
+from rekordbox_edit.locking import SCRIPTED_TIMEOUT, database_lock
 from rekordbox_edit.models import ConvertOp, EditOp, Track
 from rekordbox_edit.query import require_session
 from rekordbox_edit.utils import AudioInfo, get_file_type_for_format
@@ -13,6 +17,26 @@ from rekordbox_edit.utils import AudioInfo, get_file_type_for_format
 logger = logging.getLogger(__name__)
 
 _COLUMN_KEYS = tuple(c.key for c in DjmdContent.__table__.columns)
+
+
+@contextmanager
+def writing(db: Rekordbox6Database, command: str) -> Iterator[None]:
+    """Guard a block that writes to the library.
+
+    Refuses to run while Rekordbox is open, then holds the single-writer lock
+    for the block. Every API write enters through here, so a caller gets both
+    without knowing they exist; the CLI's own lock nests harmlessly inside.
+
+    Wraps only the writing region, so a dry run reaches neither check.
+    """
+    rekordbox_pid = get_rekordbox_pid()
+    if rekordbox_pid:
+        raise RekordboxRunningError(
+            f"Rekordbox is running (PID {rekordbox_pid}). Close it before "
+            "writing to the database."
+        )
+    with database_lock(db.db_directory, command=command, timeout=SCRIPTED_TIMEOUT):
+        yield
 
 
 def _track_from_content(content: DjmdContent) -> Track:

--- a/rekordbox_edit/api/convert.py
+++ b/rekordbox_edit/api/convert.py
@@ -19,6 +19,7 @@ from rekordbox_edit.api._utils import (
     _sync_audio_columns,
     _update_anlz_paths,
     stamp_usns,
+    writing,
 )
 from rekordbox_edit.errors import OperationAborted
 from rekordbox_edit.models import (
@@ -577,151 +578,156 @@ def convert(
 
     assert db.session is not None
 
-    # content_map enables per-op live FolderPath / FileNameL reads in the loop.
-    content_map = {str(c.ID): c for c in contents}
-    converted_ops: list[ConvertOp] = []
-    _sweep_orphan_temp_files(op.output_path for op in ops)
+    # Guards the sweep as well as the encode loop: the sweep deletes temp
+    # files, which a concurrent run would still be writing into.
+    with writing(db, "convert"):
+        # content_map enables per-op live FolderPath / FileNameL reads in the loop.
+        content_map = {str(c.ID): c for c in contents}
+        converted_ops: list[ConvertOp] = []
+        _sweep_orphan_temp_files(op.output_path for op in ops)
 
-    output_format_name = args.format_out.upper()
-    deletable = 0
-    deleted = 0
+        output_format_name = args.format_out.upper()
+        deletable = 0
+        deleted = 0
 
-    jobs = [_encode_job_for(content_map[op.id], op, output_format_name) for op in ops]
-    if progress:
-        progress.batch_size(len(jobs))
+        jobs = [
+            _encode_job_for(content_map[op.id], op, output_format_name) for op in ops
+        ]
+        if progress:
+            progress.batch_size(len(jobs))
 
-    def _abort_batch(
-        exc: BaseException, job: _EncodeJob, attempted: int
-    ) -> ConvertAborted:
-        """Give up on the batch, keeping every conversion already committed."""
-        _rollback_session(db)
-        logger.debug(
-            f"convert aborted at {job.source_path} after "
-            f"{len(converted_ops)} committed conversion(s)"
-        )
-        return ConvertAborted(
-            str(exc),
-            failed_path=job.source_path,
-            converted=len(converted_ops),
-            not_attempted=len(ops) - attempted,
-        )
-
-    # Encoding runs on worker threads; every database touch stays here on the
-    # main thread. `encoding` maps a job's position in `jobs` to the worker
-    # currently handling it.
-    thread_count = args.threads
-    encoding: dict[int, Future[_EncodeResult]] = {}
-
-    with ThreadPoolExecutor(max_workers=thread_count) as pool:
-
-        def _start_encode(index: int) -> None:
-            """Hand job `index` to a worker, if the batch runs that far."""
-            if index < len(jobs):
-                encoding[index] = pool.submit(_encode_one, jobs[index])
-                if progress:
-                    progress.started(index, jobs[index].file_name)
-
-        def _stop_pending_encodes() -> None:
-            """Give up on everything still in flight, leaving no stray files.
-
-            Cancelling only stops work no worker has picked up yet, so an
-            encode that already finished holds a temp file nobody will move
-            into place. Those are deleted here rather than left for the next
-            run's sweep.
-            """
-            for future in encoding.values():
-                future.cancel()
-            for index, future in encoding.items():
-                if future.cancelled() or future.exception() is not None:
-                    continue
-                if future.result().skipped is None:
-                    _remove_temp_file(jobs[index].temp_path)
-            encoding.clear()
-
-        # Prime the pool with one file per worker. Nothing more starts until a
-        # result is collected below, so at most `thread_count` files are ever
-        # in flight, and an abort has wasted at most that many encodes.
-        for index in range(min(thread_count, len(jobs))):
-            _start_encode(index)
-
-        # Collect results in the order the files were listed rather than the
-        # order they happen to finish: waiting on `encoding[index]` blocks
-        # until that particular file is done, so one that finished early simply
-        # waits its turn. `index` walks `jobs`; `position` is the same count
-        # from one, for the progress line. Predictable order matters because
-        # `rbe convert --print ids` feeds other commands.
-        for index, (op, job) in enumerate(zip(ops, jobs)):
-            position = index + 1
-            content = content_map[op.id]
-
-            try:
-                result = encoding.pop(index).result()
-            except KeyboardInterrupt as e:
-                _stop_pending_encodes()
-                logger.warning("Interrupted; keeping the files already converted.")
-                raise _abort_batch(e, job, position) from e
-            except BaseException as e:
-                _stop_pending_encodes()
-                raise _abort_batch(e, job, position) from e
-
-            # A worker just came free, so give it the next file nobody has
-            # started. Starting one only after a successful collection is what
-            # keeps the in-flight count capped and leaves no queued work behind
-            # on an abort.
-            _start_encode(index + thread_count)
-
-            if progress:
-                progress.finished(index, converted=result.skipped is None)
-
-            if result.skipped:
-                skipped.append(result.skipped)
-                continue
-
-            # Printed on completion rather than at dispatch: with several
-            # encodes in flight, a line printed at dispatch would name a file
-            # that is not the one being worked on next.
-            logger.info(f"[{position}/{len(ops)}] converted {job.file_name}")
-
-            try:
-                os.replace(job.temp_path, job.output_path)
-                _apply_converted_record(
-                    content,
-                    cast(ConvertedFileProbe, result.probe),
-                    os.path.basename(job.output_path),
-                    os.path.dirname(job.output_path),
-                    output_format_name,
-                )
-                stamp_usns(db, [content])
-                db.session.commit()
-            except BaseException as e:
-                _remove_temp_file(job.temp_path)
-                _stop_pending_encodes()
-                raise _abort_batch(e, job, position) from e
-
-            converted_ops.append(
-                op.model_copy(
-                    update={
-                        "source_path": job.source_path,
-                        "output_sample_rate": result.output_sample_rate,
-                    }
-                )
+        def _abort_batch(
+            exc: BaseException, job: _EncodeJob, attempted: int
+        ) -> ConvertAborted:
+            """Give up on the batch, keeping every conversion already committed."""
+            _rollback_session(db)
+            logger.debug(
+                f"convert aborted at {job.source_path} after "
+                f"{len(converted_ops)} committed conversion(s)"
+            )
+            return ConvertAborted(
+                str(exc),
+                failed_path=job.source_path,
+                converted=len(converted_ops),
+                not_attempted=len(ops) - attempted,
             )
 
-            # Past this point the row is committed, so every failure only warns.
-            try:
-                _update_anlz_paths(db, content, os.path.basename(job.output_path))
-            except Exception as e:
-                logger.warning(
-                    f"Failed to update ANLZ path tags for {job.file_name}: {e}"
+        # Encoding runs on worker threads; every database touch stays here on the
+        # main thread. `encoding` maps a job's position in `jobs` to the worker
+        # currently handling it.
+        thread_count = args.threads
+        encoding: dict[int, Future[_EncodeResult]] = {}
+
+        with ThreadPoolExecutor(max_workers=thread_count) as pool:
+
+            def _start_encode(index: int) -> None:
+                """Hand job `index` to a worker, if the batch runs that far."""
+                if index < len(jobs):
+                    encoding[index] = pool.submit(_encode_one, jobs[index])
+                    if progress:
+                        progress.started(index, jobs[index].file_name)
+
+            def _stop_pending_encodes() -> None:
+                """Give up on everything still in flight, leaving no stray files.
+
+                Cancelling only stops work no worker has picked up yet, so an
+                encode that already finished holds a temp file nobody will move
+                into place. Those are deleted here rather than left for the next
+                run's sweep.
+                """
+                for future in encoding.values():
+                    future.cancel()
+                for index, future in encoding.items():
+                    if future.cancelled() or future.exception() is not None:
+                        continue
+                    if future.result().skipped is None:
+                        _remove_temp_file(jobs[index].temp_path)
+                encoding.clear()
+
+            # Prime the pool with one file per worker. Nothing more starts until a
+            # result is collected below, so at most `thread_count` files are ever
+            # in flight, and an abort has wasted at most that many encodes.
+            for index in range(min(thread_count, len(jobs))):
+                _start_encode(index)
+
+            # Collect results in the order the files were listed rather than the
+            # order they happen to finish: waiting on `encoding[index]` blocks
+            # until that particular file is done, so one that finished early simply
+            # waits its turn. `index` walks `jobs`; `position` is the same count
+            # from one, for the progress line. Predictable order matters because
+            # `rbe convert --print ids` feeds other commands.
+            for index, (op, job) in enumerate(zip(ops, jobs)):
+                position = index + 1
+                content = content_map[op.id]
+
+                try:
+                    result = encoding.pop(index).result()
+                except KeyboardInterrupt as e:
+                    _stop_pending_encodes()
+                    logger.warning("Interrupted; keeping the files already converted.")
+                    raise _abort_batch(e, job, position) from e
+                except BaseException as e:
+                    _stop_pending_encodes()
+                    raise _abort_batch(e, job, position) from e
+
+                # A worker just came free, so give it the next file nobody has
+                # started. Starting one only after a successful collection is what
+                # keeps the in-flight count capped and leaves no queued work behind
+                # on an abort.
+                _start_encode(index + thread_count)
+
+                if progress:
+                    progress.finished(index, converted=result.skipped is None)
+
+                if result.skipped:
+                    skipped.append(result.skipped)
+                    continue
+
+                # Printed on completion rather than at dispatch: with several
+                # encodes in flight, a line printed at dispatch would name a file
+                # that is not the one being worked on next.
+                logger.info(f"[{position}/{len(ops)}] converted {job.file_name}")
+
+                try:
+                    os.replace(job.temp_path, job.output_path)
+                    _apply_converted_record(
+                        content,
+                        cast(ConvertedFileProbe, result.probe),
+                        os.path.basename(job.output_path),
+                        os.path.dirname(job.output_path),
+                        output_format_name,
+                    )
+                    stamp_usns(db, [content])
+                    db.session.commit()
+                except BaseException as e:
+                    _remove_temp_file(job.temp_path)
+                    _stop_pending_encodes()
+                    raise _abort_batch(e, job, position) from e
+
+                converted_ops.append(
+                    op.model_copy(
+                        update={
+                            "source_path": job.source_path,
+                            "output_sample_rate": result.output_sample_rate,
+                        }
+                    )
                 )
 
-            if _deletes_original(args.delete_originals, result.is_lossless):
-                deletable += 1
+                # Past this point the row is committed, so every failure only warns.
                 try:
-                    os.remove(job.source_path)
-                    deleted += 1
+                    _update_anlz_paths(db, content, os.path.basename(job.output_path))
                 except Exception as e:
-                    logger.warning(f"Failed to delete {job.source_path}: {e}")
+                    logger.warning(
+                        f"Failed to update ANLZ path tags for {job.file_name}: {e}"
+                    )
+
+                if _deletes_original(args.delete_originals, result.is_lossless):
+                    deletable += 1
+                    try:
+                        os.remove(job.source_path)
+                        deleted += 1
+                    except Exception as e:
+                        logger.warning(f"Failed to delete {job.source_path}: {e}")
 
     logger.debug(f"convert committed {len(converted_ops)} conversion(s)")
 

--- a/rekordbox_edit/api/convert.py
+++ b/rekordbox_edit/api/convert.py
@@ -38,6 +38,7 @@ from rekordbox_edit.utils import (
     get_file_type_for_format,
     get_file_type_name,
     probe_matches_file_type,
+    require_ffmpeg,
 )
 
 logger = logging.getLogger(__name__)
@@ -124,10 +125,7 @@ def _mp3_output_kwargs(sample_rate) -> dict:
 def _run_ffmpeg(input_path, output_path, output_kwargs: dict, label: str) -> bool:
     """Run a single ffmpeg conversion. Returns True on success, False on an
     ffmpeg error; re-raises anything else. `label` names the target for logs."""
-    from rekordbox_edit.utils import ffmpeg_in_path, get_ffmpeg_directions
-
-    if not ffmpeg_in_path():
-        raise Exception(f"FFmpeg not found in PATH.{get_ffmpeg_directions()}")
+    require_ffmpeg()
 
     try:
         (
@@ -517,15 +515,8 @@ def convert(
     op's paths are re-checked and reported as `db_or_fs_changed` if they no
     longer hold.
     """
-    from rekordbox_edit.utils import ffmpeg_in_path, get_ffmpeg_directions
-
     logger.debug(f"convert start format_out={args.format_out} dry_run={dry_run}")
-
-    if not ffmpeg_in_path():
-        logger.debug("convert aborted: FFmpeg not in PATH")
-        raise RuntimeError(
-            f"FFmpeg is required but not found in PATH.{get_ffmpeg_directions()}"
-        )
+    require_ffmpeg()
 
     planned: list[ConvertOp] = []
     skipped: list[SkippedTrack] = []

--- a/rekordbox_edit/api/convert.py
+++ b/rekordbox_edit/api/convert.py
@@ -20,6 +20,7 @@ from rekordbox_edit.api._utils import (
     _update_anlz_paths,
     stamp_usns,
 )
+from rekordbox_edit.errors import OperationAborted
 from rekordbox_edit.models import (
     ConvertOp,
     ConvertRequest,
@@ -368,7 +369,7 @@ def _sweep_orphan_temp_files(output_paths: Iterable[str]) -> None:
         logger.debug(f"convert swept {removed} orphaned temp file(s)")
 
 
-class ConvertAborted(RuntimeError):
+class ConvertAborted(OperationAborted):
     """A conversion failed partway through a batch.
 
     Files converted before the failure are already committed, so the counts

--- a/rekordbox_edit/api/edit.py
+++ b/rekordbox_edit/api/edit.py
@@ -4,7 +4,7 @@ import logging
 
 from pyrekordbox import Rekordbox6Database
 
-from rekordbox_edit.api._utils import _order_tracks_by_op, stamp_usns
+from rekordbox_edit.api._utils import _order_tracks_by_op, stamp_usns, writing
 from rekordbox_edit.api.field_handlers import FIELD_HANDLERS
 from rekordbox_edit.errors import InputError
 from rekordbox_edit.models import (
@@ -138,18 +138,19 @@ def edit(
     new_values = {op.id: op.new_value for op in ops}
     old_values: dict[str, str | None] = {}
     edited = []
-    for content in contents:
-        if str(content.ID) in new_values:
-            old_values[str(content.ID)] = handler.current_value(content)
-            handler.apply(db, content, new_values[str(content.ID)])
-            edited.append(content)
-    stamp_usns(db, edited)
-    db.session.commit()
-    logger.debug(f"edit committed {len(ops)} change(s) on field={args.field}")
+    with writing(db, "edit"):
+        for content in contents:
+            if str(content.ID) in new_values:
+                old_values[str(content.ID)] = handler.current_value(content)
+                handler.apply(db, content, new_values[str(content.ID)])
+                edited.append(content)
+        stamp_usns(db, edited)
+        db.session.commit()
+        logger.debug(f"edit committed {len(ops)} change(s) on field={args.field}")
 
-    for content in contents:
-        if str(content.ID) in new_values:
-            handler.post_commit(db, content, old_values[str(content.ID)])
+        for content in contents:
+            if str(content.ID) in new_values:
+                handler.post_commit(db, content, old_values[str(content.ID)])
 
     return EditResponse(
         tracks=_order_tracks_by_op(contents, ops),

--- a/rekordbox_edit/api/edit.py
+++ b/rekordbox_edit/api/edit.py
@@ -8,8 +8,8 @@ from rekordbox_edit.api._utils import _order_tracks_by_op, stamp_usns, writing
 from rekordbox_edit.api.field_handlers import FIELD_HANDLERS
 from rekordbox_edit.errors import InputError
 from rekordbox_edit.models import (
-    EditRequest,
     EditOp,
+    EditRequest,
     EditResponse,
     EditResult,
     SkippedTrack,
@@ -71,7 +71,7 @@ def edit(
     With `dry_run=False` (default), commits the changes.
 
     Pass `ops` to apply an already-approved plan. No filter runs, so a row
-    that started matching since the plan was made cannot join the edit; each
+    that started matching after the plan was made will not join the edit; each
     op is re-checked against the filesystem and reported as
     `db_or_fs_changed` if it no longer holds.
 

--- a/rekordbox_edit/api/edit.py
+++ b/rekordbox_edit/api/edit.py
@@ -74,6 +74,10 @@ def edit(
     that started matching since the plan was made cannot join the edit; each
     op is re-checked against the filesystem and reported as
     `db_or_fs_changed` if it no longer holds.
+
+    `multi` guards the unattended case: a filter matching several rows applied
+    in one shot. A dry run only reports, and an `ops` list was approved by
+    whoever built it, so neither needs the flag.
     """
     logger.debug(f"edit start field={args.field} dry_run={dry_run}")
     handler = FIELD_HANDLERS.get(args.field)
@@ -95,7 +99,7 @@ def edit(
                 skipped.append(result)
         logger.debug(f"edit classified ops={len(planned)} skipped={len(skipped)}")
 
-        if len(planned) > 1 and not args.multi:
+        if not dry_run and len(planned) > 1 and not args.multi:
             logger.debug(f"edit aborted on multi guard with {len(planned)} ops")
             raise InputError(
                 f"Found {len(planned)} tracks that would be edited. "

--- a/rekordbox_edit/api/edit.py
+++ b/rekordbox_edit/api/edit.py
@@ -6,6 +6,7 @@ from pyrekordbox import Rekordbox6Database
 
 from rekordbox_edit.api._utils import _order_tracks_by_op, stamp_usns
 from rekordbox_edit.api.field_handlers import FIELD_HANDLERS
+from rekordbox_edit.errors import InputError
 from rekordbox_edit.models import (
     EditRequest,
     EditOp,
@@ -77,7 +78,7 @@ def edit(
     logger.debug(f"edit start field={args.field} dry_run={dry_run}")
     handler = FIELD_HANDLERS.get(args.field)
     if handler is None:
-        raise ValueError(f"Unknown field: {args.field!r}")
+        raise InputError(f"Unknown field: {args.field!r}")
     handler.validate_request(args)
 
     planned: list[EditOp] = []
@@ -96,7 +97,7 @@ def edit(
 
         if len(planned) > 1 and not args.multi:
             logger.debug(f"edit aborted on multi guard with {len(planned)} ops")
-            raise ValueError(
+            raise InputError(
                 f"Found {len(planned)} tracks that would be edited. "
                 "Refine your filters, use dry_run to inspect, or pass multi=True to edit all."
             )

--- a/rekordbox_edit/api/field_handlers.py
+++ b/rekordbox_edit/api/field_handlers.py
@@ -34,6 +34,14 @@ class FieldHandler:
     name: str
     supports_match: bool = True
 
+    forceable_skip_reasons: frozenset[SkipReason] = frozenset()
+    """Reasons this handler's validate_track returns that `force` overrides.
+
+    Declared here so a caller offering to retry with force does not have to
+    keep its own copy of what force covers, which would silently stop covering
+    a reason added later.
+    """
+
     def validate_request(self, args: EditRequest) -> None:
         """Validate request-level input. Raise ValueError on bad input."""
 
@@ -221,6 +229,7 @@ class FolderPathField(FieldHandler):
 
     name = "FolderPath"
     supports_match = True
+    forceable_skip_reasons = frozenset({"file_not_found", "length_mismatch"})
 
     _LENGTH_TOLERANCE_SECONDS = 1.0
 

--- a/rekordbox_edit/api/field_handlers.py
+++ b/rekordbox_edit/api/field_handlers.py
@@ -264,8 +264,8 @@ class FolderPathField(FieldHandler):
         try:
             probe = get_audio_info(new_value)
         except DependencyMissingError:
-            # A missing install is not a property of this track, so it must not
-            # be reported as one; every track would skip for the wrong reason.
+            # A missing install is not a property of this track
+            # Re-raise up to the handler so that we can prompt for install
             raise
         except Exception:
             return "unknown_file_type"

--- a/rekordbox_edit/api/field_handlers.py
+++ b/rekordbox_edit/api/field_handlers.py
@@ -14,6 +14,7 @@ from pyrekordbox.db6 import tables as tb
 from sqlalchemy import or_
 
 from rekordbox_edit.api._utils import _sync_audio_columns, _update_anlz_paths
+from rekordbox_edit.errors import DependencyMissingError
 from rekordbox_edit.models import EditRequest, SkipReason
 from rekordbox_edit.utils import (
     AudioInfo,
@@ -253,6 +254,10 @@ class FolderPathField(FieldHandler):
             return None  # byte-identical file: nothing to probe or sync
         try:
             probe = get_audio_info(new_value)
+        except DependencyMissingError:
+            # A missing install is not a property of this track, so it must not
+            # be reported as one; every track would skip for the wrong reason.
+            raise
         except Exception:
             return "unknown_file_type"
         if get_file_type_for_probe(probe["codec"], probe["container"]) is None:

--- a/rekordbox_edit/api/import_.py
+++ b/rekordbox_edit/api/import_.py
@@ -10,6 +10,7 @@ from pyrekordbox import Rekordbox6Database
 from pyrekordbox.db6 import tables as tb
 
 from rekordbox_edit.api._utils import _track_from_content, stamp_usns
+from rekordbox_edit.errors import InputError
 from rekordbox_edit.models import (
     ImportOp,
     ImportRequest,
@@ -45,10 +46,10 @@ UNMAPPED_EXTENSIONS = frozenset(
 )
 
 
-class ImportInputError(ValueError):
+class ImportInputError(InputError):
     """The request itself is invalid: a path that does not exist, an
     unconfirmed directory argument, or a playlist name that matches no
-    playlist or more than one. Distinct from a write-phase ValueError, which
+    playlist or more than one. Distinct from a write-phase failure, which
     means the database failed and must not be reported as user error."""
 
 

--- a/rekordbox_edit/api/import_.py
+++ b/rekordbox_edit/api/import_.py
@@ -9,7 +9,7 @@ from typing import NamedTuple, cast
 from pyrekordbox import Rekordbox6Database
 from pyrekordbox.db6 import tables as tb
 
-from rekordbox_edit.api._utils import _track_from_content, stamp_usns
+from rekordbox_edit.api._utils import _track_from_content, stamp_usns, writing
 from rekordbox_edit.errors import InputError
 from rekordbox_edit.models import (
     ImportOp,
@@ -438,27 +438,30 @@ def import_tracks(
 
     applied: list[ImportOp] = []
     written: list[tb.DjmdContent] = []
-    try:
-        # Relational rows created along the way each take a USN too.
-        incidental: list = []
-        for op, candidate in planned:
-            if op.action == "create":
-                content = _build_content(db, candidate, incidental)
-                applied.append(op.model_copy(update={"id": str(content.ID)}))
-            else:
-                content = existing[candidate.key]
-                applied.append(op)
-            written.append(content)
-            if playlist is not None:
-                db.add_to_playlist(playlist, content)
+    with writing(db, "import"):
+        try:
+            # Relational rows created along the way each take a USN too.
+            incidental: list = []
+            for op, candidate in planned:
+                if op.action == "create":
+                    content = _build_content(db, candidate, incidental)
+                    applied.append(op.model_copy(update={"id": str(content.ID)}))
+                else:
+                    content = existing[candidate.key]
+                    applied.append(op)
+                written.append(content)
+                if playlist is not None:
+                    db.add_to_playlist(playlist, content)
 
-        stamp_usns(db, [*written, *incidental])
-        session.commit()
-        logger.debug(f"import committed {len(applied)} row(s)")
-    except BaseException:
-        logger.error(f"import rolling back after {len(applied)} partial operation(s)")
-        session.rollback()
-        raise
+            stamp_usns(db, [*written, *incidental])
+            session.commit()
+            logger.debug(f"import committed {len(applied)} row(s)")
+        except BaseException:
+            logger.error(
+                f"import rolling back after {len(applied)} partial operation(s)"
+            )
+            session.rollback()
+            raise
 
     tracks = [_track_from_content(content) for content in written]
     return _response(tracks, args.playlist, applied, skipped)

--- a/rekordbox_edit/cli/_click.py
+++ b/rekordbox_edit/cli/_click.py
@@ -1,18 +1,11 @@
-from enum import Enum
+"""Click option and argument definitions shared by the commands."""
+
 from pathlib import Path
 
 import click
 
+from rekordbox_edit.logger import PrintChoice
 from rekordbox_edit.models import DEFAULT_THREADS
-
-
-class PrintChoice(Enum):
-    SILENT = 0
-    IDS = 1
-    INFO = 2
-    DEBUG = 3
-    JSON = 4
-
 
 print_option = click.option(
     "--print",
@@ -167,7 +160,7 @@ edit_click_options = [
     click.option(
         "--multi",
         is_flag=True,
-        help="Allow editing more than one track (required when filters match multiple tracks)",
+        help="Allow editing more than one track (required when --yes applies a filter matching several)",
     ),
     click.option(
         "--force",

--- a/rekordbox_edit/cli/_utils.py
+++ b/rekordbox_edit/cli/_utils.py
@@ -10,7 +10,6 @@ from typing import TypeVar
 import click
 from pydantic import BaseModel, ValidationError
 from pyrekordbox import Rekordbox6Database
-from pyrekordbox.utils import get_rekordbox_pid
 from sqlalchemy import event
 from sqlalchemy.engine import Engine
 
@@ -79,19 +78,6 @@ def _print_response_json(response: BaseModel) -> None:
     print(response.model_dump_json())
 
 
-def _refuse_while_rekordbox_runs() -> None:
-    """Exit if Rekordbox is open. Writing underneath it risks losing changes:
-    it holds rows in memory and can write its own copy back over ours."""
-    rekordbox_pid = get_rekordbox_pid()
-    if not rekordbox_pid:
-        return
-    logger.error(
-        f"Rekordbox is running (PID {rekordbox_pid}). Close it before writing "
-        "to the database."
-    )
-    sys.exit(1)
-
-
 @event.listens_for(Engine, "connect")
 def _set_busy_timeout(dbapi_connection, _record) -> None:
     """Make SQLite wait instead of failing immediately on a contended write lock.
@@ -127,9 +113,11 @@ def _write_lock(db, kwargs):
 def with_database(*, writes: bool = False):
     """Inject an opened Rekordbox6Database as `db` and close it on exit.
 
-    Pass writes=True for commands that modify the DB: the wrapper aborts when
-    Rekordbox is running, and holds the single-writer advisory lock for the
-    whole run. A dry run gets neither, since it writes nothing.
+    Pass writes=True for commands that modify the DB: the wrapper holds the
+    single-writer advisory lock across the whole run, so the plan and apply
+    passes cannot be interleaved by another process. The API takes that lock
+    again per write, which nests harmlessly, and owns the refusal to run while
+    Rekordbox is open.
 
     Also the one place API errors become CLI ones, so no command repeats the
     mapping: bad input is a usage error, and an unusable environment logs and
@@ -140,8 +128,6 @@ def with_database(*, writes: bool = False):
         @database_path_option
         @functools.wraps(func)
         def wrapper(**kwargs):
-            if writes and not kwargs.get("dry_run"):
-                _refuse_while_rekordbox_runs()
             database_path: str | None = kwargs.pop("database_path", None)
             db = Rekordbox6Database(path=database_path)  # ty: ignore[invalid-argument-type]
             try:

--- a/rekordbox_edit/cli/_utils.py
+++ b/rekordbox_edit/cli/_utils.py
@@ -10,8 +10,6 @@ from typing import TypeVar
 import click
 from pydantic import BaseModel, ValidationError
 from pyrekordbox import Rekordbox6Database
-from sqlalchemy import event
-from sqlalchemy.engine import Engine
 
 from rekordbox_edit._click import PrintChoice, database_path_option
 from rekordbox_edit.errors import (
@@ -25,10 +23,6 @@ from rekordbox_edit.locking import SCRIPTED_TIMEOUT, database_lock
 logger = logging.getLogger(__name__)
 
 SCRIPTING_MODES = (PrintChoice.IDS, PrintChoice.SILENT, PrintChoice.JSON)
-
-#: How long SQLite retries when another connection (typically Rekordbox
-#: itself) holds the write lock, before raising OperationalError.
-BUSY_TIMEOUT_MS = 5000
 
 _ArgsT = TypeVar("_ArgsT", bound=BaseModel)
 
@@ -92,21 +86,6 @@ def _print_response_ids(response) -> None:
 def _print_response_json(response: BaseModel) -> None:
     """Print the response envelope as JSON."""
     print(response.model_dump_json())
-
-
-@event.listens_for(Engine, "connect")
-def _set_busy_timeout(dbapi_connection, _record) -> None:
-    """Make SQLite wait instead of failing immediately on a contended write lock.
-
-    Bound to the Engine class rather than an instance because pyrekordbox
-    builds the engine itself and connects lazily on the first query, leaving
-    no point at which to attach a per-engine listener.
-    """
-    cursor = dbapi_connection.cursor()
-    try:
-        cursor.execute(f"PRAGMA busy_timeout = {BUSY_TIMEOUT_MS}")
-    finally:
-        cursor.close()
 
 
 def _write_lock(db, kwargs):

--- a/rekordbox_edit/cli/_utils.py
+++ b/rekordbox_edit/cli/_utils.py
@@ -56,9 +56,25 @@ def _handle_stdin(args) -> bool:
 
 
 def _validate_scripting_preconditions(
-    print_opt, *, piped_stdin: bool, dry_run: bool, yes: bool
+    print_opt, *, piped_stdin: bool, dry_run: bool, yes: bool, interactive: bool = False
 ) -> None:
-    """Raise UsageError for invalid scripting-mode combinations."""
+    """Raise UsageError for invalid confirmation and scripting combinations.
+
+    --interactive contradicts both of the others: --yes means do not ask, and a
+    dry run applies nothing for a per-item answer to change. Rejecting the
+    combination keeps the flag from being silently discarded, which is what
+    used to happen.
+    """
+    if interactive and yes:
+        raise click.UsageError(
+            "--interactive and --yes are mutually exclusive: one asks about "
+            "every item, the other asks about none"
+        )
+    if interactive and dry_run:
+        raise click.UsageError(
+            "--interactive and --dry-run are mutually exclusive: a dry run "
+            "applies nothing, so there is nothing to confirm"
+        )
     confirmed = dry_run or yes
     if print_opt in SCRIPTING_MODES and not confirmed:
         raise click.UsageError(

--- a/rekordbox_edit/cli/_utils.py
+++ b/rekordbox_edit/cli/_utils.py
@@ -1,9 +1,10 @@
-"""CLI-private helpers: stdin handling, scripting guards, print emitters."""
+"""CLI-private helpers: stdin handling, scripting guards, prompts, print emitters."""
 
 import contextlib
 import functools
 import logging
 import sys
+from enum import Enum
 from typing import TypeVar
 
 import click
@@ -14,7 +15,13 @@ from sqlalchemy import event
 from sqlalchemy.engine import Engine
 
 from rekordbox_edit._click import PrintChoice, database_path_option
-from rekordbox_edit.locking import SCRIPTED_TIMEOUT, DatabaseBusyError, database_lock
+from rekordbox_edit.errors import (
+    DatabaseBusyError,
+    DependencyMissingError,
+    InputError,
+    RekordboxRunningError,
+)
+from rekordbox_edit.locking import SCRIPTED_TIMEOUT, database_lock
 
 logger = logging.getLogger(__name__)
 
@@ -121,9 +128,12 @@ def with_database(*, writes: bool = False):
     """Inject an opened Rekordbox6Database as `db` and close it on exit.
 
     Pass writes=True for commands that modify the DB: the wrapper aborts when
-    Rekordbox is running (or prompts to continue in interactive modes), and
-    holds the single-writer advisory lock for the whole run. A dry run gets
-    neither, since it writes nothing.
+    Rekordbox is running, and holds the single-writer advisory lock for the
+    whole run. A dry run gets neither, since it writes nothing.
+
+    Also the one place API errors become CLI ones, so no command repeats the
+    mapping: bad input is a usage error, and an unusable environment logs and
+    exits 1.
     """
 
     def decorator(func):
@@ -139,7 +149,13 @@ def with_database(*, writes: bool = False):
                     return func(db=db, **kwargs)
                 with _write_lock(db, kwargs):
                     return func(db=db, **kwargs)
-            except DatabaseBusyError as e:
+            except InputError as e:
+                raise click.UsageError(str(e)) from e
+            except (
+                DatabaseBusyError,
+                DependencyMissingError,
+                RekordboxRunningError,
+            ) as e:
                 logger.error(str(e))
                 sys.exit(1)
             finally:
@@ -148,3 +164,58 @@ def with_database(*, writes: bool = False):
         return wrapper
 
     return decorator
+
+
+class UserQuit(Exception):
+    """Raised when the user answers a prompt with 'q'."""
+
+
+def confirm(
+    prompt: str,
+    default: bool = False,
+    binary: bool = False,
+    abort: bool = False,
+):
+    """Prompts the user to prompt [y]es/[n]o/[q]uit
+
+    Args:
+        prompt: The question to ask the user
+        default: Default response (True for y, False for n)
+        binary: If True, prompt a simple y/n
+        abort: If True, prompt a simple y/n where 'n' raises a UserQuit Exception
+    """
+
+    class ConfirmChoice(Enum):
+        YES = "y"
+        NO = "n"
+        QUIT = "q"
+
+    if abort or binary:
+        choices = [ConfirmChoice.YES.value, ConfirmChoice.NO.value]
+        default_choice = ConfirmChoice.YES.value if default else ConfirmChoice.NO.value
+    else:
+        choices = [
+            ConfirmChoice.YES.value,
+            ConfirmChoice.NO.value,
+            ConfirmChoice.QUIT.value,
+        ]
+        default_choice = ConfirmChoice.YES.value if default else ConfirmChoice.NO.value
+
+    response: str = click.prompt(
+        prompt,
+        type=click.Choice(choices, case_sensitive=False),
+        default=default_choice,
+    )
+
+    if response.lower() == ConfirmChoice.YES.value:
+        logger.debug(f"User confirmed: {prompt}")
+        return True
+    elif response.lower() == ConfirmChoice.NO.value:
+        logger.debug(f"User declined: {prompt}")
+        if abort:
+            raise UserQuit("User declined to continue")
+        else:
+            return False
+    elif response.lower()[0] == ConfirmChoice.QUIT.value:
+        logger.debug("User quit.")
+        raise UserQuit("User quit")

--- a/rekordbox_edit/cli/_utils.py
+++ b/rekordbox_edit/cli/_utils.py
@@ -11,7 +11,7 @@ import click
 from pydantic import BaseModel, ValidationError
 from pyrekordbox import Rekordbox6Database
 
-from rekordbox_edit._click import PrintChoice, database_path_option
+from rekordbox_edit.cli._click import database_path_option
 from rekordbox_edit.errors import (
     DatabaseBusyError,
     DependencyMissingError,
@@ -19,6 +19,7 @@ from rekordbox_edit.errors import (
     RekordboxRunningError,
 )
 from rekordbox_edit.locking import SCRIPTED_TIMEOUT, database_lock
+from rekordbox_edit.logger import PrintChoice
 
 logger = logging.getLogger(__name__)
 

--- a/rekordbox_edit/cli/convert.py
+++ b/rekordbox_edit/cli/convert.py
@@ -5,8 +5,7 @@ import sys
 
 import click
 
-from rekordbox_edit._click import (
-    PrintChoice,
+from rekordbox_edit.cli._click import (
     add_click_options,
     convert_click_options,
     global_click_confirmations,
@@ -28,7 +27,7 @@ from rekordbox_edit.cli._utils import (
     with_database,
 )
 from rekordbox_edit.display import PrintableField, print_track_info
-from rekordbox_edit.logger import get_debug_file_path, set_level
+from rekordbox_edit.logger import PrintChoice, get_debug_file_path, set_level
 from rekordbox_edit.models import ConvertRequest
 
 logger = logging.getLogger(__name__)

--- a/rekordbox_edit/cli/convert.py
+++ b/rekordbox_edit/cli/convert.py
@@ -71,7 +71,11 @@ def convert_command(db, **kwargs):
     set_level(print_opt)
     piped_stdin = _handle_stdin(args)
     _validate_scripting_preconditions(
-        print_opt, piped_stdin=piped_stdin, dry_run=dry_run, yes=yes
+        print_opt,
+        piped_stdin=piped_stdin,
+        dry_run=dry_run,
+        yes=yes,
+        interactive=interactive,
     )
 
     scripting_mode = print_opt in SCRIPTING_MODES

--- a/rekordbox_edit/cli/convert.py
+++ b/rekordbox_edit/cli/convert.py
@@ -22,13 +22,14 @@ from rekordbox_edit.cli._utils import (
     _handle_stdin,
     _print_response_ids,
     _print_response_json,
+    UserQuit,
     _validate_scripting_preconditions,
+    confirm,
     with_database,
 )
 from rekordbox_edit.display import PrintableField, print_track_info
 from rekordbox_edit.logger import get_debug_file_path, set_level
 from rekordbox_edit.models import ConvertRequest
-from rekordbox_edit.utils import UserQuit, confirm
 
 logger = logging.getLogger(__name__)
 

--- a/rekordbox_edit/cli/edit.py
+++ b/rekordbox_edit/cli/edit.py
@@ -21,13 +21,14 @@ from rekordbox_edit.cli._utils import (
     _handle_stdin,
     _print_response_ids,
     _print_response_json,
+    UserQuit,
     _validate_scripting_preconditions,
+    confirm,
     with_database,
 )
 from rekordbox_edit.display import PrintableField, print_track_info
 from rekordbox_edit.logger import get_debug_file_path, set_level
 from rekordbox_edit.models import EditRequest
-from rekordbox_edit.utils import UserQuit, confirm
 
 logger = logging.getLogger(__name__)
 
@@ -68,10 +69,7 @@ def edit_command(db, **kwargs):
     )
 
     if yes or dry_run:
-        try:
-            response = edit(db, args, dry_run=dry_run)
-        except ValueError as e:
-            raise click.UsageError(str(e)) from e
+        response = edit(db, args, dry_run=dry_run)
 
         if not response.result.edits and not dry_run:
             logger.info("No changes to make.")
@@ -81,10 +79,7 @@ def edit_command(db, **kwargs):
         return
 
     # Default / interactive: preview first.
-    try:
-        preview = edit(db, args, dry_run=True)
-    except ValueError as e:
-        raise click.UsageError(str(e)) from e
+    preview = edit(db, args, dry_run=True)
 
     gated = [s for s in preview.result.skipped if s.reason in _GATED_SKIP_REASONS]
     if gated and not args.force:
@@ -97,10 +92,7 @@ def edit_command(db, **kwargs):
                 default=False,
             ):
                 args = args.model_copy(update={"force": True})
-                try:
-                    preview = edit(db, args, dry_run=True)
-                except ValueError as e:
-                    raise click.UsageError(str(e)) from e
+                preview = edit(db, args, dry_run=True)
         except UserQuit:
             return
 
@@ -128,10 +120,7 @@ def edit_command(db, **kwargs):
             return
         chosen = set(selected_ids)
         selected = [op for op in preview.result.edits if op.id in chosen]
-        try:
-            response = edit(db, args, ops=selected)
-        except ValueError as e:
-            raise click.UsageError(str(e)) from e
+        response = edit(db, args, ops=selected)
     else:
         try:
             if not confirm(f"Apply {len(preview.result.edits)} edit(s)?", default=True):
@@ -139,10 +128,7 @@ def edit_command(db, **kwargs):
                 return
         except UserQuit:
             return
-        try:
-            response = edit(db, args, ops=preview.result.edits)
-        except ValueError as e:
-            raise click.UsageError(str(e)) from e
+        response = edit(db, args, ops=preview.result.edits)
 
     _print_edit_result(response, print_opt, dry_run=False)
 

--- a/rekordbox_edit/cli/edit.py
+++ b/rekordbox_edit/cli/edit.py
@@ -32,9 +32,6 @@ from rekordbox_edit.models import EditRequest
 
 logger = logging.getLogger(__name__)
 
-# Skip reasons a user can override with --force; other reasons stay skipped.
-_GATED_SKIP_REASONS = frozenset({"file_not_found", "length_mismatch"})
-
 
 @click.command(
     epilog=f"Debug logs for each run can be found at:\n{get_debug_file_path().parent}"
@@ -85,7 +82,8 @@ def edit_command(db, **kwargs):
     # Default / interactive: preview first.
     preview = edit(db, args, dry_run=True)
 
-    gated = [s for s in preview.result.skipped if s.reason in _GATED_SKIP_REASONS]
+    forceable = FIELD_HANDLERS[args.field].forceable_skip_reasons
+    gated = [s for s in preview.result.skipped if s.reason in forceable]
     if gated and not args.force:
         logger.info(f"{len(gated)} track(s) were held back by safety checks:")
         for s in gated:

--- a/rekordbox_edit/cli/edit.py
+++ b/rekordbox_edit/cli/edit.py
@@ -65,7 +65,11 @@ def edit_command(db, **kwargs):
     piped_stdin = _handle_stdin(args)
 
     _validate_scripting_preconditions(
-        print_opt, piped_stdin=piped_stdin, dry_run=dry_run, yes=yes
+        print_opt,
+        piped_stdin=piped_stdin,
+        dry_run=dry_run,
+        yes=yes,
+        interactive=interactive,
     )
 
     if yes or dry_run:

--- a/rekordbox_edit/cli/edit.py
+++ b/rekordbox_edit/cli/edit.py
@@ -4,6 +4,8 @@ import logging
 
 import click
 
+from rekordbox_edit.api.edit import edit
+from rekordbox_edit.api.field_handlers import FIELD_HANDLERS
 from rekordbox_edit.cli._click import (
     add_click_options,
     edit_click_options,
@@ -12,15 +14,13 @@ from rekordbox_edit.cli._click import (
     print_option,
     track_ids_argument,
 )
-from rekordbox_edit.api.edit import edit
-from rekordbox_edit.api.field_handlers import FIELD_HANDLERS
 from rekordbox_edit.cli._utils import (
     SCRIPTING_MODES,
+    UserQuit,
     _build_args,
     _handle_stdin,
     _print_response_ids,
     _print_response_json,
-    UserQuit,
     _validate_scripting_preconditions,
     confirm,
     with_database,
@@ -151,13 +151,12 @@ def edit_command(db, **kwargs):
 #: than a reason code, since these are the only account a user gets of tracks
 #: their filters matched but the command did not touch.
 _SKIP_MESSAGES: dict[str, str] = {
-    "no_change": "already hold the requested value",
-    "file_not_found": "name a file that does not exist (--force writes the path anyway)",
+    "no_change": "existing value already matches the requested value",
+    "file_not_found": "file does not exist",
     "length_mismatch": (
-        "name a file whose duration contradicts the stored length "
-        "(--force writes it anyway)"
+        "file's duration contradicts the stored length (override with --force)"
     ),
-    "unknown_file_type": "name a file in no format Rekordbox recognizes",
+    "unknown_file_type": "file is in format Rekordbox doesn't support",
     "db_or_fs_changed": "changed since the preview",
 }
 

--- a/rekordbox_edit/cli/edit.py
+++ b/rekordbox_edit/cli/edit.py
@@ -32,6 +32,10 @@ from rekordbox_edit.models import EditRequest
 
 logger = logging.getLogger(__name__)
 
+# Skips a preview cannot predict: they surface only when the approved plan is
+# re-checked against the database and filesystem at write time.
+_LIVE_ONLY_SKIPS = frozenset({"db_or_fs_changed"})
+
 
 @click.command(
     epilog=f"Debug logs for each run can be found at:\n{get_debug_file_path().parent}"
@@ -71,6 +75,7 @@ def edit_command(db, **kwargs):
 
     if yes or dry_run:
         response = edit(db, args, dry_run=dry_run)
+        _report_skips(response.result.skipped)
 
         if not response.result.edits and not dry_run:
             logger.info("No changes to make.")
@@ -84,7 +89,11 @@ def edit_command(db, **kwargs):
 
     forceable = FIELD_HANDLERS[args.field].forceable_skip_reasons
     gated = [s for s in preview.result.skipped if s.reason in forceable]
+    # Reasons the prompt below spells out per track, so the summary does not
+    # repeat them.
+    reported_individually: frozenset[str] = frozenset()
     if gated and not args.force:
+        reported_individually = forceable
         logger.info(f"{len(gated)} track(s) were held back by safety checks:")
         for s in gated:
             logger.info(f"  {s.id}: {s.reason}")
@@ -95,8 +104,11 @@ def edit_command(db, **kwargs):
             ):
                 args = args.model_copy(update={"force": True})
                 preview = edit(db, args, dry_run=True)
+                reported_individually = frozenset()
         except UserQuit:
             return
+
+    _report_skips(preview.result.skipped, exclude=reported_individually)
 
     if not preview.result.edits:
         logger.info("No changes to make.")
@@ -132,7 +144,37 @@ def edit_command(db, **kwargs):
             return
         response = edit(db, args, ops=preview.result.edits)
 
+    _report_skips([s for s in response.result.skipped if s.reason in _LIVE_ONLY_SKIPS])
     _print_edit_result(response, print_opt, dry_run=False)
+
+
+#: How each skip reason reads as a one-line summary. Phrased as a reason rather
+#: than a reason code, since these are the only account a user gets of tracks
+#: their filters matched but the command did not touch.
+_SKIP_MESSAGES: dict[str, str] = {
+    "no_change": "already hold the requested value",
+    "file_not_found": "name a file that does not exist (--force writes the path anyway)",
+    "length_mismatch": (
+        "name a file whose duration contradicts the stored length "
+        "(--force writes it anyway)"
+    ),
+    "unknown_file_type": "name a file in no format Rekordbox recognizes",
+    "db_or_fs_changed": "changed since the preview",
+}
+
+
+def _report_skips(skipped, *, exclude: frozenset[str] = frozenset()) -> None:
+    """Say what was passed over and why, one line per reason.
+
+    Without this a run reports only what it changed, so a filter that matched
+    30 tracks and edited 4 looks like it found 4.
+    """
+    for reason, message in _SKIP_MESSAGES.items():
+        if reason in exclude:
+            continue
+        count = sum(1 for s in skipped if s.reason == reason)
+        if count:
+            logger.warning(f"Skipping {count} track(s): {message}")
 
 
 def _print_edit_result(response, print_opt, *, dry_run: bool) -> None:

--- a/rekordbox_edit/cli/edit.py
+++ b/rekordbox_edit/cli/edit.py
@@ -4,8 +4,7 @@ import logging
 
 import click
 
-from rekordbox_edit._click import (
-    PrintChoice,
+from rekordbox_edit.cli._click import (
     add_click_options,
     edit_click_options,
     global_click_confirmations,
@@ -27,7 +26,7 @@ from rekordbox_edit.cli._utils import (
     with_database,
 )
 from rekordbox_edit.display import PrintableField, print_track_info
-from rekordbox_edit.logger import get_debug_file_path, set_level
+from rekordbox_edit.logger import PrintChoice, get_debug_file_path, set_level
 from rekordbox_edit.models import EditRequest
 
 logger = logging.getLogger(__name__)

--- a/rekordbox_edit/cli/import_.py
+++ b/rekordbox_edit/cli/import_.py
@@ -15,7 +15,6 @@ from rekordbox_edit._click import (
 )
 from rekordbox_edit.api.import_ import (
     DirectoryConfirmationRequired,
-    ImportInputError,
     import_tracks,
 )
 from rekordbox_edit.cli._utils import (
@@ -23,13 +22,14 @@ from rekordbox_edit.cli._utils import (
     _build_args,
     _print_response_ids,
     _print_response_json,
+    UserQuit,
     _validate_scripting_preconditions,
+    confirm,
     with_database,
 )
 from rekordbox_edit.display import print_track_info
 from rekordbox_edit.logger import get_debug_file_path, set_level
 from rekordbox_edit.models import ImportOp, ImportRequest
-from rekordbox_edit.utils import UserQuit, confirm
 
 logger = logging.getLogger(__name__)
 
@@ -58,19 +58,6 @@ def import_command(db, **kwargs):
 
     interactive_ok = print_opt not in SCRIPTING_MODES and not yes
 
-    def _attempt_import(request, **call_kwargs):
-        """One import_tracks() call, with bad input reported as a usage error.
-
-        The directory gate passes through: it is the one input error the
-        caller answers with a prompt rather than an exit.
-        """
-        try:
-            return import_tracks(db, request, **call_kwargs)
-        except DirectoryConfirmationRequired:
-            raise
-        except ImportInputError as e:
-            raise click.UsageError(str(e)) from e
-
     def _import_confirming_walk(request, **call_kwargs):
         """Import, turning the directory gate into a prompt when interactive.
 
@@ -78,7 +65,7 @@ def import_command(db, **kwargs):
         declined or quit the prompt.
         """
         try:
-            return _attempt_import(request, **call_kwargs), request
+            return import_tracks(db, request, **call_kwargs), request
         except DirectoryConfirmationRequired as e:
             if not interactive_ok:
                 raise click.UsageError(f"{e} Pass --yes to confirm.") from e
@@ -94,7 +81,7 @@ def import_command(db, **kwargs):
         # Answered yes: one retry, which cannot reach the gate again. It can
         # still fail on the playlist name, which the gate preempted before.
         request = request.model_copy(update={"recurse": True})
-        return _attempt_import(request, **call_kwargs), request
+        return import_tracks(db, request, **call_kwargs), request
 
     if yes or dry_run:
         response, _ = _import_confirming_walk(args, dry_run=dry_run)
@@ -134,7 +121,7 @@ def import_command(db, **kwargs):
     # Passing the previewed ops means no second directory walk, so a file
     # created during the prompt cannot be imported unseen, and the directory
     # gate cannot fire again.
-    response = _attempt_import(confirmed_args, ops=preview.result.added)
+    response = import_tracks(db, confirmed_args, ops=preview.result.added)
     _print_import_result(response, print_opt, dry_run=False)
 
 

--- a/rekordbox_edit/cli/import_.py
+++ b/rekordbox_edit/cli/import_.py
@@ -4,8 +4,7 @@ import logging
 
 import click
 
-from rekordbox_edit._click import (
-    PrintChoice,
+from rekordbox_edit.cli._click import (
     add_click_options,
     global_click_confirmations,
     import_command_options,
@@ -27,7 +26,7 @@ from rekordbox_edit.cli._utils import (
     with_database,
 )
 from rekordbox_edit.display import print_track_info
-from rekordbox_edit.logger import get_debug_file_path, set_level
+from rekordbox_edit.logger import PrintChoice, get_debug_file_path, set_level
 from rekordbox_edit.models import ImportOp, ImportRequest
 
 logger = logging.getLogger(__name__)

--- a/rekordbox_edit/cli/import_.py
+++ b/rekordbox_edit/cli/import_.py
@@ -7,11 +7,10 @@ import click
 from rekordbox_edit._click import (
     PrintChoice,
     add_click_options,
-    dry_run_option,
+    global_click_confirmations,
     import_command_options,
     paths_argument,
     print_option,
-    yes_option,
 )
 from rekordbox_edit.api.import_ import (
     DirectoryConfirmationRequired,
@@ -37,7 +36,13 @@ logger = logging.getLogger(__name__)
 @click.command(
     epilog=f"Debug logs for each run can be found at:\n{get_debug_file_path().parent}"
 )
-@add_click_options([*import_command_options, dry_run_option, yes_option, print_option])
+@add_click_options(
+    [
+        *import_command_options,
+        *global_click_confirmations,
+        print_option,
+    ]
+)
 @paths_argument
 @with_database(writes=True)
 def import_command(db, **kwargs):
@@ -45,15 +50,21 @@ def import_command(db, **kwargs):
     print_opt = kwargs.pop("print_opt", None)
     dry_run = kwargs.pop("dry_run", False)
     yes = kwargs.pop("yes", False)
+    interactive = kwargs.pop("interactive", False)
     kwargs["paths"] = list(kwargs.get("paths") or ())
-    # --yes is the only authorization for a directory walk; an interactive run
-    # earns it from the prompt below instead.
-    kwargs["recurse"] = yes
+    # --yes authorizes a directory walk outright. A dry run writes nothing, and
+    # previewing is how you inspect what a walk covers, so it walks freely too.
+    # Anything else earns the walk from the prompt below.
+    kwargs["recurse"] = yes or dry_run
     args = _build_args(ImportRequest, kwargs)
     set_level(print_opt)
 
     _validate_scripting_preconditions(
-        print_opt, piped_stdin=False, dry_run=dry_run, yes=yes
+        print_opt,
+        piped_stdin=False,
+        dry_run=dry_run,
+        yes=yes,
+        interactive=interactive,
     )
 
     interactive_ok = print_opt not in SCRIPTING_MODES and not yes
@@ -110,19 +121,53 @@ def import_command(db, **kwargs):
     # scripting --print mode, so the preview always prints.
     print_track_info(preview.tracks)
 
-    created, linked = _count_added(preview.result.added)
-    try:
-        if not confirm(f"{_add_summary(created, linked)}?", default=True):
+    if interactive:
+        chosen = _select_ops(preview)
+        if not chosen:
             logger.info("Cancelled.")
             return
-    except UserQuit:
-        return
+    else:
+        created, linked = _count_added(preview.result.added)
+        try:
+            if not confirm(f"{_add_summary(created, linked)}?", default=True):
+                logger.info("Cancelled.")
+                return
+        except UserQuit:
+            return
+        chosen = preview.result.added
 
     # Passing the previewed ops means no second directory walk, so a file
     # created during the prompt cannot be imported unseen, and the directory
     # gate cannot fire again.
-    response = import_tracks(db, confirmed_args, ops=preview.result.added)
+    response = import_tracks(db, confirmed_args, ops=chosen)
     _print_import_result(response, print_opt, dry_run=False)
+
+
+def _op_prompt(op: ImportOp, track, playlist: str | None) -> str:
+    """The question for one pending op, phrased for what it will actually do.
+
+    A create places the track in the playlist too when one was named, so it
+    reads as one action rather than two.
+    """
+    name = track.FileNameL or op.path
+    if op.action == "playlist_add":
+        return f"  Place {name} in {playlist}?"
+    if playlist:
+        return f"  Add {name} and place it in {playlist}?"
+    return f"  Add {name}?"
+
+
+def _select_ops(preview) -> list[ImportOp]:
+    """Walk the previewed ops, keeping the ones the user confirms."""
+    playlist = preview.result.playlist
+    chosen: list[ImportOp] = []
+    for track, op in zip(preview.tracks, preview.result.added):
+        try:
+            if confirm(_op_prompt(op, track, playlist), default=True):
+                chosen.append(op)
+        except UserQuit:
+            break
+    return chosen
 
 
 def _count_added(added: list[ImportOp]) -> tuple[int, int]:

--- a/rekordbox_edit/cli/search.py
+++ b/rekordbox_edit/cli/search.py
@@ -4,8 +4,7 @@ import logging
 
 import click
 
-from rekordbox_edit._click import (
-    PrintChoice,
+from rekordbox_edit.cli._click import (
     add_click_options,
     global_click_filters,
     print_option,
@@ -20,7 +19,7 @@ from rekordbox_edit.cli._utils import (
     with_database,
 )
 from rekordbox_edit.display import print_track_info
-from rekordbox_edit.logger import get_debug_file_path, set_level
+from rekordbox_edit.logger import PrintChoice, get_debug_file_path, set_level
 from rekordbox_edit.models import SearchRequest
 
 logger = logging.getLogger(__name__)

--- a/rekordbox_edit/errors.py
+++ b/rekordbox_edit/errors.py
@@ -1,9 +1,7 @@
 """Exception hierarchy for rekordbox-edit.
 
-Every error the API raises on purpose descends from `RekordboxEditError`, so a
-caller can catch one type rather than the three unrelated families that
-preceded this module. `InputError` keeps `ValueError` in its MRO because bad
-input raised a plain `ValueError` before the hierarchy existed.
+Exports a top-level `RekordboxEditError`, from which all other internal
+errors descend.
 
 The CLI maps these to exit codes in one place, `cli._utils.with_database`.
 """
@@ -21,7 +19,7 @@ class InputError(RekordboxEditError, ValueError):
 
 
 class DependencyMissingError(RekordboxEditError):
-    """A required external program is not installed."""
+    """A required external program (e.g. ffmpeg) is not installed."""
 
 
 class RekordboxRunningError(RekordboxEditError):

--- a/rekordbox_edit/errors.py
+++ b/rekordbox_edit/errors.py
@@ -32,8 +32,22 @@ class RekordboxRunningError(RekordboxEditError):
     """
 
 
-class DatabaseBusyError(RekordboxEditError):
-    """Another rekordbox-edit process holds the write lock for this database."""
+class DatabaseNotConnectedError(RekordboxEditError, RuntimeError):
+    """The database has no open session.
+
+    Usually a database that was never opened, or one closed early. Keeps
+    RuntimeError in its MRO, which is what this raised before the hierarchy.
+    """
+
+
+class DatabaseBusyError(RekordboxEditError, TimeoutError):
+    """Another rekordbox-edit process holds the write lock for this database.
+
+    A TimeoutError because that is literally what happened: the lock did not
+    come free within the caller's timeout. This mirrors filelock.Timeout, the
+    exception it translates, which is itself a TimeoutError, so catching it as
+    one keeps working. Note that makes it an OSError too.
+    """
 
 
 class OperationAborted(RekordboxEditError):

--- a/rekordbox_edit/errors.py
+++ b/rekordbox_edit/errors.py
@@ -1,0 +1,40 @@
+"""Exception hierarchy for rekordbox-edit.
+
+Every error the API raises on purpose descends from `RekordboxEditError`, so a
+caller can catch one type rather than the three unrelated families that
+preceded this module. `InputError` keeps `ValueError` in its MRO because bad
+input raised a plain `ValueError` before the hierarchy existed.
+
+The CLI maps these to exit codes in one place, `cli._utils.with_database`.
+"""
+
+
+class RekordboxEditError(Exception):
+    """Base for every error rekordbox-edit raises on purpose."""
+
+
+class InputError(RekordboxEditError, ValueError):
+    """The request itself is invalid, and no amount of retrying will help.
+
+    The CLI reports these as usage errors.
+    """
+
+
+class DependencyMissingError(RekordboxEditError):
+    """A required external program is not installed."""
+
+
+class RekordboxRunningError(RekordboxEditError):
+    """Rekordbox holds the library open.
+
+    Writing underneath it risks losing changes: it keeps rows in memory and can
+    write its own copy back over ours.
+    """
+
+
+class DatabaseBusyError(RekordboxEditError):
+    """Another rekordbox-edit process holds the write lock for this database."""
+
+
+class OperationAborted(RekordboxEditError):
+    """A write gave up partway. Work committed before the failure is kept."""

--- a/rekordbox_edit/locking.py
+++ b/rekordbox_edit/locking.py
@@ -73,10 +73,15 @@ def database_lock(db_directory, command: str, timeout: float) -> Iterator[None]:
     """Hold the single-writer lock for `db_directory` for the duration of the block.
 
     Raises DatabaseBusyError if the lock is not free within `timeout` seconds.
+
+    Re-entrant within one process, via filelock's per-path singleton: a CLI run
+    holds this for its whole plan/apply span while each API call it makes takes
+    it again, and only the outermost release frees it. A lock held by another
+    process is still refused, which is the exclusion that matters.
     """
     path = _lock_path(db_directory)
     path.parent.mkdir(parents=True, exist_ok=True)
-    lock = FileLock(str(path))
+    lock = FileLock(str(path), is_singleton=True)
     try:
         lock.acquire(timeout=timeout)
     except Timeout as e:

--- a/rekordbox_edit/locking.py
+++ b/rekordbox_edit/locking.py
@@ -19,7 +19,11 @@ from typing import Iterator
 from filelock import FileLock, Timeout
 from platformdirs import PlatformDirs
 
+from rekordbox_edit.errors import DatabaseBusyError
+
 logger = logging.getLogger(__name__)
+
+__all__ = ["DatabaseBusyError", "SCRIPTED_TIMEOUT", "database_lock"]
 
 #: How long a non-interactive command waits for the lock. Interactive
 #: commands pass 0 so a user at a terminal fails fast instead of hanging.
@@ -29,10 +33,6 @@ _LOCK_DIR = (
     Path(PlatformDirs(appname="rekordbox-edit", ensure_exists=True).user_data_dir)
     / "locks"
 )
-
-
-class DatabaseBusyError(RuntimeError):
-    """Another rbe process holds the write lock for this database."""
 
 
 def _lock_path(db_directory) -> Path:

--- a/rekordbox_edit/logger.py
+++ b/rekordbox_edit/logger.py
@@ -3,6 +3,7 @@
 
 import atexit
 import logging
+from enum import Enum
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
@@ -10,7 +11,6 @@ from typing import Optional
 from platformdirs import PlatformDirs
 from rich.console import Console
 
-from rekordbox_edit._click import PrintChoice
 from rekordbox_edit.display import RBE_THEME, RbeHighlighter
 
 LOG_FILE_NAME = f"debug_{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.log"
@@ -18,6 +18,17 @@ LOG_FILE_NAME = f"debug_{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.log"
 _APP_DIR = Path(
     PlatformDirs(appname="rekordbox-edit", ensure_exists=True).user_data_dir
 )
+
+
+class PrintChoice(Enum):
+    """How much console output a command should produce."""
+
+    SILENT = 0
+    IDS = 1
+    INFO = 2
+    DEBUG = 3
+    JSON = 4
+
 
 _console_handler: Optional["ConsoleLogHandler"] = None
 _debug_file_path: Path = _APP_DIR / LOG_FILE_NAME

--- a/rekordbox_edit/query.py
+++ b/rekordbox_edit/query.py
@@ -15,6 +15,7 @@ from pyrekordbox.db6.tables import (
 from sqlalchemy import ColumnElement, Result, and_, func, or_, select
 from sqlalchemy.orm import Session, aliased
 
+from rekordbox_edit.errors import DatabaseNotConnectedError
 from rekordbox_edit.models import FilterArgs
 
 logger = logging.getLogger(__name__)
@@ -25,7 +26,9 @@ MatchMode = Literal["grouped", "all", "any"]
 def require_session(db: Rekordbox6Database) -> Session:
     """The database's open session, narrowed from `Session | None`."""
     if not db.session:
-        raise RuntimeError("Failed to connect to Rekordbox Database: No Session.")
+        raise DatabaseNotConnectedError(
+            "Failed to connect to Rekordbox Database: No Session."
+        )
     return db.session
 
 

--- a/rekordbox_edit/tags.py
+++ b/rekordbox_edit/tags.py
@@ -12,11 +12,13 @@ from typing import TypedDict
 import mutagen
 
 from rekordbox_edit.utils import FILE_TYPES
+from rekordbox_edit.errors import RekordboxEditError
+
 
 logger = logging.getLogger(__name__)
 
 
-class UnreadableFile(Exception):
+class UnreadableFile(RekordboxEditError):
     """Raised when a path is not audio mutagen can parse."""
 
 

--- a/rekordbox_edit/utils.py
+++ b/rekordbox_edit/utils.py
@@ -9,7 +9,7 @@ from typing import TypedDict
 
 import ffmpeg
 
-from rekordbox_edit.errors import InputError
+from rekordbox_edit.errors import DependencyMissingError, InputError
 
 logger = logging.getLogger(__name__)
 
@@ -211,20 +211,28 @@ def ffmpeg_in_path():
     return shutil.which("ffmpeg") is not None
 
 
+def require_ffmpeg() -> None:
+    """Raise DependencyMissingError unless ffmpeg is on PATH.
+
+    The single presence check. Callers that probe or encode call this first so
+    a missing install is reported as a missing install, rather than surfacing
+    as whatever the failed probe happened to look like.
+    """
+    if ffmpeg_in_path():
+        return
+    raise DependencyMissingError(
+        f"FFmpeg is required but not found in PATH.{get_ffmpeg_directions()}"
+    )
+
+
 def get_ffmpeg_directions():
-    """Get helpful error message for missing ffmpeg"""
-    if platform.system() == "Windows":  # Windows
+    """How to install ffmpeg on this platform."""
+    if platform.system() == "Windows":
         return """
-FFmpeg is required for rekordbox-edit.
-Please install FFmpeg:
-https://ffmpeg.org/download.html
+Install it from https://ffmpeg.org/download.html
 """
-    else:  # macOS
-        return """
-FFmpeg is required for rekordbox-edit.
-Please install FFmpeg:
-brew install ffmpeg
-or https://ffmpeg.org/download.html
+    return """
+Install it with `brew install ffmpeg`, or from https://ffmpeg.org/download.html
 """
 
 
@@ -248,11 +256,8 @@ def get_audio_info(file_path) -> AudioInfo:
     format-specific assumptions (e.g. MP3 has no true bit depth). ``codec``
     is the stream's codec_name and ``container`` the probe's format_name.
     """
+    require_ffmpeg()
     try:
-        # Check if ffmpeg is available first
-        if not ffmpeg_in_path():
-            raise Exception(get_ffmpeg_directions())
-
         probe = ffmpeg.probe(file_path)
         audio_stream = next(
             (stream for stream in probe["streams"] if stream["codec_type"] == "audio"),

--- a/rekordbox_edit/utils.py
+++ b/rekordbox_edit/utils.py
@@ -7,16 +7,11 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import TypedDict
 
-import click
 import ffmpeg
 
+from rekordbox_edit.errors import InputError
+
 logger = logging.getLogger(__name__)
-
-
-class UserQuit(Exception):
-    """Exception raised when user chooses to quit"""
-
-    pass
 
 
 @dataclass(frozen=True)
@@ -157,11 +152,11 @@ def get_file_type_codes_for_format(format_name: str) -> set[int]:
     Tokens mirror FileType values one to one.
     """
     if not format_name:
-        raise ValueError("Format name cannot be empty or None")
+        raise InputError("Format name cannot be empty or None")
     token = format_name.lower()
     codes = {info.code for info in FILE_TYPES.items() if token == info.token}
     if not codes:
-        raise ValueError(f"Unknown format: {format_name}")
+        raise InputError(f"Unknown format: {format_name}")
     return codes
 
 
@@ -169,10 +164,10 @@ def get_file_type_for_format(format_name: str) -> int:
     """The FileType code Rekordbox records for files RBE writes in this
     output format (case-insensitive). Raises for non-output formats."""
     if not format_name:
-        raise ValueError("Format name cannot be empty or None")
+        raise InputError("Format name cannot be empty or None")
     token = format_name.lower()
     if token not in _OUTPUT_TOKENS:
-        raise ValueError(f"Unknown format: {format_name}")
+        raise InputError(f"Unknown format: {format_name}")
     return FILE_TYPES[token].code
 
 
@@ -334,15 +329,15 @@ _RATING_STEP = 51  # Rekordbox stores N stars as N * 51.
 
 
 def parse_star_rating(value: "str | int") -> int:
-    """Parse a 0-5 star rating. Raise ValueError if not an integer in range."""
+    """Parse a 0-5 star rating. Raise InputError if not an integer in range."""
     try:
         stars = int(value)
     except (TypeError, ValueError):
-        raise ValueError(
+        raise InputError(
             f"Rating must be an integer 0-{_RATING_STARS_MAX}, got {value!r}"
         )
     if not 0 <= stars <= _RATING_STARS_MAX:
-        raise ValueError(
+        raise InputError(
             f"Rating must be between 0 and {_RATING_STARS_MAX}, got {stars}"
         )
     return stars
@@ -356,55 +351,3 @@ def star_rating_to_stored(stars: int) -> int:
 def stored_to_star_rating(stored: int) -> int:
     """Convert a stored rating back to a 0-5 star count."""
     return round(stored / _RATING_STEP)
-
-
-def confirm(
-    prompt: str,
-    default: bool = False,
-    binary: bool = False,
-    abort: bool = False,
-):
-    """Prompts the user to prompt [y]es/[n]o/[q]uit
-
-    Args:
-        prompt: The question to ask the user
-        default: Default response (True for y, False for n)
-        binary: If True, prompt a simple y/n
-        abort: If True, prompt a simple y/n where 'n' raises a UserQuit Exception
-    """
-    from enum import Enum
-
-    class ConfirmChoice(Enum):
-        YES = "y"
-        NO = "n"
-        QUIT = "q"
-
-    if abort or binary:
-        choices = [ConfirmChoice.YES.value, ConfirmChoice.NO.value]
-        default_choice = ConfirmChoice.YES.value if default else ConfirmChoice.NO.value
-    else:
-        choices = [
-            ConfirmChoice.YES.value,
-            ConfirmChoice.NO.value,
-            ConfirmChoice.QUIT.value,
-        ]
-        default_choice = ConfirmChoice.YES.value if default else ConfirmChoice.NO.value
-
-    response: str = click.prompt(
-        prompt,
-        type=click.Choice(choices, case_sensitive=False),
-        default=default_choice,
-    )
-
-    if response.lower() == ConfirmChoice.YES.value:
-        logger.debug(f"User confirmed: {prompt}")
-        return True
-    elif response.lower() == ConfirmChoice.NO.value:
-        logger.debug(f"User declined: {prompt}")
-        if abort:
-            raise UserQuit("User declined to continue")
-        else:
-            return False
-    elif response.lower()[0] == ConfirmChoice.QUIT.value:
-        logger.debug("User quit.")
-        raise UserQuit("User quit")

--- a/tests/api/test_convert.py
+++ b/tests/api/test_convert.py
@@ -954,7 +954,7 @@ class TestConvertRealRun:
         content = make_djmd_content_item(ID="1", FileType=11, FolderPath="/in.wav")
         _seed_filter(mock_gfc, content)
 
-        with pytest.raises(RuntimeError, match="Conversion failed"):
+        with pytest.raises(ConvertAborted, match="Conversion failed"):
             convert(mock_db, ConvertRequest(format_out="aiff", overwrite=True))
 
         mock_rollback.assert_called_once()
@@ -1199,7 +1199,7 @@ class TestConvertRealRun:
         content = make_djmd_content_item(ID="1", FileType=11, FolderPath="/in.wav")
         _seed_filter(mock_gfc, content)
 
-        with pytest.raises(RuntimeError, match="DB error"):
+        with pytest.raises(ConvertAborted, match="DB error"):
             convert(mock_db, ConvertRequest(format_out="aiff", overwrite=True))
         mock_rollback.assert_called_once()
 

--- a/tests/api/test_convert.py
+++ b/tests/api/test_convert.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock, patch
 import ffmpeg
 import pytest
 
+from rekordbox_edit.errors import DependencyMissingError
 from rekordbox_edit.api.convert import (
     TEMP_PREFIX,
     ConvertAborted,
@@ -527,7 +528,7 @@ class TestConvertRealRun:
 
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=False)
     def test_no_ffmpeg_raises_immediately(self, _, mock_db):
-        with pytest.raises(RuntimeError, match="FFmpeg"):
+        with pytest.raises(DependencyMissingError, match="FFmpeg"):
             convert(mock_db, ConvertRequest(format_out="aiff"))
 
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=True)
@@ -2081,7 +2082,7 @@ class TestRunFfmpeg:
 
     @patch("rekordbox_edit.utils.ffmpeg_in_path", return_value=False)
     def test_ffmpeg_not_found_raises(self, _):
-        with pytest.raises(Exception, match="FFmpeg not found in PATH"):
+        with pytest.raises(DependencyMissingError, match="not found in PATH"):
             _run_ffmpeg("in.flac", "out.aiff", {"acodec": "pcm_s16be"}, "aiff")
 
     def test_success_passes_kwargs_through(self, chain):

--- a/tests/api/test_edit.py
+++ b/tests/api/test_edit.py
@@ -6,7 +6,7 @@ from rekordbox_edit.api.field_handlers import FIELD_HANDLERS
 from sqlalchemy import text
 
 from rekordbox_edit.query import require_session
-from rekordbox_edit.errors import RekordboxRunningError
+from rekordbox_edit.errors import InputError, RekordboxRunningError
 from rekordbox_edit.models import (
     EditRequest,
     EditOp,
@@ -115,23 +115,39 @@ class TestEditDryRun:
         assert response.result.skipped[0].reason == "no_change"
 
     @patch("rekordbox_edit.api.edit.get_filtered_content")
-    def test_dry_run_still_raises_multi_guard(
+    def test_dry_run_reports_a_bulk_edit_instead_of_refusing_it(
         self, mock_gfc, mock_db, make_djmd_content_item
     ):
-        # multi guard MUST still raise even in dry-run; it's a usage error,
-        # not a side effect. Verify behaviour matches real-run.
+        # The guard is about applying an unattended bulk edit. A dry run writes
+        # nothing, and refusing to preview would contradict the guard's own
+        # advice to inspect with a dry run first.
         contents = [
             make_djmd_content_item(ID="1", Title="Old"),
             make_djmd_content_item(ID="2", Title="Old"),
         ]
         mock_gfc.return_value.scalars.return_value.all.return_value = contents
 
-        with pytest.raises(ValueError, match="multi"):
-            edit(
-                mock_db,
-                EditRequest(field="Title", replace_value="New", multi=False),
-                dry_run=True,
-            )
+        response = edit(
+            mock_db,
+            EditRequest(field="Title", replace_value="New", multi=False),
+            dry_run=True,
+        )
+
+        assert len(response.result.edits) == 2
+        mock_db.session.commit.assert_not_called()
+
+    @patch("rekordbox_edit.api.edit.get_filtered_content")
+    def test_one_shot_bulk_edit_still_needs_multi(
+        self, mock_gfc, mock_db, make_djmd_content_item
+    ):
+        contents = [
+            make_djmd_content_item(ID="1", Title="Old"),
+            make_djmd_content_item(ID="2", Title="Old"),
+        ]
+        mock_gfc.return_value.scalars.return_value.all.return_value = contents
+
+        with pytest.raises(InputError, match="multi"):
+            edit(mock_db, EditRequest(field="Title", replace_value="New"))
 
 
 class TestEditRealRun:

--- a/tests/api/test_edit.py
+++ b/tests/api/test_edit.py
@@ -6,6 +6,7 @@ from rekordbox_edit.api.field_handlers import FIELD_HANDLERS
 from sqlalchemy import text
 
 from rekordbox_edit.query import require_session
+from rekordbox_edit.errors import RekordboxRunningError
 from rekordbox_edit.models import (
     EditRequest,
     EditOp,
@@ -415,3 +416,32 @@ class TestEditStampsUsns:
 
         assert response.result.edits == []
         assert session.execute(self._COUNTER).scalar() == start
+
+
+class TestEditRefusesWhileRekordboxRuns:
+    @patch("rekordbox_edit.api.edit.get_filtered_content")
+    def test_write_is_refused(self, mock_gfc, mock_db, make_djmd_content_item):
+        mock_gfc.return_value.scalars.return_value.all.return_value = [
+            make_djmd_content_item(ID="1", Title="Old")
+        ]
+
+        with patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=9):
+            with pytest.raises(RekordboxRunningError):
+                edit(mock_db, EditRequest(field="Title", replace_value="New"))
+
+        mock_db.session.commit.assert_not_called()
+
+    @patch("rekordbox_edit.api.edit.get_filtered_content")
+    def test_dry_run_is_allowed(self, mock_gfc, mock_db, make_djmd_content_item):
+        mock_gfc.return_value.scalars.return_value.all.return_value = [
+            make_djmd_content_item(ID="1", Title="Old")
+        ]
+
+        with patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=9):
+            response = edit(
+                mock_db,
+                EditRequest(field="Title", replace_value="New"),
+                dry_run=True,
+            )
+
+        assert len(response.result.edits) == 1

--- a/tests/api/test_field_handlers.py
+++ b/tests/api/test_field_handlers.py
@@ -8,6 +8,7 @@ from rekordbox_edit.api.field_handlers import (
     RelationalField,
     StringField,
 )
+from rekordbox_edit.errors import DependencyMissingError
 from rekordbox_edit.models import EditRequest
 
 
@@ -401,6 +402,26 @@ class TestFolderPathField:
         )
 
         assert reason == "unknown_file_type"
+
+    @patch(
+        "rekordbox_edit.api.field_handlers.get_audio_info",
+        side_effect=DependencyMissingError("FFmpeg is required"),
+    )
+    @patch("rekordbox_edit.api.field_handlers.os.path.getsize", return_value=2000)
+    @patch("rekordbox_edit.api.field_handlers.os.path.exists", return_value=True)
+    def test_validate_missing_ffmpeg_is_not_a_per_track_skip(
+        self, _exists, _getsize, _probe_fn, make_djmd_content_item
+    ):
+        # Swallowing this would report every track as an unrecognized file
+        # rather than naming the missing install.
+        content = make_djmd_content_item(ID="1")
+        content.FileSize = 1000
+        args = EditRequest(field="FolderPath", replace_value="/new/song.wav")
+
+        with pytest.raises(DependencyMissingError):
+            _folder_handler().validate_track(
+                MagicMock(), content, "/new/song.wav", args
+            )
 
     @patch(
         "rekordbox_edit.api.field_handlers.get_audio_info",

--- a/tests/api/test_field_handlers.py
+++ b/tests/api/test_field_handlers.py
@@ -1,3 +1,4 @@
+from typing import get_args
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -9,7 +10,7 @@ from rekordbox_edit.api.field_handlers import (
     StringField,
 )
 from rekordbox_edit.errors import DependencyMissingError
-from rekordbox_edit.models import EditRequest
+from rekordbox_edit.models import EditRequest, SkipReason
 
 
 def _artist_handler():
@@ -708,3 +709,20 @@ class TestFolderPathField:
 
         # Must not raise: the row commit already succeeded.
         _folder_handler().post_commit(MagicMock(), content, "/old/dir/song.wav")
+
+
+class TestForceableSkipReasons:
+    def test_folder_path_declares_what_force_overrides(self):
+        assert FIELD_HANDLERS["FolderPath"].forceable_skip_reasons == frozenset(
+            {"file_not_found", "length_mismatch"}
+        )
+
+    def test_handlers_without_gates_declare_nothing(self):
+        # A caller offering to retry with force reads this rather than keeping
+        # its own list, so a handler with no gates must offer no retry.
+        assert FIELD_HANDLERS["Title"].forceable_skip_reasons == frozenset()
+
+    def test_every_declared_reason_is_a_real_skip_reason(self):
+        valid = set(get_args(SkipReason))
+        for handler in FIELD_HANDLERS.values():
+            assert handler.forceable_skip_reasons <= valid

--- a/tests/api/test_import.py
+++ b/tests/api/test_import.py
@@ -23,6 +23,7 @@ from rekordbox_edit.api.import_ import (
 )
 from sqlalchemy import text
 
+from rekordbox_edit.errors import RekordboxRunningError
 from rekordbox_edit.models import ImportOp, ImportRequest, SkippedTrack
 from rekordbox_edit.query import require_session
 from rekordbox_edit.query import normalize_path
@@ -990,3 +991,24 @@ class TestImportStampsUsns:
         import_tracks(db, ImportRequest(paths=[str(audio_file)]), dry_run=True)
 
         assert session.execute(self._COUNTER).scalar() == start
+
+
+class TestImportRefusesWhileRekordboxRuns:
+    def test_write_is_refused(self, mock_db, one_flac, stub_tags):
+        mock_db.session.query.return_value.filter_by.return_value.__iter__ = (
+            lambda self: iter([])
+        )
+
+        with patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=9):
+            with pytest.raises(RekordboxRunningError):
+                import_tracks(mock_db, ImportRequest(paths=[one_flac]))
+
+        mock_db.session.commit.assert_not_called()
+
+    def test_dry_run_is_allowed(self, mock_db, one_flac, stub_tags):
+        with patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=9):
+            response = import_tracks(
+                mock_db, ImportRequest(paths=[one_flac]), dry_run=True
+            )
+
+        assert len(response.result.added) == 1

--- a/tests/api/test_utils.py
+++ b/tests/api/test_utils.py
@@ -2,9 +2,10 @@
 
 import logging
 import threading
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
+from filelock import FileLock, Timeout
 from pyrekordbox import Rekordbox6Database
 from sqlalchemy import text
 
@@ -14,7 +15,10 @@ from rekordbox_edit.api._utils import (
     _order_tracks_by_op,
     _track_from_content,
     stamp_usns,
+    writing,
 )
+from rekordbox_edit.errors import DatabaseBusyError, RekordboxRunningError
+from rekordbox_edit.locking import _lock_path, database_lock
 from rekordbox_edit.models import ConvertOp, Track
 from rekordbox_edit.query import require_session
 
@@ -216,3 +220,58 @@ class TestDriverTransactionAssumption:
         stamp_usns(db, db.get_content().limit(1).all())
 
         assert self._dbapi(db).in_transaction is True
+
+
+class TestWriting:
+    """The guard every API write enters through."""
+
+    def test_refuses_while_rekordbox_runs(self, tmp_path):
+        db = Mock(db_directory=tmp_path)
+        with patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=4321):
+            with pytest.raises(RekordboxRunningError, match="4321"):
+                with writing(db, "edit"):
+                    pass
+
+    def test_holds_the_write_lock_for_the_block(self, tmp_path):
+        db = Mock(db_directory=tmp_path)
+        with patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None):
+            with writing(db, "edit"):
+                # A separate FileLock instance is what another process's flock
+                # looks like, so this is the exclusion that actually matters.
+                foreign = FileLock(str(_lock_path(tmp_path)))
+                with pytest.raises(Timeout):
+                    foreign.acquire(timeout=0.1)
+
+    def test_nests_inside_a_lock_the_caller_already_holds(self, tmp_path):
+        # The CLI holds the lock across plan and apply while each API call it
+        # makes takes it again.
+        db = Mock(db_directory=tmp_path)
+        with patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None):
+            with database_lock(tmp_path, command="convert", timeout=0):
+                with writing(db, "convert"):
+                    pass
+
+    def test_releases_the_lock_when_the_block_raises(self, tmp_path):
+        db = Mock(db_directory=tmp_path)
+        with patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None):
+            with pytest.raises(RuntimeError):
+                with writing(db, "edit"):
+                    raise RuntimeError("boom")
+            with writing(db, "edit"):
+                pass
+
+    def test_a_foreign_holder_is_reported_as_busy(self, tmp_path):
+        db = Mock(db_directory=tmp_path)
+        foreign = FileLock(str(_lock_path(tmp_path)))
+        _lock_path(tmp_path).parent.mkdir(parents=True, exist_ok=True)
+        foreign.acquire(timeout=0)
+        try:
+            with (
+                patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None),
+                patch("rekordbox_edit.api._utils.SCRIPTED_TIMEOUT", 0),
+            ):
+                with pytest.raises(DatabaseBusyError):
+                    with writing(db, "edit"):
+                        pass
+        finally:
+            foreign.release()

--- a/tests/cli/test_convert.py
+++ b/tests/cli/test_convert.py
@@ -15,7 +15,7 @@ from rekordbox_edit.models import (
     SkippedTrack,
     Track,
 )
-from rekordbox_edit.utils import UserQuit
+from rekordbox_edit.cli._utils import UserQuit
 
 
 @pytest.fixture(autouse=True)

--- a/tests/cli/test_convert.py
+++ b/tests/cli/test_convert.py
@@ -43,7 +43,7 @@ def _response(tracks=None, converted=None, deleted=0, skipped=None, format_out="
 class TestConvertCommand:
     @patch("rekordbox_edit.cli.convert.convert")
     @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
-    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None)
+    @patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None)
     def test_yes_calls_convert_once(self, _pid, mock_db_class, mock_convert):
         mock_db_class.return_value = Mock(session=Mock())
         mock_convert.return_value = _response()
@@ -55,7 +55,7 @@ class TestConvertCommand:
 
     @patch("rekordbox_edit.cli.convert.convert")
     @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
-    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None)
+    @patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None)
     def test_dry_run(self, _pid, mock_db_class, mock_convert):
         mock_db_class.return_value = Mock(session=Mock())
         mock_convert.return_value = _response()
@@ -70,7 +70,7 @@ class TestConvertCommand:
 
     @patch("rekordbox_edit.cli.convert.convert")
     @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
-    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None)
+    @patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None)
     def test_warns_already_target_skip(
         self, _pid, mock_db_class, mock_convert, mock_logger
     ):
@@ -87,7 +87,7 @@ class TestConvertCommand:
 
     @patch("rekordbox_edit.cli.convert.convert")
     @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
-    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None)
+    @patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None)
     def test_warns_output_conflict_skip(
         self, _pid, mock_db_class, mock_convert, mock_logger
     ):
@@ -103,7 +103,7 @@ class TestConvertCommand:
 
     @patch("rekordbox_edit.cli.convert.convert")
     @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
-    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None)
+    @patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None)
     def test_warns_unsupported_source_skip(
         self, _pid, mock_db_class, mock_convert, mock_logger
     ):
@@ -119,7 +119,7 @@ class TestConvertCommand:
 
     @patch("rekordbox_edit.cli.convert.convert")
     @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
-    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None)
+    @patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None)
     def test_logs_deleted_count(self, _pid, mock_db_class, mock_convert, mock_logger):
         mock_db_class.return_value = Mock(session=Mock())
         mock_convert.return_value = _response(deleted=2)
@@ -128,17 +128,9 @@ class TestConvertCommand:
 
         mock_logger.info.assert_any_call("Deleted 2 original file(s)")
 
-    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
-    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=12345)
-    def test_a_write_refuses_while_rekordbox_runs(self, _pid, mock_db_class):
-        result = CliRunner().invoke(convert_command, ["--format-out", "aiff"])
-
-        assert result.exit_code == 1
-        mock_db_class.assert_not_called()
-
     @patch("rekordbox_edit.cli.convert.convert")
     @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
-    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=12345)
+    @patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=12345)
     def test_a_dry_run_runs_while_rekordbox_runs(
         self, _pid, mock_db_class, mock_convert
     ):
@@ -157,7 +149,7 @@ class TestConvertCommand:
     def test_a_scripting_dry_run_is_not_blocked_either(self, mock_db_class):
         mock_db_class.return_value = Mock(session=Mock())
         with (
-            patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=12345),
+            patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=12345),
             patch("rekordbox_edit.cli.convert.convert", return_value=_response()),
         ):
             result = CliRunner().invoke(
@@ -167,19 +159,9 @@ class TestConvertCommand:
 
         assert result.exit_code == 0
 
-    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
-    def test_aborts_in_scripting_mode_when_rekordbox_running(self, mock_db_class):
-        with patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=12345):
-            result = CliRunner().invoke(
-                convert_command,
-                ["--format-out", "aiff", "--yes", "--print", "silent"],
-            )
-
-        assert result.exit_code != 0
-
     @patch("rekordbox_edit.cli.convert.convert")
     @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
-    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None)
+    @patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None)
     def test_print_json_emits_envelope(self, _pid, mock_db_class, mock_convert):
         import json
 
@@ -198,7 +180,7 @@ class TestConvertCommand:
     @patch("rekordbox_edit.cli.convert.confirm", return_value=True)
     @patch("rekordbox_edit.cli.convert.convert")
     @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
-    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None)
+    @patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None)
     def test_default_flow_previews_then_commits(
         self, _pid, mock_db_class, mock_convert, _confirm, _print
     ):
@@ -216,7 +198,7 @@ class TestConvertCommand:
     @patch("rekordbox_edit.cli.convert.confirm", return_value=True)
     @patch("rekordbox_edit.cli.convert.convert")
     @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
-    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None)
+    @patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None)
     def test_default_flow_reports_live_codec_mismatch_once(
         self, _pid, mock_db_class, mock_convert, _confirm, _print, mock_logger
     ):
@@ -242,7 +224,7 @@ class TestConvertCommand:
     @patch("rekordbox_edit.cli.convert.confirm", return_value=False)
     @patch("rekordbox_edit.cli.convert.convert")
     @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
-    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None)
+    @patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None)
     def test_default_flow_user_declines_skips_commit(
         self, _pid, mock_db_class, mock_convert, _confirm, _print
     ):
@@ -259,7 +241,7 @@ class TestConvertCommand:
     @patch("rekordbox_edit.cli.convert.confirm", side_effect=UserQuit)
     @patch("rekordbox_edit.cli.convert.convert")
     @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
-    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None)
+    @patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None)
     def test_default_flow_user_quit_skips_commit(
         self, _pid, mock_db_class, mock_convert, _confirm, _print
     ):
@@ -273,7 +255,7 @@ class TestConvertCommand:
 
     @patch("rekordbox_edit.cli.convert.convert")
     @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
-    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None)
+    @patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None)
     def test_default_flow_empty_preview_exits_cleanly(
         self, _pid, mock_db_class, mock_convert
     ):
@@ -294,7 +276,7 @@ class TestConvertCommand:
     @patch("rekordbox_edit.cli.convert.confirm")
     @patch("rekordbox_edit.cli.convert.convert")
     @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
-    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None)
+    @patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None)
     def test_interactive_narrows_to_confirmed_tracks(
         self, _pid, mock_db_class, mock_convert, mock_confirm, _print
     ):
@@ -324,7 +306,7 @@ class TestConvertCommand:
     @patch("rekordbox_edit.cli.convert.confirm")
     @patch("rekordbox_edit.cli.convert.convert")
     @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
-    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None)
+    @patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None)
     def test_quitting_mid_prompt_converts_only_what_was_confirmed(
         self, _pid, mock_db_class, mock_convert, mock_confirm, _print
     ):
@@ -353,7 +335,7 @@ class TestConvertCommand:
     @patch("rekordbox_edit.cli.convert.confirm", side_effect=UserQuit)
     @patch("rekordbox_edit.cli.convert.convert")
     @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
-    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None)
+    @patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None)
     def test_quitting_before_confirming_anything_converts_nothing(
         self, _pid, mock_db_class, mock_convert, _confirm, _print
     ):
@@ -367,19 +349,11 @@ class TestConvertCommand:
         assert result.exit_code == 0
         mock_convert.assert_called_once()  # preview only
 
-    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
-    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=12345)
-    def test_yes_does_not_override_the_refusal(self, _pid, mock_db_class):
-        result = CliRunner().invoke(convert_command, ["--format-out", "aiff", "--yes"])
-
-        assert result.exit_code == 1
-        mock_db_class.assert_not_called()
-
 
 class TestPartialBatchReporting:
     @patch("rekordbox_edit.cli.convert.convert")
     @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
-    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None)
+    @patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None)
     def test_a_stopped_batch_reports_what_survived(
         self, _pid, mock_db_class, mock_convert, mock_logger
     ):
@@ -403,7 +377,7 @@ class TestPartialBatchReporting:
 class TestMissingSourceReporting:
     @patch("rekordbox_edit.cli.convert.convert")
     @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
-    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None)
+    @patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None)
     def test_a_vanished_source_is_reported_from_the_live_pass(
         self, _pid, mock_db_class, mock_convert, mock_logger
     ):
@@ -428,7 +402,7 @@ class TestDriftReporting:
     @patch("rekordbox_edit.cli.convert.confirm", return_value=True)
     @patch("rekordbox_edit.cli.convert.convert")
     @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
-    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None)
+    @patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None)
     def test_a_file_that_changed_during_the_prompt_is_reported(
         self, _pid, mock_db_class, mock_convert, _confirm, _print, mock_logger
     ):
@@ -450,7 +424,7 @@ class TestDriftReporting:
 class TestThreadsFlag:
     @patch("rekordbox_edit.cli.convert.convert")
     @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
-    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None)
+    @patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None)
     def test_threads_reaches_the_request(self, _pid, mock_db_class, mock_convert):
         mock_db_class.return_value = Mock(session=Mock())
         mock_convert.return_value = _response()
@@ -464,7 +438,7 @@ class TestThreadsFlag:
 
     @patch("rekordbox_edit.cli.convert.convert")
     @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
-    @patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None)
+    @patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None)
     def test_omitting_threads_uses_the_conservative_default(
         self, _pid, mock_db_class, mock_convert
     ):

--- a/tests/cli/test_edit.py
+++ b/tests/cli/test_edit.py
@@ -444,3 +444,90 @@ class TestEditForceFlow:
         assert result.exit_code == 0
         mock_edit.assert_called_once()
         assert mock_edit.call_args.args[1].force is False
+
+
+def _warnings(mock_logger) -> str:
+    return "\n".join(str(c.args[0]) for c in mock_logger.warning.call_args_list)
+
+
+def _infos(mock_logger) -> str:
+    return "\n".join(str(c.args[0]) for c in mock_logger.info.call_args_list)
+
+
+class TestEditSkipReporting:
+    """A run used to report only what it changed, so a filter matching 30
+    tracks and editing 4 looked like it found 4."""
+
+    @patch("rekordbox_edit.cli.edit.print_track_info")
+    @patch("rekordbox_edit.cli.edit.edit")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    def test_yes_reports_why_tracks_were_passed_over(
+        self, mock_db_class, mock_edit, _print, mock_logger
+    ):
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_edit.return_value = _response(
+            skipped=[
+                SkippedTrack(id="2", reason="no_change"),
+                SkippedTrack(id="3", reason="no_change"),
+                SkippedTrack(id="4", reason="unknown_file_type"),
+            ]
+        )
+
+        result = CliRunner().invoke(
+            edit_command, ["Title", "--replace", "New", "--yes"]
+        )
+
+        assert result.exit_code == 0
+        warnings = _warnings(mock_logger)
+        assert "Skipping 2 track(s): already hold the requested value" in warnings
+        assert "Skipping 1 track(s): name a file in no format" in warnings
+
+    @patch("rekordbox_edit.cli.edit.print_track_info")
+    @patch("rekordbox_edit.cli.edit.edit")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    def test_dry_run_reports_them_too(
+        self, mock_db_class, mock_edit, _print, mock_logger
+    ):
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_edit.return_value = _response(
+            skipped=[SkippedTrack(id="2", reason="no_change")]
+        )
+
+        CliRunner().invoke(edit_command, ["Title", "--replace", "New", "--dry-run"])
+
+        assert "already hold the requested value" in _warnings(mock_logger)
+
+    @patch("rekordbox_edit.cli.edit.print_track_info")
+    @patch("rekordbox_edit.cli.edit.confirm")
+    @patch("rekordbox_edit.cli.edit.edit")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    def test_gated_reasons_are_not_reported_twice(
+        self, mock_db_class, mock_edit, mock_confirm, _print, mock_logger
+    ):
+        # The force prompt names those tracks individually, so the summary
+        # must leave that reason out.
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_edit.side_effect = [_gated_response(), _gated_response()]
+        mock_confirm.side_effect = [False, True]
+
+        CliRunner().invoke(edit_command, ["FolderPath", "--replace", "/new/x.wav"])
+
+        assert "were held back by safety checks" in _infos(mock_logger)
+        assert "name a file that does not exist" not in _warnings(mock_logger)
+
+    @patch("rekordbox_edit.cli.edit.print_track_info")
+    @patch("rekordbox_edit.cli.edit.confirm", return_value=True)
+    @patch("rekordbox_edit.cli.edit.edit")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    def test_a_track_that_changed_after_the_preview_is_reported(
+        self, mock_db_class, mock_edit, _confirm, _print, mock_logger
+    ):
+        mock_db_class.return_value = Mock(session=Mock())
+        applied = _response(skipped=[SkippedTrack(id="2", reason="db_or_fs_changed")])
+        mock_edit.side_effect = [_response(), applied]
+
+        CliRunner().invoke(edit_command, ["Title", "--replace", "New"])
+
+        assert "Skipping 1 track(s): changed since the preview" in _warnings(
+            mock_logger
+        )

--- a/tests/cli/test_edit.py
+++ b/tests/cli/test_edit.py
@@ -1,14 +1,22 @@
 """Tests for cli/edit.py."""
 
+from typing import get_args
 from unittest.mock import Mock, patch
 
 import pytest
 from click.testing import CliRunner
 
-from rekordbox_edit.cli.edit import edit_command
-from rekordbox_edit.models import EditOp, EditResponse, EditResult, SkippedTrack, Track
 from rekordbox_edit.cli._utils import UserQuit
+from rekordbox_edit.cli.edit import _SKIP_MESSAGES, edit_command
 from rekordbox_edit.errors import InputError
+from rekordbox_edit.models import (
+    EditOp,
+    EditResponse,
+    EditResult,
+    SkippedTrack,
+    SkipReason,
+    Track,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -479,8 +487,11 @@ class TestEditSkipReporting:
 
         assert result.exit_code == 0
         warnings = _warnings(mock_logger)
-        assert "Skipping 2 track(s): already hold the requested value" in warnings
-        assert "Skipping 1 track(s): name a file in no format" in warnings
+        assert "Skipping 2 track(s): existing value already matches" in warnings
+        assert (
+            "Skipping 1 track(s): file is in format Rekordbox doesn't support"
+            in warnings
+        )
 
     @patch("rekordbox_edit.cli.edit.print_track_info")
     @patch("rekordbox_edit.cli.edit.edit")
@@ -495,7 +506,7 @@ class TestEditSkipReporting:
 
         CliRunner().invoke(edit_command, ["Title", "--replace", "New", "--dry-run"])
 
-        assert "already hold the requested value" in _warnings(mock_logger)
+        assert "existing value already matches" in _warnings(mock_logger)
 
     @patch("rekordbox_edit.cli.edit.print_track_info")
     @patch("rekordbox_edit.cli.edit.confirm")
@@ -513,7 +524,7 @@ class TestEditSkipReporting:
         CliRunner().invoke(edit_command, ["FolderPath", "--replace", "/new/x.wav"])
 
         assert "were held back by safety checks" in _infos(mock_logger)
-        assert "name a file that does not exist" not in _warnings(mock_logger)
+        assert "file does not exist" not in _warnings(mock_logger)
 
     @patch("rekordbox_edit.cli.edit.print_track_info")
     @patch("rekordbox_edit.cli.edit.confirm", return_value=True)
@@ -529,5 +540,28 @@ class TestEditSkipReporting:
         CliRunner().invoke(edit_command, ["Title", "--replace", "New"])
 
         assert "Skipping 1 track(s): changed since the preview" in _warnings(
+            mock_logger
+        )
+
+    def test_no_message_is_keyed_on_a_reason_that_cannot_occur(self):
+        # _report_skips matches on equality with SkippedTrack.reason, so a key
+        # that is not a SkipReason is silently never emitted.
+        assert set(_SKIP_MESSAGES) <= set(get_args(SkipReason))
+
+    @pytest.mark.parametrize("reason", sorted(_SKIP_MESSAGES))
+    @patch("rekordbox_edit.cli.edit.print_track_info")
+    @patch("rekordbox_edit.cli.edit.edit")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    def test_every_reason_in_the_table_is_emitted(
+        self, mock_db_class, mock_edit, _print, reason, mock_logger
+    ):
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_edit.return_value = _response(
+            skipped=[SkippedTrack(id="2", reason=reason)]
+        )
+
+        CliRunner().invoke(edit_command, ["Title", "--replace", "New", "--yes"])
+
+        assert f"Skipping 1 track(s): {_SKIP_MESSAGES[reason]}" in _warnings(
             mock_logger
         )

--- a/tests/cli/test_edit.py
+++ b/tests/cli/test_edit.py
@@ -7,7 +7,8 @@ from click.testing import CliRunner
 
 from rekordbox_edit.cli.edit import edit_command
 from rekordbox_edit.models import EditOp, EditResponse, EditResult, SkippedTrack, Track
-from rekordbox_edit.utils import UserQuit
+from rekordbox_edit.cli._utils import UserQuit
+from rekordbox_edit.errors import InputError
 
 
 @pytest.fixture(autouse=True)
@@ -79,7 +80,7 @@ class TestEditCommand:
     @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
     def test_value_error_becomes_usage_error(self, mock_db_class, mock_edit):
         mock_db_class.return_value = Mock(session=Mock())
-        mock_edit.side_effect = ValueError("Found 2 tracks that would be edited")
+        mock_edit.side_effect = InputError("Found 2 tracks that would be edited")
 
         result = CliRunner().invoke(
             edit_command, ["Title", "--replace", "New", "--yes"]
@@ -94,7 +95,7 @@ class TestEditCommand:
         self, mock_db_class, mock_edit
     ):
         mock_db_class.return_value = Mock(session=Mock())
-        mock_edit.side_effect = ValueError("Found 2 tracks that would be edited")
+        mock_edit.side_effect = InputError("Found 2 tracks that would be edited")
 
         result = CliRunner().invoke(edit_command, ["Title", "--replace", "New"])
 
@@ -105,14 +106,14 @@ class TestEditCommand:
     @patch("rekordbox_edit.cli.edit.confirm", return_value=True)
     @patch("rekordbox_edit.cli.edit.edit")
     @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
-    def test_apply_pass_value_error_becomes_usage_error(
+    def test_apply_pass_input_error_becomes_usage_error(
         self, mock_db_class, mock_edit, _confirm, _print
     ):
         # The preview passes the --multi guard and the apply pass does not.
         mock_db_class.return_value = Mock(session=Mock())
         mock_edit.side_effect = [
             _response(),
-            ValueError("Found 2 tracks that would be edited"),
+            InputError("Found 2 tracks that would be edited"),
         ]
 
         result = CliRunner().invoke(edit_command, ["Title", "--replace", "New"])
@@ -130,7 +131,7 @@ class TestEditCommand:
         mock_db_class.return_value = Mock(session=Mock())
         mock_edit.side_effect = [
             _response(),
-            ValueError("Found 2 tracks that would be edited"),
+            InputError("Found 2 tracks that would be edited"),
         ]
 
         result = CliRunner().invoke(
@@ -419,7 +420,7 @@ class TestEditForceFlow:
         mock_db_class.return_value = Mock(session=Mock())
         mock_edit.side_effect = [
             _gated_response(),
-            ValueError("Found 2 tracks that would be edited"),
+            InputError("Found 2 tracks that would be edited"),
         ]
         mock_confirm.side_effect = [True]
 

--- a/tests/cli/test_edit.py
+++ b/tests/cli/test_edit.py
@@ -19,7 +19,7 @@ def mock_logger():
 
 @pytest.fixture(autouse=True)
 def mock_rekordbox_not_running():
-    with patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None):
+    with patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None):
         yield
 
 

--- a/tests/cli/test_import.py
+++ b/tests/cli/test_import.py
@@ -18,7 +18,7 @@ from rekordbox_edit.models import (
     SkippedTrack,
     Track,
 )
-from rekordbox_edit.utils import UserQuit
+from rekordbox_edit.cli._utils import UserQuit
 
 
 @pytest.fixture(autouse=True)

--- a/tests/cli/test_import.py
+++ b/tests/cli/test_import.py
@@ -29,7 +29,7 @@ def mock_logger():
 
 @pytest.fixture(autouse=True)
 def mock_rekordbox_not_running():
-    with patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None):
+    with patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None):
         yield
 
 

--- a/tests/cli/test_import.py
+++ b/tests/cli/test_import.py
@@ -373,9 +373,9 @@ class TestImportCommand:
         assert "Path does not exist" in result.output
         assert "Traceback" not in result.output
 
-    def test_no_interactive_flag_registered(self, runner):
+    def test_interactive_flag_is_registered(self, runner):
         result = runner.invoke(import_command, ["--help"])
-        assert "--interactive" not in result.output
+        assert "--interactive" in result.output
 
     @patch("rekordbox_edit.cli.import_.import_tracks")
     @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
@@ -568,3 +568,78 @@ class TestImportCommand:
         messages = [c.args[0] for c in mock_log.info.call_args_list]
         assert "Added 1 track(s)." in messages
         assert "Placed 1 existing track(s) in the playlist." in messages
+
+
+class TestImportInteractive:
+    @patch("rekordbox_edit.cli.import_.print_track_info")
+    @patch("rekordbox_edit.cli.import_.confirm")
+    @patch("rekordbox_edit.cli.import_.import_tracks")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    def test_only_confirmed_ops_are_applied(
+        self, mock_db_class, mock_import, mock_confirm, _print
+    ):
+        mock_db_class.return_value = Mock(session=Mock())
+        tracks = [
+            Track(ID="1", FileNameL="a.flac", FolderPath="/m/a.flac"),
+            Track(ID="2", FileNameL="b.flac", FolderPath="/m/b.flac"),
+        ]
+        preview = _response(tracks=tracks)
+        mock_import.side_effect = [preview, _response(tracks=tracks[:1])]
+        mock_confirm.side_effect = [True, False]
+
+        result = CliRunner().invoke(import_command, ["/m/a.flac", "/m/b.flac", "-i"])
+
+        assert result.exit_code == 0
+        applied = mock_import.call_args.kwargs["ops"]
+        assert [op.id for op in applied] == ["1"]
+
+    @patch("rekordbox_edit.cli.import_.print_track_info")
+    @patch("rekordbox_edit.cli.import_.confirm", side_effect=UserQuit)
+    @patch("rekordbox_edit.cli.import_.import_tracks")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    def test_quitting_imports_nothing(
+        self, mock_db_class, mock_import, _confirm, _print
+    ):
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_import.return_value = _response()
+
+        result = CliRunner().invoke(import_command, ["/m/a.flac", "-i"])
+
+        assert result.exit_code == 0
+        mock_import.assert_called_once()  # preview only
+
+    @patch("rekordbox_edit.cli.import_.print_track_info")
+    @patch("rekordbox_edit.cli.import_.confirm", return_value=True)
+    @patch("rekordbox_edit.cli.import_.import_tracks")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    def test_a_create_with_a_playlist_asks_once(
+        self, mock_db_class, mock_import, mock_confirm, _print
+    ):
+        # The write pass places a newly created track in the playlist as part
+        # of the same op, so it must not be two questions.
+        mock_db_class.return_value = Mock(session=Mock())
+        preview = _response(playlist="Crate")
+        mock_import.side_effect = [preview, preview]
+
+        CliRunner().invoke(
+            import_command, ["/m/a.flac", "--to-playlist", "Crate", "-i"]
+        )
+
+        assert mock_confirm.call_count == 1
+        assert "and place it in Crate" in mock_confirm.call_args.args[0]
+
+
+class TestImportDryRunWalksDirectories:
+    @patch("rekordbox_edit.cli.import_.print_track_info")
+    @patch("rekordbox_edit.cli.import_.import_tracks")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    def test_dry_run_authorizes_the_walk(self, mock_db_class, mock_import, _print):
+        # Previewing is how you inspect what a walk covers, and it writes
+        # nothing, so it must not stop to ask.
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_import.return_value = _response()
+
+        result = CliRunner().invoke(import_command, ["/m/crate", "--dry-run"])
+
+        assert result.exit_code == 0
+        assert mock_import.call_args.args[1].recurse is True

--- a/tests/cli/test_locking.py
+++ b/tests/cli/test_locking.py
@@ -158,11 +158,14 @@ class TestWaitBudget:
 
 
 class TestBusyTimeout:
-    def test_pragma_is_applied_to_new_sqlite_connections(self, tmp_path):
+    def test_the_driver_supplies_a_busy_timeout_without_help(self, tmp_path):
+        # rekordbox-edit used to install this pragma through a connect
+        # listener. The DBAPI already sets it from sqlite3.connect's default
+        # timeout=5.0, so the listener set a value that was already in effect
+        # and was removed. Pinned here because dropping to 0 would quietly
+        # take the retry window away.
         from sqlalchemy import create_engine, text
-
-        from rekordbox_edit.cli._utils import BUSY_TIMEOUT_MS
 
         engine = create_engine(f"sqlite:///{tmp_path / 'probe.db'}")
         with engine.connect() as conn:
-            assert conn.execute(text("PRAGMA busy_timeout")).scalar() == BUSY_TIMEOUT_MS
+            assert conn.execute(text("PRAGMA busy_timeout")).scalar() >= 5000

--- a/tests/cli/test_locking.py
+++ b/tests/cli/test_locking.py
@@ -7,7 +7,7 @@ from click.testing import CliRunner
 
 from rekordbox_edit.cli.edit import edit_command
 from rekordbox_edit.cli.search import search_command
-from rekordbox_edit.locking import database_lock
+from tests.test_locking import foreign_holder
 from rekordbox_edit.models import (
     EditOp,
     EditResponse,
@@ -19,7 +19,7 @@ from rekordbox_edit.models import (
 
 @pytest.fixture(autouse=True)
 def mock_rekordbox_not_running():
-    with patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None):
+    with patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None):
         yield
 
 
@@ -53,7 +53,7 @@ class TestWriteLock:
         mock_db_class.return_value = Mock(session=Mock(), db_directory=library)
         mock_edit.return_value = _response()
 
-        with database_lock(library, command="convert", timeout=0):
+        with foreign_holder(library, command="convert"):
             result = CliRunner().invoke(edit_command, ["Title", "--replace", "New"])
 
         assert result.exit_code == 1
@@ -69,7 +69,7 @@ class TestWriteLock:
         mock_db_class.return_value = Mock(session=Mock(), db_directory=library)
         mock_edit.return_value = _response()
 
-        with database_lock(library, command="convert", timeout=0):
+        with foreign_holder(library, command="convert"):
             result = CliRunner().invoke(
                 edit_command, ["Title", "--replace", "New", "--dry-run"]
             )
@@ -85,7 +85,7 @@ class TestWriteLock:
         mock_db_class.return_value = Mock(session=Mock(), db_directory=library)
         mock_search.return_value = _search_response()
 
-        with database_lock(library, command="convert", timeout=0):
+        with foreign_holder(library, command="convert"):
             result = CliRunner().invoke(search_command, ["--title", "x"])
 
         assert result.exit_code == 0
@@ -100,7 +100,7 @@ class TestWriteLock:
 
         CliRunner().invoke(edit_command, ["Title", "--replace", "New", "--yes"])
 
-        with database_lock(library, command="convert", timeout=0):
+        with foreign_holder(library, command="convert"):
             pass
 
     @patch("rekordbox_edit.cli.edit.edit", side_effect=RuntimeError("boom"))
@@ -112,7 +112,7 @@ class TestWriteLock:
 
         CliRunner().invoke(edit_command, ["Title", "--replace", "New", "--yes"])
 
-        with database_lock(library, command="convert", timeout=0):
+        with foreign_holder(library, command="convert"):
             pass
 
 

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -278,3 +278,47 @@ class TestWithDatabaseErrorTranslation:
         result = self._invoke(mock_db_class, mock_edit, RuntimeError("boom"))
 
         assert isinstance(result.exception, RuntimeError)
+
+
+class TestInteractiveExclusivity:
+    """--interactive used to be discarded in silence whenever --yes or
+    --dry-run was present."""
+
+    @pytest.mark.parametrize(
+        "other,expected",
+        [
+            ("--yes", "asks about none"),
+            ("--dry-run", "nothing to confirm"),
+        ],
+    )
+    def test_interactive_conflicts_are_rejected(self, other, expected):
+        with pytest.raises(click.UsageError, match=expected):
+            _validate_scripting_preconditions(
+                PrintChoice.INFO,
+                piped_stdin=False,
+                dry_run=other == "--dry-run",
+                yes=other == "--yes",
+                interactive=True,
+            )
+
+    def test_interactive_alone_is_fine(self):
+        _validate_scripting_preconditions(
+            PrintChoice.INFO,
+            piped_stdin=False,
+            dry_run=False,
+            yes=False,
+            interactive=True,
+        )
+
+    def test_interactive_cannot_reach_a_scripting_print_mode(self):
+        # Prompts and the machine payload share stdout, so an interactive
+        # scripted run would interleave them. Exclusivity above rules the
+        # combination out before it can be reached.
+        with pytest.raises(click.UsageError, match="requires --dry-run or --yes"):
+            _validate_scripting_preconditions(
+                PrintChoice.IDS,
+                piped_stdin=False,
+                dry_run=False,
+                yes=False,
+                interactive=True,
+            )

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -236,7 +236,7 @@ class TestWithDatabaseErrorTranslation:
 
     @pytest.fixture(autouse=True)
     def _rekordbox_not_running(self):
-        with patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None):
+        with patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None):
             yield
 
     def _invoke(self, mock_db_class, mock_edit, error):

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -5,7 +5,7 @@ import pytest
 
 from click.testing import CliRunner
 
-from rekordbox_edit._click import PrintChoice
+from rekordbox_edit.logger import PrintChoice
 from rekordbox_edit.cli.edit import edit_command
 from rekordbox_edit.errors import (
     DatabaseBusyError,

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -3,12 +3,23 @@ from unittest.mock import Mock, patch
 import click
 import pytest
 
+from click.testing import CliRunner
+
 from rekordbox_edit._click import PrintChoice
+from rekordbox_edit.cli.edit import edit_command
+from rekordbox_edit.errors import (
+    DatabaseBusyError,
+    DependencyMissingError,
+    InputError,
+    RekordboxRunningError,
+)
 from rekordbox_edit.cli._utils import (
+    UserQuit,
     _handle_stdin,
     _print_response_ids,
     _print_response_json,
     _validate_scripting_preconditions,
+    confirm,
 )
 from rekordbox_edit.models import (
     ConvertOp,
@@ -139,3 +150,131 @@ class TestPrintResponseJson:
 
         payload = json.loads(capsys.readouterr().out)
         assert payload["result"]["format_out"] == "aiff"
+
+
+class TestConfirm:
+    """Test confirm function."""
+
+    @pytest.fixture
+    def mock_dependencies(self, mocker):
+        """Mock all dependencies for confirm function."""
+        mock_click_prompt = mocker.patch("rekordbox_edit.cli._utils.click.prompt")
+        mock_logger = mocker.patch("rekordbox_edit.cli._utils.logger")
+        return {
+            "click_prompt": mock_click_prompt,
+            "logger": mock_logger,
+        }
+
+    def test_confirm_yes(self, mock_dependencies):
+        """Test confirm returns True when user enters 'y'."""
+        mock_dependencies["click_prompt"].return_value = "y"
+
+        result = confirm("Continue?", default=False, abort=False)
+
+        assert result is True
+        mock_dependencies["click_prompt"].assert_called_once()
+
+    def test_confirm_no(self, mock_dependencies):
+        """Test confirm returns False when user enters 'n' with abort=False."""
+        mock_dependencies["click_prompt"].return_value = "n"
+
+        result = confirm("Continue?", default=True, abort=False)
+
+        assert result is False
+        mock_dependencies["click_prompt"].assert_called_once()
+
+    def test_confirm_quit(self, mock_dependencies):
+        """Test confirm raises UserQuit when user enters 'q' with abort=False."""
+        mock_dependencies["click_prompt"].return_value = "q"
+
+        with pytest.raises(UserQuit, match="User quit"):
+            confirm("Continue?", default=True, abort=False)
+
+    def test_confirm_no_abort_true(self, mock_dependencies):
+        """Test confirm raises UserQuit when user enters 'n' with abort=True."""
+        mock_dependencies["click_prompt"].return_value = "n"
+
+        with pytest.raises(UserQuit, match="User declined"):
+            confirm("Continue?", default=True, abort=True)
+
+        mock_dependencies["click_prompt"].assert_called_once()
+
+    def test_confirm_no_binary_true(self, mock_dependencies):
+        """Test confirm raises UserQuit when user enters 'n' with abort=True."""
+        mock_dependencies["click_prompt"].return_value = "n"
+
+        confirm("Continue?", default=True, binary=True)
+
+        mock_dependencies["click_prompt"].assert_called_once()
+
+    def test_confirm_case_insensitive_yes(self, mock_dependencies):
+        """Test confirm handles case-insensitive 'YES' input."""
+        mock_dependencies["click_prompt"].return_value = "Y"
+
+        result = confirm("Continue?", default=False, abort=False)
+
+        assert result is True
+
+    def test_confirm_case_insensitive_no(self, mock_dependencies):
+        """Test confirm handles case-insensitive 'NO' input."""
+        mock_dependencies["click_prompt"].return_value = "N"
+
+        result = confirm("Continue?", default=True, abort=False)
+
+        assert result is False
+
+    def test_confirm_case_insensitive_quit(self, mock_dependencies):
+        """Test confirm handles case-insensitive 'QUIT' input."""
+        mock_dependencies["click_prompt"].return_value = "Q"
+
+        with pytest.raises(UserQuit, match="User quit"):
+            confirm("Continue?", default=True, abort=False)
+
+
+class TestWithDatabaseErrorTranslation:
+    """with_database is the single place API errors become CLI ones."""
+
+    @pytest.fixture(autouse=True)
+    def _rekordbox_not_running(self):
+        with patch("rekordbox_edit.cli._utils.get_rekordbox_pid", return_value=None):
+            yield
+
+    def _invoke(self, mock_db_class, mock_edit, error):
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_edit.side_effect = error
+        return CliRunner().invoke(edit_command, ["Title", "--replace", "New", "--yes"])
+
+    @patch("rekordbox_edit.cli.edit.edit")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    def test_input_error_becomes_a_usage_error(self, mock_db_class, mock_edit):
+        result = self._invoke(mock_db_class, mock_edit, InputError("bad filter"))
+
+        assert result.exit_code == 2
+        assert "bad filter" in result.output
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            DependencyMissingError("FFmpeg is required"),
+            RekordboxRunningError("Rekordbox is running"),
+            DatabaseBusyError("another process holds the lock"),
+        ],
+    )
+    @patch("rekordbox_edit.cli.edit.edit")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    def test_environment_errors_log_and_exit_one(
+        self, mock_db_class, mock_edit, error, caplog
+    ):
+        result = self._invoke(mock_db_class, mock_edit, error)
+
+        assert result.exit_code == 1
+        assert str(error) in caplog.text
+
+    @patch("rekordbox_edit.cli.edit.edit")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    def test_unexpected_errors_are_not_swallowed(self, mock_db_class, mock_edit):
+        # A stray RuntimeError is a bug, not user error, so it must reach
+        # main()'s crash handler rather than being reported as usage.
+        result = self._invoke(mock_db_class, mock_edit, RuntimeError("boom"))
+
+        assert isinstance(result.exception, RuntimeError)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import pytest
 from pyrekordbox.db6 import DjmdContent
 
 from rekordbox_edit import locking
+from rekordbox_edit.api import _utils as api_utils
 
 from rekordbox_edit.models import Track
 
@@ -13,6 +14,13 @@ from rekordbox_edit.models import Track
 def isolated_lock_dir(tmp_path, monkeypatch):
     """Keep write-lock files out of the real user data directory during tests."""
     monkeypatch.setattr(locking, "_LOCK_DIR", tmp_path / "locks")
+
+
+@pytest.fixture(autouse=True)
+def rekordbox_not_running(monkeypatch):
+    """Every API write consults this, so leaving it live would fail the suite
+    on any machine with Rekordbox open. Tests about the refusal patch it back."""
+    monkeypatch.setattr(api_utils, "get_rekordbox_pid", lambda: None)
 
 
 @pytest.fixture

--- a/tests/test_locking.py
+++ b/tests/test_locking.py
@@ -1,8 +1,10 @@
 import json
 import logging
 import os
+from contextlib import contextmanager
 
 import pytest
+from filelock import FileLock
 
 from rekordbox_edit import locking
 from rekordbox_edit.locking import (
@@ -11,6 +13,29 @@ from rekordbox_edit.locking import (
     _lock_path,
     database_lock,
 )
+
+
+@contextmanager
+def foreign_holder(db_directory, command="convert"):
+    """Hold the lock the way a second rekordbox-edit process would.
+
+    A separate FileLock instance takes its own flock, which is what another
+    process does at the OS level. database_lock's own instances are per-path
+    singletons and so re-enter instead of blocking, which is deliberate but
+    makes them useless for simulating contention.
+    """
+    path = _lock_path(db_directory)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock = FileLock(str(path))
+    lock.acquire(timeout=0)
+    _holder_path(path).write_text(
+        json.dumps({"pid": os.getpid(), "command": command, "started": "00:00:00"}),
+        encoding="utf-8",
+    )
+    try:
+        yield path
+    finally:
+        lock.release()
 
 
 class TestLockPath:
@@ -22,11 +47,20 @@ class TestLockPath:
 
 
 class TestDatabaseLock:
-    def test_second_acquisition_raises_while_held(self, tmp_path):
-        with database_lock(tmp_path, command="convert", timeout=0):
+    def test_another_process_is_refused_while_held(self, tmp_path):
+        with foreign_holder(tmp_path):
             with pytest.raises(DatabaseBusyError):
                 with database_lock(tmp_path, command="edit", timeout=0):
                     pass
+
+    def test_nesting_within_one_process_re_enters(self, tmp_path):
+        # A CLI run holds this across plan and apply while each API call it
+        # makes takes it again; only the outermost release frees it.
+        with database_lock(tmp_path, command="convert", timeout=0):
+            with database_lock(tmp_path, command="convert", timeout=0):
+                pass
+        with foreign_holder(tmp_path):
+            pass  # fully released once the outer block exits
 
     def test_lock_is_released_on_exit(self, tmp_path):
         with database_lock(tmp_path, command="convert", timeout=0):
@@ -47,7 +81,7 @@ class TestDatabaseLock:
                 pass
 
     def test_busy_message_names_the_holder(self, tmp_path):
-        with database_lock(tmp_path, command="convert", timeout=0):
+        with foreign_holder(tmp_path, command="convert"):
             with pytest.raises(DatabaseBusyError) as excinfo:
                 with database_lock(tmp_path, command="edit", timeout=0):
                     pass
@@ -56,8 +90,8 @@ class TestDatabaseLock:
         assert '"convert"' in message
 
     def test_busy_message_falls_back_when_holder_unreadable(self, tmp_path):
-        with database_lock(tmp_path, command="convert", timeout=0):
-            _holder_path(_lock_path(tmp_path)).write_text("not json", encoding="utf-8")
+        with foreign_holder(tmp_path) as path:
+            _holder_path(path).write_text("not json", encoding="utf-8")
             with pytest.raises(DatabaseBusyError) as excinfo:
                 with database_lock(tmp_path, command="edit", timeout=0):
                     pass

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -8,7 +8,7 @@ import pytest
 from platformdirs import PlatformDirs
 
 import rekordbox_edit.logger as rbe_logger
-from rekordbox_edit._click import PrintChoice
+from rekordbox_edit.logger import PrintChoice
 from rekordbox_edit.logger import get_debug_file_path, set_level, setup_logging
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,6 @@ import pytest
 
 from rekordbox_edit.utils import (
     FILE_TYPES,
-    UserQuit,
     get_audio_info,
     get_extension_for_format,
     get_file_type_codes_for_format,
@@ -450,101 +449,6 @@ class TestGetAudioInfo:
 
         assert result["codec"] is None
         assert result["container"] is None
-
-
-class TestConfirm:
-    """Test confirm function."""
-
-    @pytest.fixture
-    def mock_dependencies(self, mocker):
-        """Mock all dependencies for confirm function."""
-        mock_click_prompt = mocker.patch("rekordbox_edit.utils.click.prompt")
-        mock_logger = mocker.patch("rekordbox_edit.utils.logger")
-        return {
-            "click_prompt": mock_click_prompt,
-            "logger": mock_logger,
-        }
-
-    def test_confirm_yes(self, mock_dependencies):
-        """Test confirm returns True when user enters 'y'."""
-        from rekordbox_edit.utils import confirm
-
-        mock_dependencies["click_prompt"].return_value = "y"
-
-        result = confirm("Continue?", default=False, abort=False)
-
-        assert result is True
-        mock_dependencies["click_prompt"].assert_called_once()
-
-    def test_confirm_no(self, mock_dependencies):
-        """Test confirm returns False when user enters 'n' with abort=False."""
-        from rekordbox_edit.utils import confirm
-
-        mock_dependencies["click_prompt"].return_value = "n"
-
-        result = confirm("Continue?", default=True, abort=False)
-
-        assert result is False
-        mock_dependencies["click_prompt"].assert_called_once()
-
-    def test_confirm_quit(self, mock_dependencies):
-        """Test confirm raises UserQuit when user enters 'q' with abort=False."""
-        from rekordbox_edit.utils import confirm
-
-        mock_dependencies["click_prompt"].return_value = "q"
-
-        with pytest.raises(UserQuit, match="User quit"):
-            confirm("Continue?", default=True, abort=False)
-
-    def test_confirm_no_abort_true(self, mock_dependencies):
-        """Test confirm raises UserQuit when user enters 'n' with abort=True."""
-        from rekordbox_edit.utils import confirm
-
-        mock_dependencies["click_prompt"].return_value = "n"
-
-        with pytest.raises(UserQuit, match="User declined"):
-            confirm("Continue?", default=True, abort=True)
-
-        mock_dependencies["click_prompt"].assert_called_once()
-
-    def test_confirm_no_binary_true(self, mock_dependencies):
-        """Test confirm raises UserQuit when user enters 'n' with abort=True."""
-        from rekordbox_edit.utils import confirm
-
-        mock_dependencies["click_prompt"].return_value = "n"
-
-        confirm("Continue?", default=True, binary=True)
-
-        mock_dependencies["click_prompt"].assert_called_once()
-
-    def test_confirm_case_insensitive_yes(self, mock_dependencies):
-        """Test confirm handles case-insensitive 'YES' input."""
-        from rekordbox_edit.utils import confirm
-
-        mock_dependencies["click_prompt"].return_value = "Y"
-
-        result = confirm("Continue?", default=False, abort=False)
-
-        assert result is True
-
-    def test_confirm_case_insensitive_no(self, mock_dependencies):
-        """Test confirm handles case-insensitive 'NO' input."""
-        from rekordbox_edit.utils import confirm
-
-        mock_dependencies["click_prompt"].return_value = "N"
-
-        result = confirm("Continue?", default=True, abort=False)
-
-        assert result is False
-
-    def test_confirm_case_insensitive_quit(self, mock_dependencies):
-        """Test confirm handles case-insensitive 'QUIT' input."""
-        from rekordbox_edit.utils import confirm
-
-        mock_dependencies["click_prompt"].return_value = "Q"
-
-        with pytest.raises(UserQuit, match="User quit"):
-            confirm("Continue?", default=True, abort=False)
 
 
 class TestProbeMatchesFileType:


### PR DESCRIPTION
Review of the two layers after recent changes: whether checks sit in the right place, whether flags behave consistently, and whether the Python API is a first-class surface.

## Layering

- Every API error now descends from `RekordboxEditError`; `with_database` owns the mapping to exit codes, removing four duplicated `try/except ValueError` blocks in `cli/edit.py`.
- The Rekordbox-running refusal and the single-writer lock move from the CLI into the three API write functions, so a Python caller gets both. The advisory lock is re-entrant within a process, so the CLI's whole-run lock still nests around it.
- `confirm`/`UserQuit` and `_click.py` move into `cli/`. No root module imports `click` or the `cli` package.

## Fixes

- A missing FFmpeg was reported as an unhandled exception asking the user to file a bug. It also reached `edit` as `unknown_file_type`, blaming every track for an empty PATH.
- `--interactive` was silently discarded whenever `--yes` or `--dry-run` was present; the combinations are now rejected.
- `edit` reported skipped tracks in no code path, so a filter matching 30 tracks and editing 4 looked like it found 4.
- The `--multi` guard fired on dry runs, contradicting its own advice to inspect with one and making `--interactive` unreachable on bulk edits.
- `import --dry-run` refused to walk a directory even though it writes nothing.

## Additions

- `import` gains `--interactive`, the only write command without it.
- Handlers declare `forceable_skip_reasons` instead of the CLI restating them.

## Notes

- The busy-timeout listener was deleted, not moved: `sqlite3.connect`'s default already applies 5000ms, so it set a value already in effect.
- Behaviour change: with Rekordbox open, an interactive run now refuses at the apply pass rather than before the preview.

Verified with `make lint`, `make typecheck`, `make test` (703 passed), `make docs-build --strict`, and `make test-e2e-docker` (33 passed).