### PR TITLE
feat!: clean up flags and make them consistent across apis

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Edit track metadata:
 
 ```bash
 # Fix a typo across every matching track title
-rbe edit --title "Teh" Title --match "Teh" --replace "The" --multi
+rbe edit --title "Teh" Title --match "Teh" --replace "The"
 ```
 
 Convert audio files:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Convert audio files:
 
 ```bash
 # Preview what would be converted
-rbe convert --artist "Daft Punk" --dry-run
+rbe convert --artist "Daft Punk" --format-out aiff --dry-run
 
 # Convert all FLAC or WAV files to AIFF without confirming
 rbe convert --format flac --format wav --format-out aiff --yes

--- a/docs/api.md
+++ b/docs/api.md
@@ -25,8 +25,8 @@ duration of the write to prevent concurrent writes by other rekordbox-edit proce
 
 ## Errors
 
-Every error these functions raise on purpose descends from
-[`RekordboxEditError`][rekordbox_edit.errors.RekordboxEditError], so one `except` clause covers them.
+Most errors these functions raise descend from
+[`RekordboxEditError`][rekordbox_edit.errors.RekordboxEditError].
 [`InputError`][rekordbox_edit.errors.InputError] also subclasses `ValueError`.
 
 ::: rekordbox_edit.errors

--- a/docs/api.md
+++ b/docs/api.md
@@ -30,8 +30,6 @@ Most errors these functions raise descend from
 [`InputError`][rekordbox_edit.errors.InputError] also subclasses `ValueError`.
 
 ::: rekordbox_edit.errors
-options:
-heading_level: 3
 
 ## Functions
 
@@ -48,83 +46,47 @@ heading_level: 3
 The models form three layers: the [`FilterArgs`][rekordbox_edit.models.FilterArgs] base that every command shares, the per-command requests and responses, and the lower-level domain types those req/resp models are built from.
 
 ::: rekordbox_edit.models.FilterArgs
-options:
-heading_level: 3
 
 ### Search
 
 ::: rekordbox_edit.models.SearchRequest
-options:
-heading_level: 4
 
 ::: rekordbox_edit.models.SearchResponse
-options:
-heading_level: 4
 
 ### Edit
 
 ::: rekordbox_edit.models.EditRequest
-options:
-heading_level: 4
 
 ::: rekordbox_edit.models.EditResponse
-options:
-heading_level: 4
 
 ::: rekordbox_edit.models.EditResult
-options:
-heading_level: 4
 
 ### Convert
 
 ::: rekordbox_edit.models.ConvertRequest
-options:
-heading_level: 4
 
 ::: rekordbox_edit.models.ConvertResponse
-options:
-heading_level: 4
 
 ::: rekordbox_edit.models.ConvertResult
-options:
-heading_level: 4
 
 ### Import
 
 ::: rekordbox_edit.models.ImportRequest
-options:
-heading_level: 4
 
 ::: rekordbox_edit.models.ImportResponse
-options:
-heading_level: 4
 
 ::: rekordbox_edit.models.ImportResult
-options:
-heading_level: 4
 
 ### Miscellaneous
 
 ::: rekordbox_edit.models.Track
-options:
-heading_level: 4
 
 ::: rekordbox_edit.models.EditOp
-options:
-heading_level: 4
 
 ::: rekordbox_edit.models.ConvertOp
-options:
-heading_level: 4
 
 ::: rekordbox_edit.models.ImportOp
-options:
-heading_level: 4
 
 ::: rekordbox_edit.models.SkippedTrack
-options:
-heading_level: 4
 
 ::: rekordbox_edit.models.SkipReason
-options:
-heading_level: 4

--- a/docs/commands/convert.md
+++ b/docs/commands/convert.md
@@ -21,9 +21,11 @@ All conversions target **16-bit / 44.1 kHz**, with a few nuances:
 
 `--delete-originals` controls what happens to the source file after a successful conversion:
 
-- `lossless` (default) — delete the original only when the conversion lost no audio information; keep it when the conversion was lossy (MP3 output or down-sampled hi-res output)
+- `none` (default) — never delete the original
+- `lossless` — delete the original only when the conversion lost no audio information; keep it when the conversion was lossy (MP3 output or down-sampled hi-res output)
 - `all` — always delete the original
-- `none` — never delete the original
+
+Deleting a source file is not something a run should do unless you asked for it, so the default keeps every original and you opt in per run.
 
 ## Converting Several Files at Once
 

--- a/docs/commands/convert.md
+++ b/docs/commands/convert.md
@@ -5,9 +5,9 @@ Convert audio files between formats and update the Rekordbox database to point a
 ## Supported Formats
 
 - **Input:** FLAC, AIFF, WAV (hi-res formats only — lossy-compressed sources are skipped)
-- **Output:** AIFF (default), FLAC, WAV, or MP3 (320kbps CBR)
+- **Output:** AIFF, FLAC, WAV, or MP3 (320kbps CBR), chosen with the required `--format-out`
 
-Tracks already in the target format are skipped. So are tracks whose output file already exists: `convert` counts them and asks whether to overwrite, defaulting to no. `--overwrite` answers that up front and no prompt appears, while `--yes` takes the default and leaves them skipped.
+Tracks already in the target format are skipped. So are tracks whose output file already exists: `convert` counts them and asks whether to overwrite, defaulting to no. `--yes` will skip these without asking, whereas `--overwrite` will overwrite them without asking.
 
 ## Bit Depth and Sample Rate
 
@@ -24,8 +24,6 @@ All conversions target **16-bit / 44.1 kHz**, with a few nuances:
 - `none` (default) — never delete the original
 - `lossless` — delete the original only when the conversion lost no audio information; keep it when the conversion was lossy (MP3 output or down-sampled hi-res output)
 - `all` — always delete the original
-
-Deleting a source file is not something a run should do unless you asked for it, so the default keeps every original and you opt in per run.
 
 ## Converting Several Files at Once
 
@@ -60,7 +58,7 @@ rbe convert --format-out aiff --format flac --yes --delete-originals lossless
 rbe convert --format-out aiff --format flac --print ids --dry-run
 
 # Convert everything a search finds
-rbe search --artist "Lauryn Hill" --print ids | rbe convert --yes
+rbe search --artist "Lauryn Hill" --print ids | rbe convert --format-out aiff --yes
 
 # Max out your CPU to handle a batch of MP3s
 rbe convert --format-out mp3 --playlist "NeedsConverting" --threads 8 --yes

--- a/docs/commands/convert.md
+++ b/docs/commands/convert.md
@@ -7,7 +7,7 @@ Convert audio files between formats and update the Rekordbox database to point a
 - **Input:** FLAC, AIFF, WAV (hi-res formats only — lossy-compressed sources are skipped)
 - **Output:** AIFF (default), FLAC, WAV, or MP3 (320kbps CBR)
 
-Tracks already in the target format are skipped, as are tracks whose output file already exists (override with `--overwrite`).
+Tracks already in the target format are skipped. So are tracks whose output file already exists: `convert` counts them and asks whether to overwrite, defaulting to no. `--overwrite` answers that up front and no prompt appears, while `--yes` takes the default and leaves them skipped.
 
 ## Bit Depth and Sample Rate
 

--- a/docs/commands/convert.md
+++ b/docs/commands/convert.md
@@ -53,8 +53,8 @@ rbe convert --format-out wav --artist "Burial" --yes
 # Convert to MP3 but delete originals
 rbe convert --format-out mp3 --playlist "Export" --yes --delete-originals all
 
-# Keep originals when converting to AIFF
-rbe convert --format-out aiff --format flac --yes --delete-originals none
+# Delete originals only where the conversion lost nothing
+rbe convert --format-out aiff --format flac --yes --delete-originals lossless
 
 # Get just the IDs of files that would be converted
 rbe convert --format-out aiff --format flac --print ids --dry-run
@@ -68,7 +68,7 @@ rbe convert --format-out mp3 --playlist "NeedsConverting" --threads 8 --yes
 
 ### Checks
 
-- Without flags, `convert` shows every planned change and asks once before applying. `--interactive` confirms each track individually; `--dry-run` previews without writing; `--yes` confirms the default choice for all prompts without asking. `--interactive` cannot be combined with `--yes` or `--dry-run`.
+- Without flags, `convert` shows every planned change and asks once before applying. See [Confirmations](../filtering.md#confirmations) for how `--dry-run`, `--interactive`, and `--yes` change that.
 - `convert` will encode exactly the tracks the preview showed. If in between the time you're prompted and later confirm a new track that matches your filters lands in your library, it won't be included.
 - **Rekordbox running:** Writing while Rekordbox is open risks losing your changes, so `convert` will refuse to perform any writes. `--dry-run` is unaffected.
 - Before a large run, walk through the checklist in [What Should I Do Before Converting?](../faqs.md#what-should-i-do-before-converting)

--- a/docs/commands/edit.md
+++ b/docs/commands/edit.md
@@ -44,7 +44,7 @@ rbe edit --exact-title "Acid Rain" FolderPath --replace "/Users/me/Music/acid-ra
 
 ## Checks
 
-- Without flags, `edit` shows every planned change and asks once before applying. `--interactive` confirms each track individually; `--dry-run` previews without writing; `--yes` confirms the default choice for all prompts without asking. `--interactive` cannot be combined with `--yes` or `--dry-run`.
+- Without flags, `edit` shows every planned change and asks once before applying. See [Confirmations](../filtering.md#confirmations) for how `--dry-run`, `--interactive`, and `--yes` change that.
 - `edit` writes exactly the tracks the preview showed. If in between the time you're prompted and later confirm a new track lands in your library that matches your filters, it won't be included. A track whose file changed in that window is skipped rather than written with stale metadata.
 - **Rekordbox running:** writing while Rekordbox is open risks losing your changes, so `edit` will refuse to perform any writes. `--dry-run` is unaffected.
 

--- a/docs/commands/edit.md
+++ b/docs/commands/edit.md
@@ -32,7 +32,7 @@ By default edits will be skipped in the following cases:
 - The new path points to a file whose duration doesn't match what's in rekordbox _and_ the track has cues or an analysis, since those are time-indexed and would land misaligned.
 - The file's format is one Rekordbox doesn't support--this is always skipped.
 
-`edit` lists the held-back tracks and asks once whether to include them. Providing the `--yes` flag will skip them without prompting whereas `--force` edit them anyway. Including a missing file writes only the path columns.
+Each of the first two cases is a gate with its own flag, and `edit` lists the tracks it holds back and asks about it separately: `--allow-missing` writes a path with no file behind it, updating only the path columns, and `--allow-mismatch` accepts a duration that contradicts the stored length. Passing a flag answers its question up front, so no prompt appears. `--yes` takes the default answer to every prompt, and a gate's default is no, so `--yes` on its own leaves the held-back tracks skipped and reports them.
 
 ```bash
 # Relocate a library folder in bulk

--- a/docs/commands/edit.md
+++ b/docs/commands/edit.md
@@ -46,7 +46,6 @@ rbe edit --exact-title "Acid Rain" FolderPath --replace "/Users/me/Music/acid-ra
 
 - Without flags, `edit` shows every planned change and asks once before applying. `--interactive` confirms each track individually; `--dry-run` previews without writing; `--yes` confirms the default choice for all prompts without asking. `--interactive` cannot be combined with `--yes` or `--dry-run`.
 - `edit` writes exactly the tracks the preview showed. If in between the time you're prompted and later confirm a new track lands in your library that matches your filters, it won't be included. A track whose file changed in that window is skipped rather than written with stale metadata.
-- When filters match more than one track, an unattended run (i.e. `--yes`) refuses unless you pass `--multi`. This prevents a mistakenly broad filter from editing across many tracks mistakenly. `--dry-run` and `--interactive` are unaffected.
 - **Rekordbox running:** writing while Rekordbox is open risks losing your changes, so `edit` will refuse to perform any writes. `--dry-run` is unaffected.
 
 ## Examples
@@ -59,7 +58,7 @@ rbe edit --title "(Original Mix)" Title --match " (Original Mix)" --replace "" -
 rbe edit --title "(Original Mix)" Title --match " (Original Mix)" --replace "" --interactive
 
 # Pipe a search result in and edit those exact tracks
-rbe search --playlist "Mislabeled" --print ids | rbe edit Title --match "  " --replace " " --multi --yes
+rbe search --playlist "Mislabeled" --print ids | rbe edit Title --match "  " --replace " " --yes
 ```
 
 See [Filtering](../filtering.md) for the full filter language.

--- a/docs/commands/import.md
+++ b/docs/commands/import.md
@@ -37,7 +37,7 @@ A file already in the library, matched by its resolved, case-insensitive path, i
 
 ## Checks
 
-- Without flags, `import` shows every track it plans to add and asks once before writing; `--interactive` asks about each file separately; `--dry-run` previews without writing; `--yes` confirms the default choice for all prompts without asking. `--interactive` cannot be combined with `--yes` or `--dry-run`.
+- Without flags, `import` shows every track it plans to add and asks once before writing. See [Confirmations](../filtering.md#confirmations) for how `--dry-run`, `--interactive`, and `--yes` change that.
 - A directory argument is walked recursively for audio files. Ran interactively, `import` reports how many files it found and asks before continuing. `--yes` authorizes the walk outright, and is required alongside a non-interactive `--print` mode. `--dry-run` walks without asking, since it writes nothing.
 - **Rekordbox running:** writing while Rekordbox is open risks losing your changes, so `import` will refuse to perform any writes. `--dry-run` is unaffected.
 

--- a/docs/commands/search.md
+++ b/docs/commands/search.md
@@ -15,7 +15,7 @@ rbe search --playlist "Techno" --print ids
 rbe search --playlist "Techno" --format flac --match-any
 
 # Feed results to another command
-rbe search --artist "Lauryn Hill" --print ids | rbe convert --yes
+rbe search --artist "Lauryn Hill" --print ids | rbe convert --format-out aiff --yes
 ```
 
 See [Filtering](../filtering.md) for the full filter language and piping recipes.

--- a/docs/filtering.md
+++ b/docs/filtering.md
@@ -87,6 +87,26 @@ All commands take `--print [silent|ids|info|debug|json]`:
 
     `silent`, `ids`, and `json` are non-interactive print modes, so they require `--yes` or `--dry-run`.
 
+## Confirmations
+
+Every command that writes previews its plan and asks before applying it. Three flags change that, and they mean the same thing in `edit`, `convert`, and `import`:
+
+- `--dry-run` prints the plan and stops. Nothing is written.
+- `--interactive` (`-i`) asks about each item separately rather than once about the whole plan. It cannot be combined with `--yes` or `--dry-run`.
+- `--yes` (`-y`) takes the default answer to every prompt instead of asking.
+
+The last one is worth stating precisely, because `--yes` is not "say yes to everything." A few prompts guard a specific risky condition, and those default to **no**:
+
+| Prompt | Default | Flag that authorizes it |
+|---|---|---|
+| Write a `FolderPath` with no file behind it | no | `--allow-missing` |
+| Write a `FolderPath` whose duration contradicts the stored length | no | `--allow-mismatch` |
+| Overwrite an output file that already exists | no | `--overwrite` |
+
+So `rbe edit FolderPath --replace /new/path --yes` skips the tracks whose new path does not exist and reports them; adding `--allow-missing` is what writes them. Passing one of these flags also answers its question up front, so the prompt does not appear in an interactive run either.
+
+Every item a command passes over is accounted for by reason when the run finishes, whether a gate held it back or a filter matched a track that needed no change.
+
 ## Scripting and Piping
 
 `--print ids` output feeds straight into another command's track-ID arguments:

--- a/docs/filtering.md
+++ b/docs/filtering.md
@@ -89,23 +89,17 @@ All commands take `--print [silent|ids|info|debug|json]`:
 
 ## Confirmations
 
-Every command that writes previews its plan and asks before applying it. Three flags change that, and they mean the same thing in `edit`, `convert`, and `import`:
+Every command that writes previews its plan and asks before applying it. You can change this behavior by providing one of:
 
 - `--dry-run` prints the plan and stops. Nothing is written.
 - `--interactive` (`-i`) asks about each item separately rather than once about the whole plan. It cannot be combined with `--yes` or `--dry-run`.
-- `--yes` (`-y`) takes the default answer to every prompt instead of asking.
+- `--yes` (`-y`) approves the plan and other prompts without asking.
 
-The last one is worth stating precisely, because `--yes` is not "say yes to everything." A few prompts guard a specific risky condition, and those default to **no**:
+!!! note
 
-| Prompt | Default | Flag that authorizes it |
-|---|---|---|
-| Write a `FolderPath` with no file behind it | no | `--allow-missing` |
-| Write a `FolderPath` whose duration contradicts the stored length | no | `--allow-mismatch` |
-| Overwrite an output file that already exists | no | `--overwrite` |
+    Command-specific guards require providing their corresponding flag to override their default behavior. For example, providing `--yes` to the convert command will not overwrite existing files unless you explicitly provide the `--overwrite` flag.
 
-So `rbe edit FolderPath --replace /new/path --yes` skips the tracks whose new path does not exist and reports them; adding `--allow-missing` is what writes them. Passing one of these flags also answers its question up front, so the prompt does not appear in an interactive run either.
-
-Every item a command passes over is accounted for by reason when the run finishes, whether a gate held it back or a filter matched a track that needed no change.
+For every command, if a check decides to skip them, the corresponding operation will be returned in the response with an explanatory [SkipReason](api.md#rekordbox_edit.models.SkipReason).
 
 ## Scripting and Piping
 
@@ -113,7 +107,7 @@ Every item a command passes over is accounted for by reason when the run finishe
 
 ```bash
 # Convert all of the items found by the initial search command
-rbe search --artist "Lauryn Hill" --print ids | rbe convert --yes
+rbe search --artist "Lauryn Hill" --print ids | rbe convert --format-out aiff --yes
 ```
 
 **OR between AND-groups** — merge results from two commands using a subshell:

--- a/rekordbox_edit/api/edit.py
+++ b/rekordbox_edit/api/edit.py
@@ -74,10 +74,6 @@ def edit(
     that started matching after the plan was made will not join the edit; each
     op is re-checked against the filesystem and reported as
     `db_or_fs_changed` if it no longer holds.
-
-    `multi` guards the unattended case: a filter matching several rows applied
-    in one shot. A dry run only reports, and an `ops` list was approved by
-    whoever built it, so neither needs the flag.
     """
     logger.debug(f"edit start field={args.field} dry_run={dry_run}")
     handler = FIELD_HANDLERS.get(args.field)
@@ -98,13 +94,6 @@ def edit(
             else:
                 skipped.append(result)
         logger.debug(f"edit classified ops={len(planned)} skipped={len(skipped)}")
-
-        if not dry_run and len(planned) > 1 and not args.multi:
-            logger.debug(f"edit aborted on multi guard with {len(planned)} ops")
-            raise InputError(
-                f"Found {len(planned)} tracks that would be edited. "
-                "Refine your filters, use dry_run to inspect, or pass multi=True to edit all."
-            )
     else:
         rows = find_content_by_ids(db, [op.id for op in ops])
         contents = []

--- a/rekordbox_edit/api/field_handlers.py
+++ b/rekordbox_edit/api/field_handlers.py
@@ -34,12 +34,12 @@ class FieldHandler:
     name: str
     supports_match: bool = True
 
-    forceable_skip_reasons: frozenset[SkipReason] = frozenset()
-    """Reasons this handler's validate_track returns that `force` overrides.
+    gated_skip_reasons: dict[SkipReason, str] = {}
+    """Skip reasons validate_track returns that a request field authorizes,
+    mapped to the name of that `EditRequest` field.
 
-    Declared here so a caller offering to retry with force does not have to
-    keep its own copy of what force covers, which would silently stop covering
-    a reason added later.
+    Declared here so a caller offering to lift a gate does not keep its own
+    copy of which gates exist or which flag lifts each one.
     """
 
     def validate_request(self, args: EditRequest) -> None:
@@ -221,15 +221,18 @@ class FolderPathField(FieldHandler):
     keeps the columns describing that file in sync.
 
     Validation stats the target: a missing file skips the track (or, under
-    force, writes the path without any metadata sync), a byte-identical file
-    needs no probe or sync, and a changed file is probed. A probed duration
+    allow_missing, writes the path without any metadata sync), a byte-identical
+    file needs no probe or sync, and a changed file is probed. A probed duration
     contradicting the stored Length gates tracks whose cues or analysis are
-    time-indexed, since those would land misaligned; force overrides both
-    gates. A probe no Rekordbox FileType matches always skips."""
+    time-indexed, since those would land misaligned; allow_mismatch lifts that
+    gate. A probe no Rekordbox FileType matches always skips."""
 
     name = "FolderPath"
     supports_match = True
-    forceable_skip_reasons = frozenset({"file_not_found", "length_mismatch"})
+    gated_skip_reasons = {
+        "file_not_found": "allow_missing",
+        "length_mismatch": "allow_mismatch",
+    }
 
     _LENGTH_TOLERANCE_SECONDS = 1.0
 
@@ -252,7 +255,7 @@ class FolderPathField(FieldHandler):
 
     def validate_track(self, db, content, new_value, args):
         if not os.path.exists(new_value):
-            if args.force:
+            if args.allow_missing:
                 logger.warning(
                     f"{new_value} does not exist; writing the path without "
                     "syncing audio metadata"
@@ -287,7 +290,7 @@ class FolderPathField(FieldHandler):
                 f"{new_value} runs {duration:.1f}s but the track's stored "
                 f"length is {content.Length}s"
             )
-            if args.force:
+            if args.allow_mismatch:
                 logger.warning(f"{mismatch}; cues and beat grid may be misaligned")
             elif self._has_time_indexed_analysis(db, content):
                 return "length_mismatch"

--- a/rekordbox_edit/cli/_click.py
+++ b/rekordbox_edit/cli/_click.py
@@ -173,8 +173,8 @@ convert_click_options = [
     click.option(
         "--delete-originals",
         type=click.Choice(["none", "lossless", "all"], case_sensitive=False),
-        default="lossless",
-        help="When to delete original files after conversion: 'lossless' deletes them only when no audio information was lost (down-sampling and MP3 output count as lossy), 'all' always deletes them, 'none' never deletes them (default: lossless)",
+        default="none",
+        help="When to delete original files after conversion: 'none' never deletes them, 'lossless' deletes them only when no audio information was lost (down-sampling and MP3 output count as lossy), 'all' always deletes them (default: none)",
     ),
     click.option(
         "--overwrite",

--- a/rekordbox_edit/cli/_click.py
+++ b/rekordbox_edit/cli/_click.py
@@ -130,7 +130,7 @@ yes_option = click.option(
     "--yes",
     "-y",
     is_flag=True,
-    help="Skip confirmation prompt",
+    help="Take the default answer to every confirmation prompt instead of asking. Prompts guarding a risky condition default to no, so --yes leaves those items out unless the flag naming that condition is also passed",
 )
 
 interactive_option = click.option(

--- a/rekordbox_edit/cli/_click.py
+++ b/rekordbox_edit/cli/_click.py
@@ -158,11 +158,6 @@ edit_click_options = [
         help="Find this literal string within the field value and replace only that portion",
     ),
     click.option(
-        "--multi",
-        is_flag=True,
-        help="Allow editing more than one track (required when --yes applies a filter matching several)",
-    ),
-    click.option(
         "--force",
         is_flag=True,
         help="Proceed past per-track safety gates that would otherwise skip a track (e.g. a FolderPath target that is missing or whose duration contradicts the track's stored length)",

--- a/rekordbox_edit/cli/_click.py
+++ b/rekordbox_edit/cli/_click.py
@@ -158,9 +158,14 @@ edit_click_options = [
         help="Find this literal string within the field value and replace only that portion",
     ),
     click.option(
-        "--force",
+        "--allow-missing",
         is_flag=True,
-        help="Proceed past per-track safety gates that would otherwise skip a track (e.g. a FolderPath target that is missing or whose duration contradicts the track's stored length)",
+        help="Write a FolderPath that does not exist instead of skipping the track. The columns describing the audio file are left alone, since there is no file to read them from",
+    ),
+    click.option(
+        "--allow-mismatch",
+        is_flag=True,
+        help="Write a FolderPath whose duration contradicts the track's stored length instead of skipping the track. Cues and the beat grid may land misaligned",
     ),
 ]
 

--- a/rekordbox_edit/cli/_click.py
+++ b/rekordbox_edit/cli/_click.py
@@ -130,7 +130,7 @@ yes_option = click.option(
     "--yes",
     "-y",
     is_flag=True,
-    help="Take the default answer to every confirmation prompt instead of asking. Prompts guarding a risky condition default to no, so --yes leaves those items out unless the flag naming that condition is also passed",
+    help="Accept the command's plan without asking. Per-command guards require their corresponding flag to override.",
 )
 
 interactive_option = click.option(
@@ -191,8 +191,8 @@ convert_click_options = [
     click.option(
         "--format-out",
         type=click.Choice(["aiff", "flac", "wav", "mp3"], case_sensitive=False),
-        default="aiff",
-        help="Output format (default: aiff)",
+        required=True,
+        help="Format to convert to",
     ),
 ]
 

--- a/rekordbox_edit/cli/convert.py
+++ b/rekordbox_edit/cli/convert.py
@@ -90,7 +90,13 @@ def convert_command(db, **kwargs):
 
     # Default / interactive: preview first.
     preview = convert(db, args, dry_run=True)
-    _report_skips(preview.result.skipped)
+
+    try:
+        args, preview, named = _prompt_overwrite(db, args, preview)
+    except UserQuit:
+        return
+
+    _report_skips(preview.result.skipped, exclude=named)
 
     if not preview.result.converted:
         logger.info("No files need conversion.")
@@ -160,33 +166,54 @@ def _convert_reporting_partials(
         sys.exit(1)
 
 
-def _report_skips(skipped) -> None:
-    already_target = sum(1 for s in skipped if s.reason == "already_target_format")
-    unsupported = sum(1 for s in skipped if s.reason == "unsupported_source_format")
-    conflicts = sum(1 for s in skipped if s.reason == "output_file_exists")
-    mismatches = sum(1 for s in skipped if s.reason == "codec_mismatch")
-    missing = sum(1 for s in skipped if s.reason == "file_not_found")
-    drifted = sum(1 for s in skipped if s.reason == "db_or_fs_changed")
-    if already_target:
-        logger.warning(f"Skipping {already_target} file(s): already in target format")
-    if unsupported:
-        logger.warning(
-            f"Skipping {unsupported} file(s): unsupported source format "
-            "(only FLAC, ALAC, AIFF, WAV are converted)"
-        )
-    if conflicts:
-        logger.warning(
-            f"Skipping {conflicts} file(s): output exists (use --overwrite to convert)"
-        )
-    if mismatches:
-        logger.warning(
-            f"Skipping {mismatches} file(s): file content does not match its "
-            "Rekordbox file type"
-        )
-    if missing:
-        logger.warning(f"Skipping {missing} file(s): source file is gone")
-    if drifted:
-        logger.warning(f"Skipping {drifted} file(s): changed since the preview")
+def _prompt_overwrite(db, args, preview):
+    """Offer to clobber output files that already exist, which are skipped by
+    default.
+
+    Returns the request and preview to carry forward, and the skip reason this
+    prompt accounted for so the summary does not repeat it. Passing
+    `--overwrite` answers the question up front, so no prompt appears.
+    """
+    if args.overwrite:
+        return args, preview, frozenset()
+    conflicts = [s for s in preview.result.skipped if s.reason == "output_file_exists"]
+    if not conflicts:
+        return args, preview, frozenset()
+
+    logger.info(
+        f"{len(conflicts)} file(s) already have a {args.format_out.upper()} file "
+        "at the path this would write."
+    )
+    if not confirm(
+        f"Overwrite {len(conflicts)} existing output file(s)?", default=False
+    ):
+        return args, preview, frozenset({"output_file_exists"})
+
+    args = args.model_copy(update={"overwrite": True})
+    return args, convert(db, args, dry_run=True), frozenset()
+
+
+#: How each skip reason reads as a one-line summary, so a run that converted 4
+#: of the 30 files a filter matched accounts for the other 26.
+_SKIP_MESSAGES: dict[str, str] = {
+    "already_target_format": "already in target format",
+    "unsupported_source_format": (
+        "unsupported source format (only FLAC, ALAC, AIFF, WAV are converted)"
+    ),
+    "output_file_exists": "output exists (use --overwrite to convert)",
+    "codec_mismatch": "file content does not match its Rekordbox file type",
+    "file_not_found": "source file is gone",
+    "db_or_fs_changed": "changed since the preview",
+}
+
+
+def _report_skips(skipped, *, exclude: frozenset[str] = frozenset()) -> None:
+    for reason, message in _SKIP_MESSAGES.items():
+        if reason in exclude:
+            continue
+        count = sum(1 for s in skipped if s.reason == reason)
+        if count:
+            logger.warning(f"Skipping {count} file(s): {message}")
 
 
 def _print_convert_result(

--- a/rekordbox_edit/cli/edit.py
+++ b/rekordbox_edit/cli/edit.py
@@ -86,26 +86,10 @@ def edit_command(db, **kwargs):
     # Default / interactive: preview first.
     preview = edit(db, args, dry_run=True)
 
-    forceable = FIELD_HANDLERS[args.field].forceable_skip_reasons
-    gated = [s for s in preview.result.skipped if s.reason in forceable]
-    # Reasons the prompt below spells out per track, so the summary does not
-    # repeat them.
-    reported_individually: frozenset[str] = frozenset()
-    if gated and not args.force:
-        reported_individually = forceable
-        logger.info(f"{len(gated)} track(s) were held back by safety checks:")
-        for s in gated:
-            logger.info(f"  {s.id}: {s.reason}")
-        try:
-            if confirm(
-                f"Include {len(gated)} held-back track(s) anyway (--force)?",
-                default=False,
-            ):
-                args = args.model_copy(update={"force": True})
-                preview = edit(db, args, dry_run=True)
-                reported_individually = frozenset()
-        except UserQuit:
-            return
+    try:
+        args, preview, reported_individually = _prompt_gates(db, args, preview)
+    except UserQuit:
+        return
 
     _report_skips(preview.result.skipped, exclude=reported_individually)
 
@@ -147,14 +131,47 @@ def edit_command(db, **kwargs):
     _print_edit_result(response, print_opt, dry_run=False)
 
 
+def _prompt_gates(db, args, preview):
+    """Offer to lift each safety gate holding tracks back, one prompt per gate.
+
+    Gates ask about a condition the user did not ask for, so each defaults to
+    no and each is asked separately: authorizing a path with no file behind it
+    is a different decision from authorizing cues that may land misaligned.
+    A gate whose flag is already set is not re-asked.
+
+    Returns the request and preview to carry forward, and the reasons these
+    prompts already spelled out track by track so the summary skips them.
+    """
+    lifted: dict[str, bool] = {}
+    named: set[str] = set()
+    for reason, field in FIELD_HANDLERS[args.field].gated_skip_reasons.items():
+        if getattr(args, field):
+            continue
+        held = [s for s in preview.result.skipped if s.reason == reason]
+        if not held:
+            continue
+        named.add(reason)
+        logger.info(f"{len(held)} track(s) held back: {_SKIP_MESSAGES[reason]}")
+        for s in held:
+            logger.info(f"  {s.id}")
+        if confirm(f"Include {len(held)} held-back track(s) anyway?", default=False):
+            lifted[field] = True
+            named.discard(reason)
+
+    if lifted:
+        args = args.model_copy(update=lifted)
+        preview = edit(db, args, dry_run=True)
+    return args, preview, frozenset(named)
+
+
 #: How each skip reason reads as a one-line summary. Phrased as a reason rather
 #: than a reason code, since these are the only account a user gets of tracks
 #: their filters matched but the command did not touch.
 _SKIP_MESSAGES: dict[str, str] = {
     "no_change": "existing value already matches the requested value",
-    "file_not_found": "file does not exist",
+    "file_not_found": "file does not exist (override with --allow-missing)",
     "length_mismatch": (
-        "file's duration contradicts the stored length (override with --force)"
+        "file's duration contradicts the stored length (override with --allow-mismatch)"
     ),
     "unknown_file_type": "file is in format Rekordbox doesn't support",
     "db_or_fs_changed": "changed since the preview",

--- a/rekordbox_edit/models.py
+++ b/rekordbox_edit/models.py
@@ -101,7 +101,9 @@ DEFAULT_THREADS = min(4, os.cpu_count() or 1)
 class ConvertRequest(FilterArgs):
     """Inputs for convert(): the shared track filters plus output format and original-file handling."""
 
-    format_out: str = "aiff"
+    format_out: str
+    """The target format. Required: a conversion that picked its own output
+    format would be a guess at what the caller wanted."""
     delete_originals: DeleteOriginalsMode = "none"
     """When to delete original files after conversion: "none" (the default)
     never deletes them, "all" always deletes them, and "lossless" deletes them

--- a/rekordbox_edit/models.py
+++ b/rekordbox_edit/models.py
@@ -102,9 +102,9 @@ class ConvertRequest(FilterArgs):
     """Inputs for convert(): the shared track filters plus output format and original-file handling."""
 
     format_out: str = "aiff"
-    delete_originals: DeleteOriginalsMode = "lossless"
-    """When to delete original files after conversion: "all" always deletes
-    them, "none" never deletes them, and "lossless" (the default) deletes them
+    delete_originals: DeleteOriginalsMode = "none"
+    """When to delete original files after conversion: "none" (the default)
+    never deletes them, "all" always deletes them, and "lossless" deletes them
     only when the conversion loses no audio information. Down-sampling to the
     conversion target counts as lossy, as does MP3 output."""
     overwrite: bool = False

--- a/rekordbox_edit/models.py
+++ b/rekordbox_edit/models.py
@@ -82,10 +82,14 @@ class EditRequest(FilterArgs):
     field: str
     replace_value: str
     match_pattern: str | None = None
-    force: bool = False
-    """Proceed on per-track safety gates that would otherwise skip the track
-    (a FolderPath target that does not exist, or one whose duration contradicts
-    the track's stored length)."""
+    allow_missing: bool = False
+    """Write a FolderPath that does not exist, rather than skipping the track.
+    The audio columns describing the file are left as they are, since there is
+    no file to read them from."""
+    allow_mismatch: bool = False
+    """Write a FolderPath whose duration contradicts the track's stored length,
+    rather than skipping the track. Cues and the beat grid are time-indexed
+    against the old duration, so they may land misaligned."""
 
 
 DeleteOriginalsMode: TypeAlias = Literal["none", "lossless", "all"]

--- a/rekordbox_edit/models.py
+++ b/rekordbox_edit/models.py
@@ -82,7 +82,6 @@ class EditRequest(FilterArgs):
     field: str
     replace_value: str
     match_pattern: str | None = None
-    multi: bool = False
     force: bool = False
     """Proceed on per-track safety gates that would otherwise skip the track
     (a FolderPath target that does not exist, or one whose duration contradicts

--- a/tests/api/test_convert.py
+++ b/tests/api/test_convert.py
@@ -1614,7 +1614,12 @@ class TestConvertPerFileCommits:
         _seed_filter(mock_gfc, *contents)
         _seed_db(mock_db, *contents)
 
-        response = convert(mock_db, ConvertRequest(format_out="aiff", overwrite=True))
+        response = convert(
+            mock_db,
+            ConvertRequest(
+                format_out="aiff", overwrite=True, delete_originals="lossless"
+            ),
+        )
 
         assert mock_db.session.commit.call_count == 2
         assert response.result.deleted == 1

--- a/tests/api/test_edit.py
+++ b/tests/api/test_edit.py
@@ -6,7 +6,7 @@ from rekordbox_edit.api.field_handlers import FIELD_HANDLERS
 from sqlalchemy import text
 
 from rekordbox_edit.query import require_session
-from rekordbox_edit.errors import InputError, RekordboxRunningError
+from rekordbox_edit.errors import RekordboxRunningError
 from rekordbox_edit.models import (
     EditRequest,
     EditOp,
@@ -115,12 +115,7 @@ class TestEditDryRun:
         assert response.result.skipped[0].reason == "no_change"
 
     @patch("rekordbox_edit.api.edit.get_filtered_content")
-    def test_dry_run_reports_a_bulk_edit_instead_of_refusing_it(
-        self, mock_gfc, mock_db, make_djmd_content_item
-    ):
-        # The guard is about applying an unattended bulk edit. A dry run writes
-        # nothing, and refusing to preview would contradict the guard's own
-        # advice to inspect with a dry run first.
+    def test_dry_run_plans_a_bulk_edit(self, mock_gfc, mock_db, make_djmd_content_item):
         contents = [
             make_djmd_content_item(ID="1", Title="Old"),
             make_djmd_content_item(ID="2", Title="Old"),
@@ -129,25 +124,12 @@ class TestEditDryRun:
 
         response = edit(
             mock_db,
-            EditRequest(field="Title", replace_value="New", multi=False),
+            EditRequest(field="Title", replace_value="New"),
             dry_run=True,
         )
 
         assert len(response.result.edits) == 2
         mock_db.session.commit.assert_not_called()
-
-    @patch("rekordbox_edit.api.edit.get_filtered_content")
-    def test_one_shot_bulk_edit_still_needs_multi(
-        self, mock_gfc, mock_db, make_djmd_content_item
-    ):
-        contents = [
-            make_djmd_content_item(ID="1", Title="Old"),
-            make_djmd_content_item(ID="2", Title="Old"),
-        ]
-        mock_gfc.return_value.scalars.return_value.all.return_value = contents
-
-        with pytest.raises(InputError, match="multi"):
-            edit(mock_db, EditRequest(field="Title", replace_value="New"))
 
 
 class TestEditRealRun:
@@ -178,7 +160,7 @@ class TestEditRealRun:
         mock_db.session.commit.assert_not_called()
 
     @patch("rekordbox_edit.api.edit.get_filtered_content")
-    def test_multi_flag_allows_multiple_edits(
+    def test_applies_every_matched_track(
         self, mock_gfc, mock_db, make_djmd_content_item
     ):
         contents = [
@@ -187,9 +169,7 @@ class TestEditRealRun:
         ]
         mock_gfc.return_value.scalars.return_value.all.return_value = contents
 
-        response = edit(
-            mock_db, EditRequest(field="Title", replace_value="New", multi=True)
-        )
+        response = edit(mock_db, EditRequest(field="Title", replace_value="New"))
 
         assert len(response.result.edits) == 2
 
@@ -206,9 +186,7 @@ class TestEditRealRun:
         ]
         mock_gfc.return_value.scalars.return_value.all.return_value = contents
 
-        response = edit(
-            mock_db, EditRequest(field="Title", replace_value="x", multi=True)
-        )
+        response = edit(mock_db, EditRequest(field="Title", replace_value="x"))
 
         # The order of result.edits follows the classifier (i.e. the order
         # of contents). tracks aligns to edits.
@@ -230,9 +208,7 @@ class TestEditRealRun:
 
         edit(
             mock_db,
-            EditRequest(
-                field="Title", replace_value="Earth", match_pattern="World", multi=True
-            ),
+            EditRequest(field="Title", replace_value="Earth", match_pattern="World"),
         )
 
         assert changed.Title == "Hello Earth"
@@ -305,7 +281,7 @@ class TestEditFromApprovedOps:
         mock_db.session.commit.assert_not_called()
 
     @patch("rekordbox_edit.api.edit.find_content_by_ids")
-    def test_ops_bypass_the_multi_guard_the_user_already_answered(
+    def test_ops_apply_without_a_filter_pass(
         self, mock_by_ids, mock_db, make_djmd_content_item
     ):
         rows = {

--- a/tests/api/test_field_handlers.py
+++ b/tests/api/test_field_handlers.py
@@ -354,12 +354,12 @@ class TestFolderPathField:
         assert reason == "file_not_found"
 
     @patch("rekordbox_edit.api.field_handlers.os.path.exists", return_value=False)
-    def test_validate_missing_file_forced_proceeds(
+    def test_validate_missing_file_allowed_proceeds(
         self, _exists, make_djmd_content_item
     ):
         content = make_djmd_content_item(ID="1")
         args = EditRequest(
-            field="FolderPath", replace_value="/new/song.wav", force=True
+            field="FolderPath", replace_value="/new/song.wav", allow_missing=True
         )
 
         reason = _folder_handler().validate_track(
@@ -430,13 +430,16 @@ class TestFolderPathField:
     )
     @patch("rekordbox_edit.api.field_handlers.os.path.getsize", return_value=2000)
     @patch("rekordbox_edit.api.field_handlers.os.path.exists", return_value=True)
-    def test_validate_unknown_codec_skips_even_forced(
+    def test_validate_unknown_codec_skips_even_when_gates_are_lifted(
         self, _exists, _getsize, _probe_fn, make_djmd_content_item
     ):
         content = make_djmd_content_item(ID="1")
         content.FileSize = 1000
         args = EditRequest(
-            field="FolderPath", replace_value="/new/song.ogg", force=True
+            field="FolderPath",
+            replace_value="/new/song.ogg",
+            allow_missing=True,
+            allow_mismatch=True,
         )
 
         reason = _folder_handler().validate_track(
@@ -516,7 +519,7 @@ class TestFolderPathField:
     )
     @patch("rekordbox_edit.api.field_handlers.os.path.getsize", return_value=2000)
     @patch("rekordbox_edit.api.field_handlers.os.path.exists", return_value=True)
-    def test_validate_length_mismatch_forced_proceeds(
+    def test_validate_length_mismatch_allowed_proceeds(
         self, _exists, _getsize, _probe_fn, make_djmd_content_item
     ):
         content = make_djmd_content_item(ID="1")
@@ -524,7 +527,7 @@ class TestFolderPathField:
         content.Length = 214
         content.AnalysisDataPath = "/PIONEER/USBANLZ/x/ANLZ0000.DAT"
         args = EditRequest(
-            field="FolderPath", replace_value="/new/song.wav", force=True
+            field="FolderPath", replace_value="/new/song.wav", allow_mismatch=True
         )
 
         reason = _folder_handler().validate_track(
@@ -654,7 +657,7 @@ class TestFolderPathField:
         assert content.FileSize == 1000
 
     @patch("rekordbox_edit.api.field_handlers.os.path.exists", return_value=False)
-    def test_apply_forced_missing_file_writes_paths_only(
+    def test_apply_allowed_missing_file_writes_paths_only(
         self, _exists, make_djmd_content_item
     ):
         handler = _folder_handler()
@@ -664,7 +667,7 @@ class TestFolderPathField:
         content.FileSize = 1000
         db = MagicMock()
         args = EditRequest(
-            field="FolderPath", replace_value="/gone/dir/song.wav", force=True
+            field="FolderPath", replace_value="/gone/dir/song.wav", allow_missing=True
         )
         assert handler.validate_track(db, content, "/gone/dir/song.wav", args) is None
 
@@ -711,18 +714,26 @@ class TestFolderPathField:
         _folder_handler().post_commit(MagicMock(), content, "/old/dir/song.wav")
 
 
-class TestForceableSkipReasons:
-    def test_folder_path_declares_what_force_overrides(self):
-        assert FIELD_HANDLERS["FolderPath"].forceable_skip_reasons == frozenset(
-            {"file_not_found", "length_mismatch"}
-        )
+class TestGatedSkipReasons:
+    def test_folder_path_maps_each_gate_to_its_field(self):
+        assert FIELD_HANDLERS["FolderPath"].gated_skip_reasons == {
+            "file_not_found": "allow_missing",
+            "length_mismatch": "allow_mismatch",
+        }
 
     def test_handlers_without_gates_declare_nothing(self):
-        # A caller offering to retry with force reads this rather than keeping
-        # its own list, so a handler with no gates must offer no retry.
-        assert FIELD_HANDLERS["Title"].forceable_skip_reasons == frozenset()
+        # A caller offering to lift a gate reads this rather than keeping its
+        # own list, so a handler with no gates must offer no prompt.
+        assert FIELD_HANDLERS["Title"].gated_skip_reasons == {}
 
     def test_every_declared_reason_is_a_real_skip_reason(self):
         valid = set(get_args(SkipReason))
         for handler in FIELD_HANDLERS.values():
-            assert handler.forceable_skip_reasons <= valid
+            assert set(handler.gated_skip_reasons) <= valid
+
+    def test_every_declared_field_exists_on_the_request(self):
+        # The CLI reads these with getattr, so a typo would silently stop
+        # lifting the gate rather than fail.
+        for handler in FIELD_HANDLERS.values():
+            for field in handler.gated_skip_reasons.values():
+                assert field in EditRequest.model_fields

--- a/tests/cli/test_convert.py
+++ b/tests/cli/test_convert.py
@@ -43,6 +43,19 @@ def _response(tracks=None, converted=None, deleted=0, skipped=None, format_out="
 class TestConvertCommand:
     @patch("rekordbox_edit.cli.convert.convert")
     @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    def test_format_out_is_required(self, mock_db_class, mock_convert):
+        # Without it a bare `rbe convert --yes` would pick a target format on
+        # the user's behalf and re-encode the library into it.
+        mock_db_class.return_value = Mock(session=Mock())
+
+        result = CliRunner().invoke(convert_command, ["--yes"])
+
+        assert result.exit_code != 0
+        assert "--format-out" in result.output
+        mock_convert.assert_not_called()
+
+    @patch("rekordbox_edit.cli.convert.convert")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
     @patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None)
     def test_yes_calls_convert_once(self, _pid, mock_db_class, mock_convert):
         mock_db_class.return_value = Mock(session=Mock())

--- a/tests/cli/test_convert.py
+++ b/tests/cli/test_convert.py
@@ -455,3 +455,113 @@ class TestThreadsFlag:
         )
 
         assert result.exit_code != 0
+
+
+class TestConvertOverwriteGate:
+    """An output file that already exists used to be skipped with only a
+    warning count, so a run could pass over files silently."""
+
+    @patch("rekordbox_edit.cli.convert.print_track_info")
+    @patch("rekordbox_edit.cli.convert.confirm")
+    @patch("rekordbox_edit.cli.convert.convert")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    @patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None)
+    def test_confirming_reconverts_with_overwrite(
+        self, _pid, mock_db_class, mock_convert, mock_confirm, _print
+    ):
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_convert.return_value = _response(
+            skipped=[SkippedTrack(id="9", reason="output_file_exists")]
+        )
+        mock_confirm.side_effect = [True, True]  # overwrite, then apply
+
+        result = CliRunner().invoke(convert_command, ["--format-out", "aiff"])
+
+        assert result.exit_code == 0
+        # preview, re-preview with overwrite on, real run
+        assert mock_convert.call_count == 3
+        assert mock_convert.call_args_list[0].args[1].overwrite is False
+        assert mock_convert.call_args_list[1].args[1].overwrite is True
+        assert mock_convert.call_args_list[1].kwargs.get("dry_run") is True
+        assert mock_convert.call_args_list[2].args[1].overwrite is True
+
+    @patch("rekordbox_edit.cli.convert.print_track_info")
+    @patch("rekordbox_edit.cli.convert.confirm")
+    @patch("rekordbox_edit.cli.convert.convert")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    @patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None)
+    def test_declining_leaves_the_conflicts_skipped(
+        self, _pid, mock_db_class, mock_convert, mock_confirm, _print
+    ):
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_convert.return_value = _response(
+            skipped=[SkippedTrack(id="9", reason="output_file_exists")]
+        )
+        mock_confirm.side_effect = [False, True]  # keep them, then apply
+
+        result = CliRunner().invoke(convert_command, ["--format-out", "aiff"])
+
+        assert result.exit_code == 0
+        assert mock_convert.call_count == 2  # preview + real run
+        assert mock_convert.call_args_list[1].args[1].overwrite is False
+
+    @patch("rekordbox_edit.cli.convert.print_track_info")
+    @patch("rekordbox_edit.cli.convert.confirm")
+    @patch("rekordbox_edit.cli.convert.convert")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    @patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None)
+    def test_no_prompt_when_overwrite_is_already_set(
+        self, _pid, mock_db_class, mock_convert, mock_confirm, _print
+    ):
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_convert.return_value = _response(
+            skipped=[SkippedTrack(id="9", reason="output_file_exists")]
+        )
+        mock_confirm.side_effect = [True]  # only the apply prompt
+
+        result = CliRunner().invoke(
+            convert_command, ["--format-out", "aiff", "--overwrite"]
+        )
+
+        assert result.exit_code == 0
+        assert mock_confirm.call_count == 1
+        assert mock_convert.call_count == 2
+
+    @patch("rekordbox_edit.cli.convert.print_track_info")
+    @patch("rekordbox_edit.cli.convert.confirm", side_effect=UserQuit)
+    @patch("rekordbox_edit.cli.convert.convert")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    @patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None)
+    def test_quitting_the_prompt_skips_the_run(
+        self, _pid, mock_db_class, mock_convert, _confirm, _print
+    ):
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_convert.return_value = _response(
+            skipped=[SkippedTrack(id="9", reason="output_file_exists")]
+        )
+
+        result = CliRunner().invoke(convert_command, ["--format-out", "aiff"])
+
+        assert result.exit_code == 0
+        mock_convert.assert_called_once()  # preview only
+
+    @patch("rekordbox_edit.cli.convert.convert")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    @patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None)
+    def test_yes_alone_leaves_the_conflicts_skipped(
+        self, _pid, mock_db_class, mock_convert, mock_logger
+    ):
+        # --yes takes the default answer to every prompt, and this gate's
+        # default is no, so only --overwrite clobbers anything.
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_convert.return_value = _response(
+            skipped=[SkippedTrack(id="9", reason="output_file_exists")]
+        )
+
+        result = CliRunner().invoke(convert_command, ["--format-out", "aiff", "--yes"])
+
+        assert result.exit_code == 0
+        mock_convert.assert_called_once()
+        assert mock_convert.call_args.args[1].overwrite is False
+        warnings = [c.args[0] for c in mock_logger.warning.call_args_list]
+        assert any("output exists" in w for w in warnings)

--- a/tests/cli/test_edit.py
+++ b/tests/cli/test_edit.py
@@ -300,7 +300,7 @@ class TestEditCommand:
         mock_edit.assert_called_once()  # preview only — UserQuit on first track
 
 
-def _gated_response(tracks=None, edits=None):
+def _gated_response(tracks=None, edits=None, skipped=None):
     tracks = (
         tracks
         if tracks is not None
@@ -316,24 +316,30 @@ def _gated_response(tracks=None, edits=None):
         result=EditResult(
             field="FolderPath",
             edits=edits,
-            skipped=[SkippedTrack(id="9", reason="file_not_found")],
+            skipped=(
+                skipped
+                if skipped is not None
+                else [SkippedTrack(id="9", reason="file_not_found")]
+            ),
         ),
     )
 
 
-class TestEditForceFlow:
+class TestEditGateFlow:
     @patch("rekordbox_edit.cli.edit.edit")
     @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
-    def test_force_flag_passes_through(self, mock_db_class, mock_edit):
+    def test_gate_flags_pass_through(self, mock_db_class, mock_edit):
         mock_db_class.return_value = Mock(session=Mock())
         mock_edit.return_value = _response()
 
         result = CliRunner().invoke(
-            edit_command, ["Title", "--replace", "New", "--yes", "--force"]
+            edit_command,
+            ["Title", "--replace", "New", "--yes", "--allow-missing"],
         )
 
         assert result.exit_code == 0
-        assert mock_edit.call_args.args[1].force is True
+        assert mock_edit.call_args.args[1].allow_missing is True
+        assert mock_edit.call_args.args[1].allow_mismatch is False
 
     @patch("rekordbox_edit.cli.edit.print_track_info")
     @patch("rekordbox_edit.cli.edit.confirm")
@@ -352,19 +358,48 @@ class TestEditForceFlow:
         )
 
         assert result.exit_code == 0
-        # preview, forced re-preview, real run
+        # preview, re-preview with the gate lifted, real run
         assert mock_edit.call_count == 3
-        assert mock_edit.call_args_list[0].args[1].force is False
-        assert mock_edit.call_args_list[1].args[1].force is True
+        assert mock_edit.call_args_list[0].args[1].allow_missing is False
+        assert mock_edit.call_args_list[1].args[1].allow_missing is True
         assert mock_edit.call_args_list[1].kwargs.get("dry_run") is True
-        assert mock_edit.call_args_list[2].args[1].force is True
+        assert mock_edit.call_args_list[2].args[1].allow_missing is True
         assert mock_edit.call_args_list[2].kwargs.get("dry_run", False) is False
 
     @patch("rekordbox_edit.cli.edit.print_track_info")
     @patch("rekordbox_edit.cli.edit.confirm")
     @patch("rekordbox_edit.cli.edit.edit")
     @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
-    def test_default_flow_gated_declined_stays_unforced(
+    def test_each_gate_is_asked_and_lifted_on_its_own(
+        self, mock_db_class, mock_edit, mock_confirm, _print
+    ):
+        # Authorizing a path with no file behind it is a different decision
+        # from authorizing cues that may land misaligned.
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_edit.return_value = _gated_response(
+            skipped=[
+                SkippedTrack(id="9", reason="file_not_found"),
+                SkippedTrack(id="8", reason="length_mismatch"),
+            ]
+        )
+        # Missing: yes. Mismatch: no. Then apply.
+        mock_confirm.side_effect = [True, False, True]
+
+        result = CliRunner().invoke(
+            edit_command, ["FolderPath", "--replace", "/new/x.wav"]
+        )
+
+        assert result.exit_code == 0
+        assert mock_confirm.call_count == 3
+        applied = mock_edit.call_args_list[-1].args[1]
+        assert applied.allow_missing is True
+        assert applied.allow_mismatch is False
+
+    @patch("rekordbox_edit.cli.edit.print_track_info")
+    @patch("rekordbox_edit.cli.edit.confirm")
+    @patch("rekordbox_edit.cli.edit.edit")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    def test_default_flow_gated_declined_leaves_the_gate_shut(
         self, mock_db_class, mock_edit, mock_confirm, _print
     ):
         mock_db_class.return_value = Mock(session=Mock())
@@ -378,13 +413,13 @@ class TestEditForceFlow:
 
         assert result.exit_code == 0
         assert mock_edit.call_count == 2  # preview + real run
-        assert mock_edit.call_args_list[1].args[1].force is False
+        assert mock_edit.call_args_list[1].args[1].allow_missing is False
 
     @patch("rekordbox_edit.cli.edit.print_track_info")
     @patch("rekordbox_edit.cli.edit.confirm")
     @patch("rekordbox_edit.cli.edit.edit")
     @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
-    def test_default_flow_no_gated_prompt_when_forced(
+    def test_no_gate_prompt_when_its_flag_is_already_set(
         self, mock_db_class, mock_edit, mock_confirm, _print
     ):
         mock_db_class.return_value = Mock(session=Mock())
@@ -392,7 +427,8 @@ class TestEditForceFlow:
         mock_confirm.side_effect = [True]  # only the apply prompt
 
         result = CliRunner().invoke(
-            edit_command, ["FolderPath", "--replace", "/new/x.wav", "--force"]
+            edit_command,
+            ["FolderPath", "--replace", "/new/x.wav", "--allow-missing"],
         )
 
         assert result.exit_code == 0
@@ -418,7 +454,9 @@ class TestEditForceFlow:
 
     @patch("rekordbox_edit.cli.edit.edit")
     @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
-    def test_yes_mode_leaves_gated_skipped(self, mock_db_class, mock_edit):
+    def test_yes_alone_leaves_gated_skipped(self, mock_db_class, mock_edit):
+        # --yes takes the default answer to every prompt, and a gate's default
+        # is no, so only the flag itself lets the held-back tracks through.
         mock_db_class.return_value = Mock(session=Mock())
         mock_edit.return_value = _gated_response()
 
@@ -428,7 +466,7 @@ class TestEditForceFlow:
 
         assert result.exit_code == 0
         mock_edit.assert_called_once()
-        assert mock_edit.call_args.args[1].force is False
+        assert mock_edit.call_args.args[1].allow_missing is False
 
 
 def _warnings(mock_logger) -> str:
@@ -492,7 +530,7 @@ class TestEditSkipReporting:
     def test_gated_reasons_are_not_reported_twice(
         self, mock_db_class, mock_edit, mock_confirm, _print, mock_logger
     ):
-        # The force prompt names those tracks individually, so the summary
+        # The gate prompt names those tracks individually, so the summary
         # must leave that reason out.
         mock_db_class.return_value = Mock(session=Mock())
         mock_edit.side_effect = [_gated_response(), _gated_response()]
@@ -500,7 +538,7 @@ class TestEditSkipReporting:
 
         CliRunner().invoke(edit_command, ["FolderPath", "--replace", "/new/x.wav"])
 
-        assert "were held back by safety checks" in _infos(mock_logger)
+        assert "track(s) held back" in _infos(mock_logger)
         assert "file does not exist" not in _warnings(mock_logger)
 
     @patch("rekordbox_edit.cli.edit.print_track_info")

--- a/tests/cli/test_edit.py
+++ b/tests/cli/test_edit.py
@@ -117,7 +117,7 @@ class TestEditCommand:
     def test_apply_pass_input_error_becomes_usage_error(
         self, mock_db_class, mock_edit, _confirm, _print
     ):
-        # The preview passes the --multi guard and the apply pass does not.
+        # The preview succeeds and the apply pass raises.
         mock_db_class.return_value = Mock(session=Mock())
         mock_edit.side_effect = [
             _response(),
@@ -415,29 +415,6 @@ class TestEditForceFlow:
 
         assert result.exit_code == 0
         mock_edit.assert_called_once()  # preview only
-
-    @patch("rekordbox_edit.cli.edit.print_track_info")
-    @patch("rekordbox_edit.cli.edit.confirm")
-    @patch("rekordbox_edit.cli.edit.edit")
-    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
-    def test_including_gated_tracks_can_trip_multi_guard(
-        self, mock_db_class, mock_edit, mock_confirm, _print
-    ):
-        # Including the held-back track widens the edit past one track, which
-        # the single-track guard rejects on the re-preview.
-        mock_db_class.return_value = Mock(session=Mock())
-        mock_edit.side_effect = [
-            _gated_response(),
-            InputError("Found 2 tracks that would be edited"),
-        ]
-        mock_confirm.side_effect = [True]
-
-        result = CliRunner().invoke(
-            edit_command, ["FolderPath", "--replace", "/new/x.wav"]
-        )
-
-        assert result.exit_code != 0
-        assert "Error" in result.output
 
     @patch("rekordbox_edit.cli.edit.edit")
     @patch("rekordbox_edit.cli._utils.Rekordbox6Database")

--- a/tests/e2e/test_edit_fields.py
+++ b/tests/e2e/test_edit_fields.py
@@ -171,7 +171,7 @@ def test_folderpath_repoint_syncs_metadata(fresh_db, staged_audio):
             exact_title=["Wave Alpha"],
             field="FolderPath",
             replace_value=target.as_posix(),
-            force=True,
+            allow_mismatch=True,
         ),
     )
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -109,7 +109,7 @@ class TestConvertRequest:
         assert isinstance(args, FilterArgs)
         assert args.format_out == "mp3"
         assert args.overwrite is True
-        assert args.delete_originals == "lossless"
+        assert args.delete_originals == "none"
         assert args.artist == ["X"]
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -99,7 +99,6 @@ class TestEditRequest:
         assert args.field == "Title"
         assert args.replace_value == "New"
         assert args.artist == ["X"]
-        assert args.multi is False
         assert args.force is False
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -112,6 +112,10 @@ class TestConvertRequest:
         assert args.delete_originals == "none"
         assert args.artist == ["X"]
 
+    def test_format_out_is_required(self):
+        with pytest.raises(ValidationError):
+            ConvertRequest()  # ty: ignore[missing-argument]  # missing format_out
+
 
 class TestSkippedTrack:
     def test_known_reasons_accepted(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -99,7 +99,8 @@ class TestEditRequest:
         assert args.field == "Title"
         assert args.replace_value == "New"
         assert args.artist == ["X"]
-        assert args.force is False
+        assert args.allow_missing is False
+        assert args.allow_mismatch is False
 
 
 class TestConvertRequest:


### PR DESCRIPTION
[refactor(edit)!: drop --multi](https://github.com/jviall/rekordbox-edit/commit/60befe33cbc384061ef1728aab777eacac18e15f) 

[feat(edit)!: replace --force with --allow-missing and --allow-mismatch](https://github.com/jviall/rekordbox-edit/commit/ddcb632ea94b2c0e1c7986fd30bceab2fe6685fc) 

[feat(convert)!: default --delete-originals to none](https://github.com/jviall/rekordbox-edit/commit/6a0bc38e5dea18e5642ec1e2305cdc4f9fa1357d) 

[feat(convert): ask before overwriting existing output files](https://github.com/jviall/rekordbox-edit/commit/6dce67052ae1202919487a8e5fd0d3b41056ae35) 

[docs: state what --yes means in one place](https://github.com/jviall/rekordbox-edit/commit/68b33fdf90e5e00bf11d83bc742d1f5183384af2)