### PR TITLE
feat: add the remove command

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,6 @@
 # API Reference
 
-Everything the CLI does is available from Python. The public surface is the four functions in `rekordbox_edit.api` and the Pydantic models in `rekordbox_edit.models` that describe their inputs and outputs.
+Everything the CLI does is available from Python. The public surface is the five functions in `rekordbox_edit.api` and the Pydantic models in `rekordbox_edit.models` that describe their inputs and outputs.
 
 ```python
 from pyrekordbox import Rekordbox6Database
@@ -17,11 +17,11 @@ Different filter kinds — `artist` and `format` above — AND together by defau
 
 `--print json` on any CLI command emits exactly these response envelopes, so the models below also document the JSON you get when scripting.
 
-A write command's response reaches its tracks two ways, though a dry run populates only one of them. For a write command (`edit`, `convert`, `import_tracks`), `tracks` at the top level holds what the command actually did, and is empty for a dry run, since a dry run changes nothing. Each op describes the planned or performed state regardless: `result.edits[].track` and its equivalents. Tracks a command declined to touch are not in `tracks`. They are at `result.skipped[].track`, alongside the reason.
+A write command's response reaches its tracks two ways, though a dry run populates only one of them. For a write command (`edit`, `convert`, `import_tracks`, `remove`), `tracks` at the top level holds what the command actually did, and is empty for a dry run, since a dry run changes nothing. Each op describes the planned or performed state regardless: `result.edits[].track` and its equivalents. Tracks a command declined to touch are not in `tracks`. They are at `result.skipped[].track`, alongside the reason.
 
 ## Writing Safely
 
-`edit`, `convert`, and `import_tracks` each have checks against concurrent writes. They will refuse to run while Rekordbox is open, raising
+`edit`, `convert`, `import_tracks`, and `remove` each have checks against concurrent writes. They will refuse to run while Rekordbox is open, raising
 [`RekordboxRunningError`][rekordbox_edit.errors.RekordboxRunningError], and each will grab a single-writer advisory lock for the
 duration of the write to prevent concurrent writes by other rekordbox-edit processes.
 
@@ -42,6 +42,8 @@ Most errors these functions raise descend from
 ::: rekordbox_edit.api.convert
 
 ::: rekordbox_edit.api.import_tracks
+
+::: rekordbox_edit.api.remove
 
 ## Models
 
@@ -79,6 +81,14 @@ The models form three layers: the [`FilterArgs`][rekordbox_edit.models.FilterArg
 
 ::: rekordbox_edit.models.ImportResult
 
+### Remove
+
+::: rekordbox_edit.models.RemoveRequest
+
+::: rekordbox_edit.models.RemoveResponse
+
+::: rekordbox_edit.models.RemoveResult
+
 ### Miscellaneous
 
 ::: rekordbox_edit.models.Track
@@ -88,6 +98,8 @@ The models form three layers: the [`FilterArgs`][rekordbox_edit.models.FilterArg
 ::: rekordbox_edit.models.ConvertOp
 
 ::: rekordbox_edit.models.ImportOp
+
+::: rekordbox_edit.models.RemoveOp
 
 ::: rekordbox_edit.models.SkippedTrack
 

--- a/docs/commands/remove.md
+++ b/docs/commands/remove.md
@@ -1,0 +1,56 @@
+# remove
+
+Delete tracks from your Rekordbox collection, optionally removing the source files as well.
+
+```bash
+rbe remove [OPTIONS] [TRACK-IDS]...
+```
+
+## What Gets Deleted
+
+`remove` deletes the track's database row, every record that references it, and the track's analysis and artwork files. If that removal leaves an artist, album, genre, or label with no tracks behind it, that record is deleted too, so the library doesn't accumulate empty metadata over time.
+
+### Removing the Audio Source
+
+Removing a track from the library does not touch the audio file it points to. Pass `--delete-source` to delete that file as well.
+
+`--delete-source` will delete all matching track files **permanently**.
+
+## This Cannot Be Undone
+
+> [!CAUTION]
+> **This command cannot be undone**. There is no undo for `remove`. Even if you re-import your files, any analysis or other Rekordbox metadata like playlists and play counts will be lost. Run with `--dry-run` first and review the plan before committing to it, and back up your library before removing in bulk.
+
+## Checks
+
+- Without flags, `remove` shows every planned removal and asks once before applying. See [Confirmations](../filtering.md#confirmations) for how `--dry-run`, `--interactive`, and `--yes` change that.
+- `remove` deletes exactly the tracks the preview showed. A track whose row vanished between the preview and your confirmation is skipped rather than removed; a track whose row changed is still removed as planned.
+- Running `remove` with no filters at all matches every track in the library, the same as `edit` and `convert`. Run with `--dry-run` first to see what an unfiltered removal would do.
+- **Rekordbox running:** writing while Rekordbox is open risks losing your changes, so `remove` will refuse to perform any writes. `--dry-run` is unaffected.
+
+## Examples
+
+```bash
+# Preview what a removal would do
+rbe remove --artist "Unknown Artist" --dry-run
+
+# Remove tracks matching a filter, confirming once
+rbe remove --title "(Demo)" --exact-title "Demo Loop"
+
+# Confirm each track individually, and remove its source file too
+rbe remove --playlist "Duplicates" --interactive --delete-source
+
+# Remove a piped-in set of tracks without prompting
+rbe search --resolved-path "/Volumes/OldDrive" --print ids | rbe remove --yes --print ids
+```
+
+See [Filtering](../filtering.md) for the full filter language.
+
+## Reference
+
+<!-- prettier-ignore -->
+::: mkdocs-click
+    :module: rekordbox_edit.cli.remove
+    :command: remove_command
+    :prog_name: rbe remove
+    :depth: 1

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,5 +58,6 @@ nav:
       - edit: commands/edit.md
       - convert: commands/convert.md
       - import: commands/import.md
+      - remove: commands/remove.md
   - FAQs: faqs.md
   - API Reference: api.md

--- a/rekordbox_edit/api/__init__.py
+++ b/rekordbox_edit/api/__init__.py
@@ -1,12 +1,13 @@
 """Public API for rekordbox-edit.
 
 Usage:
-    from rekordbox_edit.api import search, edit, convert, import_tracks
+    from rekordbox_edit.api import search, edit, convert, import_tracks, remove
 """
 
 from rekordbox_edit.api.convert import convert
 from rekordbox_edit.api.edit import edit
 from rekordbox_edit.api.import_ import import_tracks
+from rekordbox_edit.api.remove import remove
 from rekordbox_edit.api.search import search
 
-__all__ = ["search", "edit", "convert", "import_tracks"]
+__all__ = ["search", "edit", "convert", "import_tracks", "remove"]

--- a/rekordbox_edit/api/_utils.py
+++ b/rekordbox_edit/api/_utils.py
@@ -102,6 +102,26 @@ _RESERVE_USNS = text(
 )
 
 
+def reserve_usns(db: Rekordbox6Database, count: int) -> int | None:
+    """Claim `count` USNs and return the highest one claimed.
+
+    The claimed block runs from `returned - count + 1` through `returned`.
+    Call this inside the transaction that writes the rows.
+
+    Rows that are being deleted cannot be stamped, but the counter must still
+    move past them, which is why reserving is separable from stamping.
+    """
+    if count <= 0:
+        return None
+    session = require_session(db)
+    last_usn = session.execute(_RESERVE_USNS, {"count": count}).scalar()
+    if last_usn is None:
+        logger.warning("No localUpdateCount in agentRegistry; leaving USNs unstamped. ")
+        return None
+    logger.debug(f"reserved USNs {last_usn - count + 1}..{last_usn}")
+    return last_usn
+
+
 def stamp_usns(db: Rekordbox6Database, rows: Sequence[Any]) -> int | None:
     """Give each row a fresh USN and advance the library's counter.
 
@@ -124,14 +144,11 @@ def stamp_usns(db: Rekordbox6Database, rows: Sequence[Any]) -> int | None:
     if not stampable:
         return None
 
-    session = require_session(db)
-    last_usn = session.execute(_RESERVE_USNS, {"count": num_stampable}).scalar()
+    last_usn = reserve_usns(db, num_stampable)
     if last_usn is None:
-        logger.warning("No localUpdateCount in agentRegistry; leaving USNs unstamped. ")
         return None
 
     for usn, row in enumerate(stampable, start=last_usn - num_stampable + 1):
         row.rb_local_usn = usn
 
-    logger.debug(f"reserved USNs {last_usn - num_stampable + 1}..{last_usn}")
     return last_usn

--- a/rekordbox_edit/api/remove.py
+++ b/rekordbox_edit/api/remove.py
@@ -1,0 +1,514 @@
+"""Remove API for rekordbox-edit."""
+
+import logging
+import os
+import shutil
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any, TypedDict
+
+from pyrekordbox import Rekordbox6Database
+from pyrekordbox.db6 import tables as tb
+from sqlalchemy import or_
+
+from rekordbox_edit.api._utils import reserve_usns, track_from_content, writing
+from rekordbox_edit.api.field_handlers import _ARTIST_ROLE_COLUMNS
+from rekordbox_edit.models import (
+    RemoveOp,
+    RemoveRequest,
+    RemoveResponse,
+    RemoveResult,
+    SkippedTrack,
+)
+from rekordbox_edit.query import (
+    find_content_by_ids,
+    get_filtered_content,
+    require_session,
+)
+
+logger = logging.getLogger(__name__)
+
+#: The DjmdContent columns naming a track's relatives, by kind. A removal
+#: vacates every one of them. Key and colour are absent by design; see
+#: _SWEEPABLE.
+_RELATIVE_COLUMNS = {
+    "artist": ("ArtistID", "RemixerID", "OrgArtistID", "ComposerID", "Lyricist"),
+    "album": ("AlbumID",),
+    "genre": ("GenreID",),
+    "label": ("LabelID",),
+}
+
+
+def _content_child_tables() -> list[type[tb.Base]]:
+    """Every mapped table that references a track by ContentID."""
+    tables: list[type[tb.Base]] = []
+    for mapper in tb.Base.registry.mappers:
+        cls = mapper.class_
+        if cls is tb.DjmdContent:
+            continue
+        if "ContentID" in cls.__table__.columns:
+            tables.append(cls)
+    return tables
+
+
+#: The four kinds rekordbox collects at zero references, each mapped to the
+#: table holding the record and the DjmdContent column pointing at it.
+#:
+#: Key and colour are deliberately absent. DjmdKey is a closed enumeration of
+#: musical keys shared by hundreds of tracks and ColorID names a fixed
+#: palette, so collecting either would be wrong even at zero references. A
+#: caller that passes them is ignored rather than obeyed.
+_SWEEPABLE: dict[str, tuple[type[tb.Base], Any]] = {
+    "artist": (tb.DjmdArtist, tb.DjmdContent.ArtistID),
+    "album": (tb.DjmdAlbum, tb.DjmdContent.AlbumID),
+    "genre": (tb.DjmdGenre, tb.DjmdContent.GenreID),
+    "label": (tb.DjmdLabel, tb.DjmdContent.LabelID),
+}
+
+
+def _is_referenced(db: Rekordbox6Database, kind: str, record_id: str) -> bool:
+    """Whether anything still points at this record."""
+    session = require_session(db)
+    if kind == "artist":
+        in_content = (
+            session.query(tb.DjmdContent)
+            .filter(or_(*(col == record_id for col in _ARTIST_ROLE_COLUMNS)))
+            .first()
+        )
+        in_album = (
+            session.query(tb.DjmdAlbum)
+            .filter(tb.DjmdAlbum.AlbumArtistID == record_id)
+            .first()
+        )
+        return in_content is not None or in_album is not None
+    _, column = _SWEEPABLE[kind]
+    return session.query(tb.DjmdContent).filter(column == record_id).first() is not None
+
+
+def _sweep_orphans(db: Rekordbox6Database, relatives: dict[str, set[str]]) -> int:
+    """Delete every given relative nothing references, repeating to a fixpoint.
+
+    Rekordbox sweeps once, which leaks: collecting an orphaned album never
+    re-examines the artist that album's AlbumArtistID pointed at, leaving that
+    artist at zero references forever. Repeating the sweep until nothing new
+    becomes unreferenced closes that gap.
+
+    Kinds outside `_SWEEPABLE` are ignored, so passing a key or a colour id is
+    safe rather than a caller error.
+    """
+    session = require_session(db)
+    pending = {
+        kind: {i for i in ids if i not in (None, "")}
+        for kind, ids in relatives.items()
+        if kind in _SWEEPABLE
+    }
+    collected = 0
+
+    while pending:
+        cascaded: dict[str, set[str]] = {}
+        for kind, ids in pending.items():
+            table, _ = _SWEEPABLE[kind]
+            for record_id in ids:
+                if _is_referenced(db, kind, record_id):
+                    continue
+                row = session.query(table).filter_by(ID=record_id).first()
+                if row is None:
+                    continue
+                # An album's own AlbumArtistID may be the last reference
+                # holding that artist alive, so deleting the album can orphan
+                # it. That cascade is what the loop exists to catch.
+                album_artist_id = getattr(row, "AlbumArtistID", None)
+                if kind == "album" and album_artist_id:
+                    cascaded.setdefault("artist", set()).add(str(album_artist_id))
+                session.delete(row)
+                collected += 1
+                logger.debug(f"collected orphaned {kind} id={record_id}")
+        # Load-bearing: the next pass queries for references, and an
+        # uncommitted delete must be visible to that query. This function
+        # runs inside a caller's transaction, so flush rather than commit.
+        session.flush()
+        pending = cascaded
+
+    return collected
+
+
+#: share/PIONEER/USBANLZ/<xxx>/<uuid> — the analysis directory sits exactly
+#: this many path parts below the share directory in every real Rekordbox
+#: layout measured. A stored AnalysisDataPath that is shallower than this
+#: (corrupt, truncated, or written by a foreign tool) would otherwise resolve
+#: to an ancestor tier shared by every other track, so the depth is checked
+#: before any delete: see `remove_analysis_files`.
+_ANALYSIS_DIR_DEPTH = 4
+
+#: share/PIONEER/Artwork/<xxx>/<uuid> — the artwork directory sits exactly
+#: this many path parts below the share directory in every real Rekordbox
+#: layout measured. Mirrors `_ANALYSIS_DIR_DEPTH`; see `remove_artwork_files`.
+_ARTWORK_DIR_DEPTH = 4
+
+
+def _resolve_path_of_root(root: Path, path: Path) -> Path | None:
+    """Returns the path resolved, or None if it doesn't descend from the given root.
+
+    Bounds the blast radius of every delete in this module to rekordbox's own
+    managed storage. Callers still need their own check that the resolved
+    path is the *specific* directory they mean to touch, not merely somewhere
+    under the root: see `_ANALYSIS_DIR_DEPTH`.
+    """
+    resolved = path.resolve()
+    root = root.resolve()
+    if resolved == root or root not in resolved.parents:
+        logger.debug(f"Path ({resolved}) does not descend from root {root}")
+        return None
+    return resolved
+
+
+def _rmdir_if_empty_under(root: Path, directory: Path) -> None:
+    """Remove a directory only when it is empty and still under the root.
+
+    Every call site passes a computed *parent* of an already-checked path,
+    which is not itself guaranteed to still be inside the share tree (a
+    shallow stored path can walk it out to the share root or above), so this
+    re-checks containment rather than trusting the caller's arithmetic.
+
+    rmdir rather than a recursive delete, so anything unexpected inside stops
+    the cleanup instead of being swept away.
+    """
+    if _resolve_path_of_root(root, directory) is None:
+        logger.warning("Refusing to delete outside the share tree")
+        return
+    try:
+        directory.rmdir()
+        logger.debug(f"removed empty directory {directory}")
+    except OSError:
+        logger.debug(f"left non-empty directory {directory}")
+
+
+def remove_analysis_files(
+    db: Rekordbox6Database, analysis_data_path: str | None
+) -> None:
+    """Delete a track's analysis directory and its prefix directory.
+    e.g. share/PIONEER/USBANLZ/<xxx>/<uuid>
+
+    Takes an explicit path value rather than a row, because there may not
+    be a row to pass.
+    """
+    # An empty AnalysisDataPath is refused before any path is resolved. This
+    # duplicates the containment check below by design (both must independently
+    # hold before anything is deleted; do not remove either as apparently dead
+    # code): get_anlz_dir strips the leading separator and joins the remainder
+    # onto the share directory, so an empty value resolves to the share root
+    # itself, and a recursive delete there would destroy every track's analysis
+    # in the library.
+    if not analysis_data_path:
+        logger.debug("no analysis to remove")
+        return
+
+    share_dir = db.share_directory
+    anlz_dir = _resolve_path_of_root(
+        share_dir,
+        share_dir / Path(analysis_data_path.strip("\\/")).parent,
+    )
+    if anlz_dir is None:
+        logger.warning("Refusing to delete outside the share tree")
+        return
+
+    # A non-empty but malformed AnalysisDataPath is refused too. The real
+    # layout is always share/PIONEER/USBANLZ/<xxx>/<uuid>, so a value shallower
+    # than that resolves to an ancestor directory shared by every other track
+    # (e.g. all of USBANLZ, or all of PIONEER) rather than to this track's own
+    # directory. Rekordbox itself never writes a value that shape, but a
+    # corrupt or foreign-tool-written column could, and unlike an empty value
+    # this is not caught by the share-root check. Skipping the cleanup leaves
+    # orphan files behind; deleting an ancestor tier destroys the library, so
+    # an unexpected shape is refused rather than acted on.
+    depth = len(anlz_dir.relative_to(share_dir.resolve()).parts)
+    if depth != _ANALYSIS_DIR_DEPTH:
+        logger.warning(
+            "analysis path did not have the expected share/PIONEER/USBANLZ/"
+            f"<xxx>/<uuid> shape, skipping cleanup: {anlz_dir}"
+        )
+        return
+
+    if not anlz_dir.is_dir():
+        return
+
+    shutil.rmtree(anlz_dir)
+    logger.debug(f"removed analysis directory {anlz_dir}")
+    _rmdir_if_empty_under(share_dir, anlz_dir.parent)
+
+
+def remove_artwork_files(db: Rekordbox6Database, image_path: str | None) -> None:
+    """Delete a track's artwork files, then its directory and prefix if empty.
+    e.g. share/PIONEER/Artwork/<xxx>/<uuid>
+
+    Rekordbox deletes the files and leaves both directories in place and empty.
+    Removing them is a deliberate divergence: the directory name derives from
+    DjmdContent.UUID, minted fresh per inserted row, so nothing can reach an
+    abandoned one again.
+
+    A non-empty but malformed ImagePath is refused too. The real layout is
+    always share/PIONEER/Artwork/<xxx>/<uuid>, so a value shallower than that
+    resolves to an ancestor directory shared by every other track's artwork
+    (or, one level shallower still, by a Rekordbox-managed directory that
+    holds no artwork at all, such as PIONEER itself). Rekordbox itself never
+    writes a value that shape, but a corrupt or foreign-tool-written column
+    could, and unlike an empty value this is not caught by the share-root
+    check. Skipping the cleanup leaves orphan files behind; deleting an
+    ancestor tier destroys other tracks' data, so an unexpected shape is
+    refused rather than acted on.
+    """
+
+    # An empty ImagePath is refused before any path is resolved. This duplicates
+    # the containment check below by design (do not remove either as apparently
+    # dead code): an empty value joins onto the share directory unchanged, so
+    # `artwork_file` becomes the share directory itself and `art_dir`, its
+    # parent, becomes the directory one level ABOVE the share root — the
+    # library's own db_directory, which holds the main database files. That is
+    # a different, and worse, location than the share root that an empty
+    # AnalysisDataPath resolves to; it is not caught by name coincidence the way
+    # a share directory literally named "share" happens to survive in tests.
+    if not image_path:
+        logger.debug("no artwork to remove")
+        return
+
+    share_dir = db.share_directory
+    artwork_file = _resolve_path_of_root(share_dir, share_dir / image_path.strip("\\/"))
+    if artwork_file is None:
+        return
+
+    art_dir = artwork_file.parent
+    depth = len(art_dir.relative_to(share_dir.resolve()).parts)
+    if depth != _ARTWORK_DIR_DEPTH:
+        logger.warning(
+            "artwork path did not have the expected share/PIONEER/Artwork/"
+            f"<xxx>/<uuid> shape, skipping cleanup: {art_dir}"
+        )
+        return
+
+    if not art_dir.is_dir():
+        return
+
+    stem, suffix = artwork_file.stem, artwork_file.suffix
+    for name in (f"{stem}{suffix}", f"{stem}_m{suffix}", f"{stem}_s{suffix}"):
+        target = art_dir / name
+        if target.is_file():
+            target.unlink()
+            logger.debug(f"removed artwork file {target}")
+
+    _rmdir_if_empty_under(share_dir, art_dir)
+    _rmdir_if_empty_under(share_dir, art_dir.parent)
+
+
+def _relatives_of(contents: Sequence[tb.DjmdContent]) -> dict[str, set[str]]:
+    """Collect the shared records the given tracks point at, by kind.
+
+    Read before the rows are deleted, because the foreign keys go with them.
+    Each id is a candidate for deletion rather than a record to delete: the
+    sweep keeps whichever ones something else still references.
+    """
+    relatives: dict[str, set[str]] = {kind: set() for kind in _RELATIVE_COLUMNS}
+    for content in contents:
+        for kind, columns in _RELATIVE_COLUMNS.items():
+            for column in columns:
+                value = getattr(content, column, None)
+                if value not in (None, ""):
+                    relatives[kind].add(str(value))
+    return relatives
+
+
+class _OnDiskArtifacts(TypedDict):
+    """The paths a removed track leaves behind, read while its row still exists."""
+
+    id: str
+    analysis_data_path: str | None
+    image_path: str | None
+    folder_path: str | None
+    other_referents: bool
+
+
+def _img_has_other_referent(db: Rekordbox6Database, content: tb.DjmdContent) -> bool:
+    """Whether another row names the same artwork file."""
+    if not content.ImagePath:
+        return False
+    return (
+        require_session(db)
+        .query(tb.DjmdContent)
+        .filter(
+            tb.DjmdContent.ImagePath == content.ImagePath,
+            tb.DjmdContent.ID != content.ID,
+        )
+        .first()
+        is not None
+    )
+
+
+def remove(
+    db: Rekordbox6Database,
+    args: RemoveRequest,
+    *,
+    dry_run: bool = False,
+    ops: list[RemoveOp] | None = None,
+) -> RemoveResponse:
+    """Delete tracks matching the filter args from the library.
+
+    Removes the DjmdContent row, every child row keyed by ContentID, the
+    analysis and artwork files, and any shared artist, album, genre, or label
+    the removal leaves unreferenced. The source audio file is kept unless
+    `delete_source` is set.
+
+    With `dry_run=True`, returns the planned removals without any writes.
+
+    Pass `ops` to apply an already-approved plan; filters will be ignored.
+    """
+    logger.debug(f"remove start dry_run={dry_run} delete_source={args.delete_source}")
+
+    planned: list[RemoveOp] = []
+    skipped: list[SkippedTrack] = []
+    contents = []
+
+    if ops is None:
+        contents = list(get_filtered_content(db, args).scalars().all())
+        logger.debug(f"remove fetched {len(contents)} candidate(s) from filter")
+        planned = [
+            RemoveOp(id=str(c.ID), track=track_from_content(c)) for c in contents
+        ]
+    else:
+        rows = find_content_by_ids(db, [op.id for op in ops])
+        seen_ids: set[str] = set()
+        for op in ops:
+            if op.id in seen_ids:
+                logger.debug(f"skip remove id={op.id} reason=duplicate_op")
+                continue
+            seen_ids.add(op.id)
+            content = rows.get(op.id)
+            if content is None:
+                logger.debug(f"skip remove id={op.id} reason=db_or_fs_changed row_gone")
+                skipped.append(SkippedTrack(reason="db_or_fs_changed", track=op.track))
+                continue
+            contents.append(content)
+            planned.append(RemoveOp(id=op.id, track=track_from_content(content)))
+        logger.debug(f"remove re-checked ops={len(planned)} skipped={len(skipped)}")
+
+    if dry_run or not planned:
+        return RemoveResponse(
+            result=RemoveResult(
+                dry_run=dry_run,
+                removed=planned if dry_run else [],
+                skipped=skipped,
+                deleted_relatives=0,
+            )
+        )
+
+    # Load-bearing ordering: everything the post-commit file work needs
+    # (AnalysisDataPath, ImagePath, FolderPath, the other-referent check)
+    # must be read here, before the rows are deleted below. This is not
+    # defended by a test that can actually fail: a deleted-then-committed
+    # SQLAlchemy instance is expunged rather than expired regardless of
+    # `expire_on_commit`, so its already-loaded attributes stay readable
+    # in Python even if this read were moved to after the delete/commit,
+    # and every test in this module would still pass. That safety holds
+    # only because every column read above is a plain, non-deferred
+    # DjmdContent attribute loaded at query time; moving this block after
+    # the delete is safe only until a future deferred column or
+    # relationship attribute is added here, at which point it would raise
+    # DetachedInstanceError rather than return wrong data.
+    on_disk_artifacts: list[_OnDiskArtifacts] = [
+        {
+            "id": str(c.ID),
+            "analysis_data_path": c.AnalysisDataPath,
+            "image_path": c.ImagePath,
+            "folder_path": c.FolderPath,
+            "other_referents": _img_has_other_referent(db, c),
+        }
+        for c in contents
+    ]
+    relatives = _relatives_of(contents)
+
+    with writing(db, "remove"):
+        session = require_session(db)
+        child_tables = _content_child_tables()
+        child_rows_deleted = 0
+        for content in contents:
+            for table in child_tables:
+                child_rows_deleted += (
+                    session.query(table)
+                    .filter(table.__table__.c.ContentID == content.ID)
+                    .delete(synchronize_session=False)
+                )
+            session.delete(content)
+        session.flush()
+
+        deleted_relatives = _sweep_orphans(db, relatives)
+        # Every deleted row carries an rb_local_usn: the DjmdContent rows, the
+        # child rows just deleted above, and the swept orphans. Deleted rows
+        # cannot be stamped, but the counter must still move past all of them,
+        reserve_usns(db, len(planned) + child_rows_deleted + deleted_relatives)
+        session.commit()
+        logger.debug(
+            f"remove committed {len(planned)} row(s), "
+            f"{deleted_relatives} unreferenced relative(s) deleted"
+        )
+
+        deleted_sources = _remove_on_disk_artifacts(
+            on_disk_artifacts, db, delete_source=args.delete_source
+        )
+
+    for op in planned:
+        op.source_deleted = op.id in deleted_sources
+
+    return RemoveResponse(
+        result=RemoveResult(
+            dry_run=dry_run,
+            removed=planned,
+            skipped=skipped,
+            deleted_relatives=deleted_relatives,
+        )
+    )
+
+
+def _remove_on_disk_artifacts(
+    artifacts: list[_OnDiskArtifacts],
+    db: Rekordbox6Database,
+    *,
+    delete_source: bool,
+) -> set[str]:
+    """Delete the on-disk artifacts (analysis, artwork, source audio) after the
+    transaction has committed.
+
+    Runs post-commit, matching the convention edit uses for its ANLZ writes,
+    and never raises: the database write already succeeded, so a file that
+    cannot be deleted is a warning rather than an error implying otherwise.
+    """
+    deleted_sources: set[str] = set()
+    for artifact in artifacts:
+        # Each cleanup gets its own try: treating all errors as warnings
+        try:
+            remove_analysis_files(db, artifact["analysis_data_path"])
+        except Exception as e:
+            # A malformed stored path (e.g. an embedded NUL in AnalysisDataPath)
+            # raises ValueError from Path.resolve(),
+            logger.warning(
+                f"could not clean up analysis files for track {artifact['id']}: {e}"
+            )
+        try:
+            if artifact["other_referents"]:
+                logger.debug(
+                    f"artwork {artifact['image_path']} still referenced; keeping it"
+                )
+            else:
+                remove_artwork_files(db, artifact["image_path"])
+
+        except Exception as e:
+            logger.warning(
+                f"could not clean up artwork files for track {artifact['id']}: {e}"
+            )
+        folder_path = artifact["folder_path"]
+        if not delete_source or not folder_path:
+            continue
+        try:
+            os.remove(folder_path)
+            deleted_sources.add(artifact["id"])
+            logger.debug(f"deleted source file {folder_path}")
+        except Exception as e:
+            logger.warning(f"could not delete source file {folder_path}: {e}")
+    return deleted_sources

--- a/rekordbox_edit/cli/_click.py
+++ b/rekordbox_edit/cli/_click.py
@@ -76,14 +76,14 @@ global_click_filters = [
         "--path",
         type=str,
         multiple=True,
-        help="Find tracks whose file paths contain this value (case-insensitive)",
+        help="Find tracks whose file paths contain this value",
     ),
     click.option(
         "--resolved-path",
         type=str,
         multiple=True,
         help="Find tracks whose file paths contain this value after it is "
-        "resolved to an absolute path (case-insensitive)",
+        "resolved to an absolute path",
     ),
     click.option(
         "--format",
@@ -98,13 +98,13 @@ global_click_filters = [
         "--first",
         type=click.IntRange(min=1),
         default=None,
-        help="Return only the first N results",
+        help="Return only the first X results",
     ),
     click.option(
         "--last",
         type=click.IntRange(min=1),
         default=None,
-        help="Return only the last N results",
+        help="Return only the last X results",
     ),
     click.option(
         "--match-all",
@@ -196,6 +196,15 @@ convert_click_options = [
     ),
 ]
 
+remove_click_options = [
+    click.option(
+        "--delete-source",
+        is_flag=True,
+        default=False,
+        help=("Permanently delete each track's source audio file from disk."),
+    ),
+]
+
 
 paths_argument = click.argument("paths", type=str, required=True, nargs=-1)
 
@@ -204,7 +213,7 @@ import_command_options = [
         "--to-playlist",
         "playlist",
         default=None,
-        help="Add the tracks to this existing playlist (matched case-insensitively)",
+        help="Add the tracks to this existing playlist",
     ),
 ]
 

--- a/rekordbox_edit/cli/convert.py
+++ b/rekordbox_edit/cli/convert.py
@@ -5,6 +5,7 @@ import sys
 
 import click
 
+from rekordbox_edit.api.convert import ConvertAborted, convert
 from rekordbox_edit.cli._click import (
     add_click_options,
     convert_click_options,
@@ -13,15 +14,14 @@ from rekordbox_edit.cli._click import (
     print_option,
     track_ids_argument,
 )
-from rekordbox_edit.api.convert import ConvertAborted, convert
 from rekordbox_edit.cli._progress import convert_progress
 from rekordbox_edit.cli._utils import (
     SCRIPTING_MODES,
+    UserQuit,
     _build_args,
     _handle_stdin,
     _print_response_ids,
     _print_response_json,
-    UserQuit,
     _validate_scripting_preconditions,
     confirm,
     with_database,

--- a/rekordbox_edit/cli/main.py
+++ b/rekordbox_edit/cli/main.py
@@ -10,6 +10,7 @@ import click
 from rekordbox_edit.cli.convert import convert_command
 from rekordbox_edit.cli.edit import edit_command
 from rekordbox_edit.cli.import_ import import_command
+from rekordbox_edit.cli.remove import remove_command
 from rekordbox_edit.cli.search import search_command
 from rekordbox_edit.logger import get_debug_file_path, setup_logging
 
@@ -29,6 +30,7 @@ cli.add_command(search_command)
 cli.add_command(edit_command)
 cli.add_command(convert_command)
 cli.add_command(import_command)
+cli.add_command(remove_command)
 
 
 def main():

--- a/rekordbox_edit/cli/remove.py
+++ b/rekordbox_edit/cli/remove.py
@@ -1,0 +1,166 @@
+"""Remove CLI command."""
+
+import logging
+
+import click
+
+from rekordbox_edit.api.remove import remove
+from rekordbox_edit.cli._click import (
+    add_click_options,
+    global_click_confirmations,
+    global_click_filters,
+    print_option,
+    remove_click_options,
+    track_ids_argument,
+)
+from rekordbox_edit.cli._utils import (
+    SCRIPTING_MODES,
+    UserQuit,
+    _build_args,
+    _handle_stdin,
+    _print_response_ids,
+    _print_response_json,
+    _validate_scripting_preconditions,
+    confirm,
+    with_database,
+)
+from rekordbox_edit.display import print_track_info
+from rekordbox_edit.logger import PrintChoice, get_debug_file_path, set_level
+from rekordbox_edit.models import RemoveRequest
+
+logger = logging.getLogger(__name__)
+
+_SKIP_MESSAGES: dict[str, str] = {
+    "db_or_fs_changed": "changed since the preview",
+}
+
+
+@click.command(
+    epilog=f"Debug logs for each run can be found at:\n{get_debug_file_path().parent}"
+)
+@add_click_options(
+    [
+        *remove_click_options,
+        *global_click_confirmations,
+        *global_click_filters,
+        print_option,
+        track_ids_argument,
+    ]
+)
+@with_database(writes=True)
+def remove_command(db, **kwargs):
+    """Delete tracks from the Rekordbox library.
+
+    Removes the database row, every record that references it, the track's
+    analysis and artwork files, and any artist, album, genre, or label the
+    removal leaves with no tracks behind it.
+
+    The source audio file is kept by default. Pass --delete-source to delete
+    it permanently.
+
+    This cannot be undone. Back up your library before removing in bulk.
+    """
+    print_opt = kwargs.pop("print_opt", None)
+    dry_run = kwargs.pop("dry_run", False)
+    yes = kwargs.pop("yes", False)
+    interactive = kwargs.pop("interactive", False)
+    args = _build_args(RemoveRequest, kwargs)
+    set_level(print_opt)
+    piped_stdin = _handle_stdin(args)
+    _validate_scripting_preconditions(
+        print_opt,
+        piped_stdin=piped_stdin,
+        dry_run=dry_run,
+        yes=yes,
+        interactive=interactive,
+    )
+
+    scripting_mode = print_opt in SCRIPTING_MODES
+
+    if yes or dry_run:
+        response = remove(db, args, dry_run=dry_run)
+        _report_skips(response.result.skipped)
+        _print_remove_result(response, print_opt, scripting_mode, dry_run=dry_run)
+        return
+
+    preview = remove(db, args, dry_run=True)
+    _report_skips(preview.result.skipped)
+
+    if not preview.result.removed:
+        logger.info("No tracks matched.")
+        return
+
+    logger.info(f"Found {len(preview.result.removed)} track(s) to remove")
+    if not scripting_mode:
+        print_track_info([op.track for op in preview.result.removed])
+
+    if interactive:
+        selected_ids = []
+        for op in preview.result.removed:
+            try:
+                if confirm(f"  Remove {op.track.FileNameL}?", default=True):
+                    selected_ids.append(op.id)
+            except UserQuit:
+                break
+        if not selected_ids:
+            logger.info("Cancelled.")
+            return
+        chosen = set(selected_ids)
+        selected = [op for op in preview.result.removed if op.id in chosen]
+    else:
+        selected = list(preview.result.removed)
+
+    if not interactive:
+        try:
+            if not confirm(f"Remove {len(selected)} track(s)?", default=True):
+                logger.info("Cancelled.")
+                return
+        except UserQuit:
+            return
+
+    try:
+        args = _prompt_delete_source(args, len(selected))
+    except UserQuit:
+        return
+
+    response = remove(db, args, ops=selected)
+    _report_skips(response.result.skipped)
+    _print_remove_result(response, print_opt, scripting_mode, dry_run=False)
+
+
+def _prompt_delete_source(args, count: int):
+    """Offer to delete the source audio files, which are kept by default.
+
+    If the --delete-source flag is provided, the prompt is skipped.
+    """
+    if args.delete_source:
+        return args
+    if not confirm(f"Also delete {count} source file(s) from disk?", default=False):
+        return args
+    return args.model_copy(update={"delete_source": True})
+
+
+def _report_skips(skipped) -> None:
+    for reason, message in _SKIP_MESSAGES.items():
+        count = sum(1 for s in skipped if s.reason == reason)
+        if count:
+            logger.warning(f"Skipping {count} track(s): {message}")
+
+
+def _print_remove_result(response, print_opt, scripting_mode, *, dry_run: bool) -> None:
+    if not dry_run:
+        logger.info(f"\nRemoved {len(response.result.removed)} track(s)")
+        sources = sum(1 for op in response.result.removed if op.source_deleted)
+        if sources:
+            logger.info(f"Deleted {sources} source file(s)")
+        if response.result.deleted_relatives:
+            logger.info(
+                f"Deleted {response.result.deleted_relatives} unused "
+                "artist/album/genre/label record(s)"
+            )
+    if print_opt == PrintChoice.IDS:
+        _print_response_ids([op.id for op in response.result.removed])
+    elif print_opt == PrintChoice.JSON:
+        _print_response_json(response)
+    elif not scripting_mode and dry_run:
+        print_track_info([op.track for op in response.result.removed])

--- a/rekordbox_edit/models.py
+++ b/rekordbox_edit/models.py
@@ -4,12 +4,13 @@ Three layers:
 
 - **Filter base** (`FilterArgs`) declares track-selection criteria shared by all
   commands.
-- **API/Command request models** (`SearchRequest`, `EditRequest`, `ConvertRequest`, `ImportRequest`) extend `FilterArgs`
+- **API/Command request models** (`SearchRequest`, `EditRequest`, `ConvertRequest`, `ImportRequest`, `RemoveRequest`) extend `FilterArgs`
   with command-specific fields, except `ImportRequest`, which selects paths on
   disk rather than existing rows.
-- **API/Command response models** (`SearchResponse`, `EditResponse`, `ConvertResponse`, `ImportResponse`)
-  describe what each command returns.
-- **Domain types** (`Track`, `EditOp`, `ConvertOp`, `ImportOp`, `SkippedTrack`)
+- **API/Command response models** (`SearchResponse`, `EditResponse`, `ConvertResponse`, `ImportResponse`, `RemoveResponse`)
+  describe what each command returns. `RemoveRequest` and `RemoveResponse` model
+  the shape of the `remove()` command.
+- **Domain types** (`Track`, `EditOp`, `ConvertOp`, `ImportOp`, `RemoveOp`, `SkippedTrack`)
   which help describe the internals of requests/responses
 
 Response semantics:
@@ -130,6 +131,13 @@ class ImportRequest(BaseModel):
     from --yes, and from an answered walk prompt."""
 
 
+class RemoveRequest(FilterArgs):
+    """Inputs for remove(): which tracks to delete, and whether to unlink their
+    source audio files as well."""
+
+    delete_source: bool = False
+
+
 # ── Domain types ──────────────────────────────────────────────────────────
 
 
@@ -245,6 +253,17 @@ class ImportOp(BaseModel):
     the newly written row once a create is applied."""
 
 
+class RemoveOp(BaseModel):
+    """A planned or performed removal. `track` is the row as it stood
+    immediately before deletion, since it cannot be read afterward.
+    `source_deleted` is False for a planned removal, for a run without
+    --delete-source, and for a source file that was already gone."""
+
+    id: str
+    track: Track
+    source_deleted: bool = False
+
+
 # ── Response envelopes ────────────────────────────────────────────────────
 
 
@@ -320,3 +339,32 @@ class ImportResponse(BaseModel):
         if self.result.dry_run:
             return []
         return [op.track for op in self.result.added]
+
+
+class RemoveResult(BaseModel):
+    """Result payload for remove().
+
+    `deleted_relatives` counts the shared artist, album, genre, and label
+    records the removal left behind and deleted. It is an aggregate rather
+    than a per-op field because such a record is not attributable to one
+    track.
+    """
+
+    dry_run: bool
+    removed: list[RemoveOp]
+    skipped: list[SkippedTrack]
+    deleted_relatives: int
+
+
+class RemoveResponse(BaseModel):
+    result: RemoveResult
+
+    @computed_field
+    @property
+    def tracks(self) -> list[Track]:
+        """The rows this command removed, as they stood before deletion.
+        Empty for a dry run, since a dry run changes nothing; see
+        `result.removed` for what was planned."""
+        if self.result.dry_run:
+            return []
+        return [op.track for op in self.result.removed]

--- a/tests/api/test_remove.py
+++ b/tests/api/test_remove.py
@@ -1,0 +1,533 @@
+"""Tests for the remove API."""
+
+import logging
+import sys
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+from pyrekordbox.db6 import tables as tb
+from sqlalchemy import text
+
+from rekordbox_edit.api.remove import (
+    _content_child_tables,
+    _remove_on_disk_artifacts,
+    _sweep_orphans,
+    remove,
+    remove_analysis_files,
+    remove_artwork_files,
+)
+from rekordbox_edit.models import RemoveOp, RemoveRequest
+
+
+def current_usn(db):
+    return db.session.execute(
+        text("SELECT int_1 FROM agentRegistry WHERE registry_id = 'localUpdateCount'")
+    ).scalar()
+
+
+def test_child_tables_include_the_cloud_sync_tables():
+    """A hand-written list omitted these two during the research, and the
+    omission is invisible until a dangling row causes a problem elsewhere."""
+    found = set(_content_child_tables())
+    assert tb.ContentCue in found
+    assert tb.ContentFile in found
+
+
+def test_child_tables_cover_the_familiar_ones():
+    found = set(_content_child_tables())
+    for table in (
+        tb.DjmdCue,
+        tb.DjmdSongPlaylist,
+        tb.DjmdSongMyTag,
+        tb.DjmdMixerParam,
+        tb.DjmdSongHistory,
+    ):
+        assert table in found
+
+
+def test_child_tables_exclude_the_content_table_itself():
+    assert tb.DjmdContent not in _content_child_tables()
+
+
+def test_sweep_collects_an_unreferenced_artist(db):
+    artist = db.add_artist("RBE Sweep Orphan")
+    db.session.flush()
+    collected = _sweep_orphans(db, {"artist": {str(artist.ID)}})
+    assert collected == 1
+    assert db.get_artist(ID=artist.ID) is None
+
+
+def test_sweep_spares_a_referenced_artist(db):
+    content = (
+        db.session.query(tb.DjmdContent)
+        .filter(tb.DjmdContent.ArtistID.isnot(None))
+        .first()
+    )
+    assert content is not None, "fixture library has no track with an artist"
+    collected = _sweep_orphans(db, {"artist": {str(content.ArtistID)}})
+    assert collected == 0
+    assert db.get_artist(ID=content.ArtistID) is not None
+
+
+def test_sweep_reaches_a_fixpoint(db):
+    """The divergence from rekordbox: collecting the album must re-examine the
+    artist that album's AlbumArtistID pointed at."""
+    artist = db.add_artist("RBE Sweep Cascade Artist")
+    album = db.add_album("RBE Sweep Cascade Album", artist=artist)
+    db.session.flush()
+    collected = _sweep_orphans(
+        db, {"artist": {str(artist.ID)}, "album": {str(album.ID)}}
+    )
+    assert collected == 2
+    assert db.get_album(ID=album.ID) is None
+    assert db.get_artist(ID=artist.ID) is None
+
+
+def test_sweep_never_touches_keys(db):
+    key = db.session.query(tb.DjmdKey).first()
+    assert key is not None, "fixture library has no keys"
+    collected = _sweep_orphans(db, {"key": {str(key.ID)}})
+    assert collected == 0
+    assert db.session.query(tb.DjmdKey).filter_by(ID=key.ID).first() is not None
+
+
+@pytest.fixture
+def share(tmp_path):
+    """A share tree shaped like rekordbox's, with one analysed track in it."""
+    root = tmp_path / "share"
+    anlz = root / "PIONEER/USBANLZ/1c0/012d4-4636-45c1-9f09-b22809858a48"
+    art = root / "PIONEER/Artwork/1c0/012d4-4636-45c1-9f09-b22809858a48"
+    anlz.mkdir(parents=True)
+    art.mkdir(parents=True)
+    (anlz / "ANLZ0000.DAT").write_bytes(b"dat")
+    (anlz / "ANLZ0000.EXT").write_bytes(b"ext")
+    for name in ("artwork.jpg", "artwork_m.jpg", "artwork_s.jpg"):
+        (art / name).write_bytes(b"jpg")
+    return root
+
+
+@pytest.fixture
+def share_db(share):
+    """A mock database exposing only what the file helpers touch."""
+    from unittest.mock import MagicMock
+
+    db = MagicMock()
+    db.share_directory = share
+    db.get_anlz_dir.side_effect = lambda content: (
+        share / Path(content.AnalysisDataPath.strip("\\/")).parent
+    )
+    return db
+
+
+ANLZ_PATH = "/PIONEER/USBANLZ/1c0/012d4-4636-45c1-9f09-b22809858a48/ANLZ0000.DAT"
+ART_PATH = "/PIONEER/Artwork/1c0/012d4-4636-45c1-9f09-b22809858a48/artwork.jpg"
+
+
+def test_analysis_directory_and_prefix_are_removed(share_db, share):
+    remove_analysis_files(share_db, ANLZ_PATH)
+    assert not (share / "PIONEER/USBANLZ/1c0").exists()
+
+
+def test_empty_analysis_path_never_touches_the_share_root(share_db, share, caplog):
+    """The landmine: get_anlz_dir on an empty AnalysisDataPath resolves to the
+    share root, so a recursive delete there would destroy the whole library.
+
+    Asserts on the debug log rather than only the surviving tree, so the test
+    distinguishes the emptiness guard firing from containment (or anything
+    else downstream) happening to save the fixture instead.
+    """
+    with caplog.at_level(logging.DEBUG, logger="rekordbox_edit.api.remove"):
+        remove_analysis_files(share_db, "")
+    assert "no analysis to remove" in caplog.text
+    caplog.clear()
+
+    with caplog.at_level(logging.DEBUG, logger="rekordbox_edit.api.remove"):
+        remove_analysis_files(share_db, None)
+    assert "no analysis to remove" in caplog.text
+
+    assert share.exists()
+    assert (share / "PIONEER/USBANLZ/1c0/012d4-4636-45c1-9f09-b22809858a48").exists()
+    assert (share / "PIONEER/Artwork/1c0/012d4-4636-45c1-9f09-b22809858a48").exists()
+
+
+def test_shallow_analysis_path_is_refused(share_db, share, caplog):
+    """A malformed AnalysisDataPath shallower than PIONEER/USBANLZ/<xxx>/<uuid>
+    resolves to an ancestor directory shared by every other track's analysis
+    (or, one level shallower still, by every track's analysis AND artwork).
+    Corrupt, truncated, or foreign-tool-written data could produce this; real
+    rekordbox never does. Either way the depth check must refuse it rather
+    than rmtree an ancestor tier."""
+    with caplog.at_level(logging.WARNING, logger="rekordbox_edit.api.remove"):
+        remove_analysis_files(share_db, "/PIONEER/USBANLZ/x.DAT")
+    assert "did not have the expected" in caplog.text
+    caplog.clear()
+
+    with caplog.at_level(logging.WARNING, logger="rekordbox_edit.api.remove"):
+        remove_analysis_files(share_db, "/PIONEER/x.DAT")
+    assert "did not have the expected" in caplog.text
+
+    assert share.exists()
+    assert (share / "PIONEER/USBANLZ/1c0/012d4-4636-45c1-9f09-b22809858a48").exists()
+    assert (share / "PIONEER/Artwork/1c0/012d4-4636-45c1-9f09-b22809858a48").exists()
+
+
+def test_artwork_files_and_directory_are_removed(share_db, share):
+    remove_artwork_files(share_db, ART_PATH)
+    assert not (share / "PIONEER/Artwork/1c0").exists()
+
+
+def test_empty_image_path_never_touches_the_share_root(share_db, share, caplog):
+    """Asserts on the debug log rather than only the surviving tree, so the
+    test distinguishes the emptiness guard firing from containment (which
+    would resolve an empty ImagePath to db_directory, not the share root)
+    happening to save the fixture instead.
+    """
+    with caplog.at_level(logging.DEBUG, logger="rekordbox_edit.api.remove"):
+        remove_artwork_files(share_db, "")
+    assert "no artwork to remove" in caplog.text
+    caplog.clear()
+
+    with caplog.at_level(logging.DEBUG, logger="rekordbox_edit.api.remove"):
+        remove_artwork_files(share_db, None)
+    assert "no artwork to remove" in caplog.text
+
+    assert share.exists()
+    assert (share / "PIONEER/Artwork/1c0/012d4-4636-45c1-9f09-b22809858a48").exists()
+
+
+def test_shallow_artwork_path_is_refused(share_db, share, caplog):
+    """A malformed ImagePath shallower than PIONEER/Artwork/<xxx>/<uuid>
+    resolves to an ancestor directory shared by every other track's artwork,
+    or, one level shallower still, to a Rekordbox-managed file that has
+    nothing to do with artwork at all, like Rekordbox's own playlist export.
+    Corrupt, truncated, or foreign-tool-written data could produce this
+    shape; real rekordbox never does. Either way the depth check must refuse
+    it rather than delete a file it does not own."""
+    playlist_file = share / "PIONEER/masterPlaylists6.xml"
+    playlist_file.write_bytes(b"<playlists/>")
+
+    with caplog.at_level(logging.WARNING, logger="rekordbox_edit.api.remove"):
+        remove_artwork_files(share_db, "/PIONEER/masterPlaylists6.xml")
+    assert "did not have the expected" in caplog.text
+
+    assert playlist_file.exists()
+    assert (share / "PIONEER").is_dir()
+
+
+def test_artwork_outside_the_share_tree_is_skipped(share_db, tmp_path):
+    """A cover.jpg in the user's own music folder is not ours to delete, and no
+    reference count would catch it: one imported track from an album folder has
+    exactly one referent."""
+    outside = tmp_path / "music/Some Album/cover.jpg"
+    outside.parent.mkdir(parents=True)
+    outside.write_bytes(b"jpg")
+    remove_artwork_files(share_db, "/../music/Some Album/cover.jpg")
+    assert outside.exists()
+
+
+def test_analysis_outside_the_share_tree_is_skipped(share_db, tmp_path, caplog):
+    """The counterpart to the artwork check above. A stored path that walks out
+    of the share tree names something rekordbox does not manage, and a
+    recursive delete there would take the user's own files with it."""
+    outside = tmp_path / "music/Some Album/anlz"
+    outside.mkdir(parents=True)
+    (outside / "ANLZ0000.DAT").write_bytes(b"dat")
+
+    with caplog.at_level(logging.WARNING, logger="rekordbox_edit.api.remove"):
+        remove_analysis_files(share_db, "/../music/Some Album/anlz/ANLZ0000.DAT")
+
+    assert "Refusing to delete outside the share tree" in caplog.text
+    assert (outside / "ANLZ0000.DAT").exists()
+
+
+@pytest.mark.parametrize("failing", ["analysis", "artwork"])
+def test_file_work_warns_rather_than_raising(share_db, failing, caplog, monkeypatch):
+    """The database write has already committed by the time this runs, so an
+    escaping exception would report a failed write for one that landed. A
+    malformed stored path raises ValueError from Path.resolve() rather than
+    OSError, which is why both handlers catch Exception."""
+    # Patched through sys.modules rather than by dotted string: api/__init__.py
+    # re-exports the remove() function, so "rekordbox_edit.api.remove" resolves
+    # to the function and not to this module (issue #212).
+    module = sys.modules["rekordbox_edit.api.remove"]
+    monkeypatch.setattr(
+        module, f"remove_{failing}_files", Mock(side_effect=ValueError("embedded NUL"))
+    )
+
+    with caplog.at_level(logging.WARNING, logger="rekordbox_edit.api.remove"):
+        deleted = _remove_on_disk_artifacts(
+            [
+                {
+                    "id": "7",
+                    "analysis_data_path": ANLZ_PATH,
+                    "image_path": ART_PATH,
+                    "folder_path": None,
+                    "other_referents": False,
+                }
+            ],
+            share_db,
+            delete_source=False,
+        )
+
+    assert deleted == set()
+    assert f"could not clean up {failing} files for track 7" in caplog.text
+
+
+def test_artwork_with_another_referent_is_kept(share_db, share):
+    _remove_on_disk_artifacts(
+        [
+            {
+                "id": "1",
+                "analysis_data_path": None,
+                "image_path": ART_PATH,
+                "folder_path": None,
+                "other_referents": True,
+            }
+        ],
+        share_db,
+        delete_source=False,
+    )
+    art = share / "PIONEER/Artwork/1c0/012d4-4636-45c1-9f09-b22809858a48"
+    assert (art / "artwork.jpg").exists()
+
+
+def test_unexpected_file_in_the_artwork_directory_stops_the_cleanup(share_db, share):
+    """rmdir rather than a recursive delete, so a stranger survives."""
+    art = share / "PIONEER/Artwork/1c0/012d4-4636-45c1-9f09-b22809858a48"
+    (art / "notes.txt").write_bytes(b"mine")
+    remove_artwork_files(share_db, ART_PATH)
+    assert not (art / "artwork.jpg").exists()
+    assert (art / "notes.txt").exists()
+
+
+def _any_track_id(db):
+    content = db.session.query(tb.DjmdContent).first()
+    assert content is not None, "fixture library is empty"
+    return str(content.ID)
+
+
+def test_dry_run_touches_neither_the_usn_counter_nor_any_file(db, tmp_path):
+    track_id = _any_track_id(db)
+    before_usn = current_usn(db)
+    content = db.get_content(ID=track_id)
+    audio = tmp_path / "track.mp3"
+    audio.write_bytes(b"audio")
+    content.FolderPath = str(audio)
+    db.session.flush()
+
+    response = remove(
+        db, RemoveRequest(track_id=[track_id], delete_source=True), dry_run=True
+    )
+
+    assert [op.id for op in response.result.removed] == [track_id]
+    assert db.get_content(ID=track_id) is not None
+    assert current_usn(db) == before_usn
+    assert audio.exists()
+    assert response.result.deleted_relatives == 0
+
+
+def _track_with_children(db):
+    """A track that actually occupies several ContentID tables.
+
+    Picking an arbitrary row would let this test pass against a track with no
+    child rows at all, which proves nothing about the sweep.
+    """
+    tables = _content_child_tables()
+    for content in db.session.query(tb.DjmdContent).all():
+        occupied = sum(
+            1
+            for table in tables
+            if db.session.query(table)
+            .filter(table.__table__.c.ContentID == content.ID)
+            .first()
+            is not None
+        )
+        if occupied >= 2:
+            return content, occupied
+    pytest.skip("fixture library has no track occupying two child tables")
+
+
+def test_remove_deletes_the_row_and_its_children(db):
+    content, occupied = _track_with_children(db)
+    track_id = str(content.ID)
+    assert occupied >= 2
+
+    remove(db, RemoveRequest(track_id=[track_id]))
+
+    assert db.get_content(ID=track_id) is None
+    for table in _content_child_tables():
+        remaining = (
+            db.session.query(table)
+            .filter(table.__table__.c.ContentID == track_id)
+            .count()
+        )
+        assert remaining == 0, f"{table.__tablename__} still references the track"
+
+
+def test_removed_track_is_reported_as_it_stood(db):
+    content = db.session.query(tb.DjmdContent).first()
+    track_id, title = str(content.ID), content.Title
+    response = remove(db, RemoveRequest(track_id=[track_id]))
+    assert response.tracks[0].ID == track_id
+    assert response.tracks[0].Title == title
+
+
+def test_remove_advances_the_usn_counter(db):
+    # At least one for the DjmdContent row; the first fixture row may also
+    # carry child rows of its own, which reserve further USNs -- see
+    # test_usn_counter_advances_past_every_deleted_child_row for that case
+    # pinned precisely.
+    before = current_usn(db)
+    remove(db, RemoveRequest(track_id=[_any_track_id(db)]))
+    assert current_usn(db) >= before + 1
+
+
+def test_usn_counter_advances_past_every_deleted_child_row(db):
+    """A track occupying two child tables must reserve more than one USN: one
+    for the DjmdContent row, and at least one per child row deleted alongside
+    it. Reserving only for the DjmdContent row would reuse a stamp, which
+    hides a row from a syncing peer -- the dangerous direction per
+    research/remove-track-impact/decisions/remove-command-behavior.md."""
+    content, occupied = _track_with_children(db)
+    track_id = str(content.ID)
+    before = current_usn(db)
+
+    remove(db, RemoveRequest(track_id=[track_id]))
+
+    assert current_usn(db) >= before + 1 + occupied
+
+
+def test_a_vanished_row_is_skipped_not_crashed(db, make_track):
+    ghost = RemoveOp(id="99999999", track=make_track(ID="99999999"))
+    response = remove(db, RemoveRequest(), ops=[ghost])
+    assert response.result.removed == []
+    assert [s.reason for s in response.result.skipped] == ["db_or_fs_changed"]
+
+
+def test_duplicate_ops_are_removed_once(db, make_track):
+    track_id = _any_track_id(db)
+    track = make_track(ID=track_id)
+    dup = [RemoveOp(id=track_id, track=track), RemoveOp(id=track_id, track=track)]
+
+    response = remove(db, RemoveRequest(), ops=dup)
+
+    assert [op.id for op in response.result.removed] == [track_id]
+    assert response.result.removed[0].source_deleted is False
+    assert db.get_content(ID=track_id) is None
+
+
+def test_missing_source_file_still_removes_the_row(db, monkeypatch):
+    # api/__init__.py's `from rekordbox_edit.api.remove import remove` shadows
+    # the `remove` submodule attribute on the `api` package with the function
+    # itself, which breaks any attribute-chain lookup of
+    # "rekordbox_edit.api.remove" (monkeypatch's dotted-string resolution
+    # included, and even `import rekordbox_edit.api.remove as x`, since that
+    # also resolves through the same shadowed attribute). Reading straight
+    # out of sys.modules sidesteps the shadowing entirely.
+    remove_module = sys.modules["rekordbox_edit.api.remove"]
+
+    track_id = _any_track_id(db)
+    monkeypatch.setattr(
+        remove_module.os,
+        "remove",
+        lambda path: (_ for _ in ()).throw(FileNotFoundError(path)),
+    )
+    response = remove(db, RemoveRequest(track_id=[track_id], delete_source=True))
+    assert [op.id for op in response.result.removed] == [track_id]
+    assert response.result.removed[0].source_deleted is False
+    assert db.get_content(ID=track_id) is None
+
+
+def test_delete_source_unlinks_the_file(db, tmp_path):
+    audio = tmp_path / "track.mp3"
+    audio.write_bytes(b"audio")
+    content = db.session.query(tb.DjmdContent).first()
+    content.FolderPath = str(audio)
+    db.session.flush()
+    response = remove(db, RemoveRequest(track_id=[str(content.ID)], delete_source=True))
+    assert response.result.removed[0].source_deleted is True
+    assert not audio.exists()
+
+
+def test_source_survives_without_the_flag(db, tmp_path):
+    audio = tmp_path / "track.mp3"
+    audio.write_bytes(b"audio")
+    content = db.session.query(tb.DjmdContent).first()
+    content.FolderPath = str(audio)
+    db.session.flush()
+    response = remove(db, RemoveRequest(track_id=[str(content.ID)]))
+    assert response.result.removed[0].source_deleted is False
+    assert audio.exists()
+
+
+def test_remove_deletes_analysis_and_artwork_files_on_disk(db):
+    """End-to-end check that a real removal deletes the real analysis and
+    artwork directories a fixture row points at, not just the database rows.
+
+    This does NOT defend the read-before-delete ordering in remove(): a
+    mutation that read AnalysisDataPath/ImagePath after the delete/commit
+    instead of before still passes this test, because a deleted-then-
+    committed SQLAlchemy instance is expunged rather than expired (regardless
+    of `expire_on_commit`), so its already-loaded attributes stay readable in
+    Python. Verified directly by moving the read and confirming every test in
+    this module, this one included, kept passing. That ordering is called out
+    as load-bearing and untested in a comment at the `file_work` construction
+    in remove.py instead.
+    """
+    content = db.session.query(tb.DjmdContent).first()
+    assert content is not None
+
+    anlz_dir = db.share_directory / "PIONEER/USBANLZ/1c0/e2e-test-uuid"
+    art_dir = db.share_directory / "PIONEER/Artwork/1c0/e2e-test-uuid"
+    anlz_dir.mkdir(parents=True)
+    art_dir.mkdir(parents=True)
+    (anlz_dir / "ANLZ0000.DAT").write_bytes(b"dat")
+    (anlz_dir / "ANLZ0000.EXT").write_bytes(b"ext")
+    for name in ("artwork.jpg", "artwork_m.jpg", "artwork_s.jpg"):
+        (art_dir / name).write_bytes(b"jpg")
+
+    content.AnalysisDataPath = "/PIONEER/USBANLZ/1c0/e2e-test-uuid/ANLZ0000.DAT"
+    content.ImagePath = "/PIONEER/Artwork/1c0/e2e-test-uuid/artwork.jpg"
+    db.session.flush()
+
+    remove(db, RemoveRequest(track_id=[str(content.ID)]))
+
+    assert not anlz_dir.exists()
+    assert not art_dir.exists()
+
+
+def test_deleted_relatives_reports_a_swept_record(db):
+    artist = db.add_artist("RBE Remove Sweep Report Artist")
+    artist_id = str(artist.ID)
+    content = db.session.query(tb.DjmdContent).first()
+    assert content is not None
+    content.ArtistID = artist_id
+    db.session.flush()
+
+    response = remove(db, RemoveRequest(track_id=[str(content.ID)]))
+
+    # Read via a fresh query, not the `artist` instance: the commit inside
+    # remove() expires it, and re-reading an attribute off a row the sweep
+    # just deleted raises ObjectDeletedError rather than returning None.
+    assert response.result.deleted_relatives >= 1
+    assert db.get_artist(ID=artist_id) is None
+
+
+def test_artwork_survives_when_another_row_shares_the_image_path(db):
+    art_dir = db.share_directory / "PIONEER/Artwork/1c0/shared-uuid"
+    art_dir.mkdir(parents=True)
+    (art_dir / "artwork.jpg").write_bytes(b"jpg")
+    image_path = "/PIONEER/Artwork/1c0/shared-uuid/artwork.jpg"
+
+    contents = db.session.query(tb.DjmdContent).limit(2).all()
+    assert len(contents) == 2, "fixture library needs at least two tracks"
+    first, second = contents
+    first.ImagePath = image_path
+    second.ImagePath = image_path
+    db.session.flush()
+
+    remove(db, RemoveRequest(track_id=[str(first.ID)]))
+
+    assert db.get_content(ID=first.ID) is None
+    assert (art_dir / "artwork.jpg").exists()

--- a/tests/api/test_utils.py
+++ b/tests/api/test_utils.py
@@ -12,6 +12,7 @@ from sqlalchemy import text
 from tests.api.conftest import close_database
 
 from rekordbox_edit.api._utils import (
+    reserve_usns,
     stamp_usns,
     track_from_content,
     writing,
@@ -44,6 +45,25 @@ class TestTrackFromContent:
 _COUNTER = text(
     "SELECT int_1 FROM agentRegistry WHERE registry_id = 'localUpdateCount'"
 )
+
+
+def current_usn(db):
+    return db.session.execute(
+        text("SELECT int_1 FROM agentRegistry WHERE registry_id = 'localUpdateCount'")
+    ).scalar()
+
+
+class TestReserveUsns:
+    def test_reserve_usns_advances_the_counter(self, db):
+        before = current_usn(db)
+        last = reserve_usns(db, 5)
+        assert last == before + 5
+        assert current_usn(db) == before + 5
+
+    def test_reserve_usns_is_a_noop_for_zero(self, db):
+        before = current_usn(db)
+        assert reserve_usns(db, 0) is None
+        assert current_usn(db) == before
 
 
 class TestStampUsns:

--- a/tests/cli/test_remove.py
+++ b/tests/cli/test_remove.py
@@ -1,0 +1,253 @@
+"""Tests for cli/remove.py."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from rekordbox_edit.cli._utils import UserQuit
+from rekordbox_edit.cli.remove import remove_command
+from rekordbox_edit.models import (
+    RemoveOp,
+    RemoveResponse,
+    RemoveResult,
+    Track,
+)
+
+
+@pytest.fixture(autouse=True)
+def mock_logger():
+    with patch("rekordbox_edit.cli.remove.logger") as mock_log:
+        yield mock_log
+
+
+def _response(count=1, skipped=None, orphans=0, source_deleted=False, dry_run=False):
+    removed = [
+        RemoveOp(
+            id=str(i),
+            track=Track(ID=str(i), FileNameL=f"t{i}.mp3", FolderPath=f"/t{i}.mp3"),
+            source_deleted=source_deleted,
+        )
+        for i in range(count)
+    ]
+    return RemoveResponse(
+        result=RemoveResult(
+            dry_run=dry_run,
+            removed=removed,
+            skipped=skipped or [],
+            deleted_relatives=orphans,
+        )
+    )
+
+
+def _defaults_by_prompt(mock_confirm):
+    """Map each prompt's text to the `default` it was asked with."""
+    return {
+        call.args[0]: call.kwargs.get("default") for call in mock_confirm.call_args_list
+    }
+
+
+class TestRemoveCommand:
+    @patch("rekordbox_edit.cli.remove.confirm", return_value=True)
+    @patch("rekordbox_edit.cli.remove.remove")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    @patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None)
+    def test_source_prompt_defaults_to_no(
+        self, _pid, mock_db_class, mock_remove, mock_confirm
+    ):
+        """The prompt offers a destructive step the user did not ask for, so it
+        matches convert's --overwrite prompt rather than its apply
+        confirmation."""
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_remove.return_value = _response()
+
+        result = CliRunner().invoke(remove_command, ["--title", "x"])
+
+        assert result.exit_code == 0
+        defaults = _defaults_by_prompt(mock_confirm)
+        source_prompt = next(p for p in defaults if "source file" in p)
+        assert defaults[source_prompt] is False
+
+    @patch("rekordbox_edit.cli.remove.confirm", return_value=True)
+    @patch("rekordbox_edit.cli.remove.remove")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    @patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None)
+    def test_removal_confirmation_defaults_to_yes(
+        self, _pid, mock_db_class, mock_remove, mock_confirm
+    ):
+        """Applying what the user invoked, so it matches edit and convert."""
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_remove.return_value = _response()
+
+        result = CliRunner().invoke(remove_command, ["--title", "x"])
+
+        assert result.exit_code == 0
+        defaults = _defaults_by_prompt(mock_confirm)
+        apply_prompt = next(p for p in defaults if p.startswith("Remove "))
+        assert defaults[apply_prompt] is True
+
+    @patch("rekordbox_edit.cli.remove.confirm", return_value=True)
+    @patch("rekordbox_edit.cli.remove.remove")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    @patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None)
+    def test_delete_source_flag_suppresses_the_prompt(
+        self, _pid, mock_db_class, mock_remove, mock_confirm
+    ):
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_remove.return_value = _response(source_deleted=True)
+
+        result = CliRunner().invoke(remove_command, ["--title", "x", "--delete-source"])
+
+        assert result.exit_code == 0
+        assert not any("source file" in p for p in _defaults_by_prompt(mock_confirm))
+
+    @patch("rekordbox_edit.cli.remove.confirm")
+    @patch("rekordbox_edit.cli.remove.remove")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    @patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None)
+    def test_scripting_mode_never_prompts(
+        self, _pid, mock_db_class, mock_remove, mock_confirm
+    ):
+        """No prompt can be shown, so --delete-source is the only route to
+        deleting sources."""
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_remove.return_value = _response()
+
+        result = CliRunner().invoke(
+            remove_command, ["--title", "x", "--yes", "--print", "ids"]
+        )
+
+        assert result.exit_code == 0
+        mock_confirm.assert_not_called()
+        assert mock_remove.call_args.kwargs.get("ops") is None
+
+    @patch("rekordbox_edit.cli.remove.confirm", return_value=False)
+    @patch("rekordbox_edit.cli.remove.remove")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    @patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None)
+    def test_declining_the_confirmation_removes_nothing(
+        self, _pid, mock_db_class, mock_remove, mock_confirm
+    ):
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_remove.return_value = _response()
+
+        result = CliRunner().invoke(remove_command, ["--title", "x"])
+
+        assert result.exit_code == 0
+        # Only the dry-run preview ran; nothing was applied.
+        assert mock_remove.call_count == 1
+        assert mock_remove.call_args.kwargs.get("dry_run") is True
+
+    @patch("rekordbox_edit.cli.remove.confirm")
+    @patch("rekordbox_edit.cli.remove.remove")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    @patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None)
+    def test_interactive_applies_only_the_confirmed_tracks(
+        self, _pid, mock_db_class, mock_remove, mock_confirm
+    ):
+        """The one path where the answers do not map onto the whole preview, so
+        a mistake here removes a track the user declined."""
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_remove.return_value = _response(count=3)
+        # t0 yes, t1 no, t2 yes, then no to deleting the sources.
+        mock_confirm.side_effect = [True, False, True, False]
+
+        result = CliRunner().invoke(remove_command, ["--title", "x", "--interactive"])
+
+        assert result.exit_code == 0
+        assert [op.id for op in mock_remove.call_args.kwargs["ops"]] == ["0", "2"]
+        # The per-track prompts replace the bulk one rather than adding to it.
+        assert not any(
+            p.startswith("Remove 2") for p in _defaults_by_prompt(mock_confirm)
+        )
+        assert mock_remove.call_args.args[1].delete_source is False
+
+    @patch("rekordbox_edit.cli.remove.confirm")
+    @patch("rekordbox_edit.cli.remove.remove")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    @patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None)
+    def test_quitting_the_interactive_loop_keeps_the_earlier_answers(
+        self, _pid, mock_db_class, mock_remove, mock_confirm
+    ):
+        """Quitting stops the questions rather than discarding the answers
+        already given, so t0 is still removed and t2 is never asked about."""
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_remove.return_value = _response(count=3)
+        # t0 yes, quit at t1, then no to deleting the sources.
+        mock_confirm.side_effect = [True, UserQuit, False]
+
+        result = CliRunner().invoke(remove_command, ["--title", "x", "--interactive"])
+
+        assert result.exit_code == 0
+        assert [op.id for op in mock_remove.call_args.kwargs["ops"]] == ["0"]
+        assert not any("t2.mp3" in p for p in _defaults_by_prompt(mock_confirm))
+
+    @patch("rekordbox_edit.cli.remove.confirm")
+    @patch("rekordbox_edit.cli.remove.remove")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    @patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None)
+    def test_declining_every_track_removes_nothing(
+        self, _pid, mock_db_class, mock_remove, mock_confirm
+    ):
+        """An empty selection cancels rather than falling through to a removal
+        with no ops, which would report success having done nothing."""
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_remove.return_value = _response(count=3)
+        mock_confirm.side_effect = [False, False, False]
+
+        result = CliRunner().invoke(remove_command, ["--title", "x", "--interactive"])
+
+        assert result.exit_code == 0
+        assert mock_remove.call_count == 1
+        assert mock_remove.call_args.kwargs.get("dry_run") is True
+
+    @patch("rekordbox_edit.cli.remove.confirm", side_effect=UserQuit)
+    @patch("rekordbox_edit.cli.remove.remove")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    @patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None)
+    def test_quitting_the_confirmation_removes_nothing(
+        self, _pid, mock_db_class, mock_remove, _confirm
+    ):
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_remove.return_value = _response()
+
+        result = CliRunner().invoke(remove_command, ["--title", "x"])
+
+        assert result.exit_code == 0
+        assert mock_remove.call_count == 1
+        assert mock_remove.call_args.kwargs.get("dry_run") is True
+
+    @patch("rekordbox_edit.cli.remove.confirm", side_effect=[True, UserQuit])
+    @patch("rekordbox_edit.cli.remove.remove")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    @patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None)
+    def test_quitting_the_source_prompt_abandons_the_removal(
+        self, _pid, mock_db_class, mock_remove, _confirm
+    ):
+        """The source prompt comes after the removal is confirmed, so quitting
+        there abandons a removal the user already said yes to rather than
+        applying it with the sources kept."""
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_remove.return_value = _response()
+
+        result = CliRunner().invoke(remove_command, ["--title", "x"])
+
+        assert result.exit_code == 0
+        assert mock_remove.call_count == 1
+        assert mock_remove.call_args.kwargs.get("dry_run") is True
+
+    @patch("rekordbox_edit.cli.remove.confirm", return_value=True)
+    @patch("rekordbox_edit.cli.remove.remove")
+    @patch("rekordbox_edit.cli._utils.Rekordbox6Database")
+    @patch("rekordbox_edit.api._utils.get_rekordbox_pid", return_value=None)
+    def test_dry_run_applies_nothing(
+        self, _pid, mock_db_class, mock_remove, mock_confirm
+    ):
+        mock_db_class.return_value = Mock(session=Mock())
+        mock_remove.return_value = _response()
+
+        result = CliRunner().invoke(remove_command, ["--title", "x", "--dry-run"])
+
+        assert result.exit_code == 0
+        mock_confirm.assert_not_called()
+        assert mock_remove.call_args.kwargs.get("dry_run") is True

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,8 +8,8 @@ from rekordbox_edit.models import (
     ConvertRequest,
     ConvertResponse,
     ConvertResult,
-    EditRequest,
     EditOp,
+    EditRequest,
     EditResponse,
     EditResult,
     FilterArgs,
@@ -17,6 +17,10 @@ from rekordbox_edit.models import (
     ImportRequest,
     ImportResponse,
     ImportResult,
+    RemoveOp,
+    RemoveRequest,
+    RemoveResponse,
+    RemoveResult,
     SearchRequest,
     SearchResponse,
     SkippedTrack,
@@ -110,10 +114,21 @@ def _import_response(tracks, *, dry_run):
     )
 
 
+def _remove_response(tracks, *, dry_run):
+    return RemoveResponse(
+        result=RemoveResult(
+            dry_run=dry_run,
+            removed=[RemoveOp(id=str(i), track=t) for i, t in enumerate(tracks)],
+            skipped=[],
+            deleted_relatives=0,
+        )
+    )
+
+
 @pytest.mark.parametrize(
     "build_response",
-    [_edit_response, _convert_response, _import_response],
-    ids=["edit", "convert", "import"],
+    [_edit_response, _convert_response, _import_response, _remove_response],
+    ids=["edit", "convert", "import", "remove"],
 )
 def test_computed_tracks_field_is_serialized_at_top_level(build_response, make_track):
     """`tracks` is a computed field: it must survive model_dump(), not just
@@ -129,8 +144,8 @@ def test_computed_tracks_field_is_serialized_at_top_level(build_response, make_t
 
 @pytest.mark.parametrize(
     "build_response",
-    [_edit_response, _convert_response, _import_response],
-    ids=["edit", "convert", "import"],
+    [_edit_response, _convert_response, _import_response, _remove_response],
+    ids=["edit", "convert", "import", "remove"],
 )
 def test_computed_tracks_field_is_present_but_empty_on_a_dry_run(
     build_response, make_track
@@ -346,3 +361,34 @@ class TestImportResponse:
         )
         assert response.tracks == []
         assert response.result.added[0].track.FileNameL == "a.flac"
+
+
+def test_remove_response_tracks_are_the_removed_rows(make_track):
+    response = RemoveResponse(
+        result=RemoveResult(
+            dry_run=False,
+            removed=[RemoveOp(id="4", track=make_track(ID="4"))],
+            skipped=[],
+            deleted_relatives=2,
+        )
+    )
+    assert [t.ID for t in response.tracks] == ["4"]
+    assert response.result.deleted_relatives == 2
+    assert response.result.removed[0].source_deleted is False
+
+
+def test_remove_response_tracks_empty_on_dry_run(make_track):
+    response = RemoveResponse(
+        result=RemoveResult(
+            dry_run=True,
+            removed=[RemoveOp(id="4", track=make_track(ID="4"))],
+            skipped=[],
+            deleted_relatives=0,
+        )
+    )
+    assert response.tracks == []
+    assert response.result.removed[0].track.ID == "4"
+
+
+def test_remove_request_defaults_to_keeping_the_source():
+    assert RemoveRequest().delete_source is False


### PR DESCRIPTION
Adds `rbe remove`, which deletes a track from the library.

**Stacked on #211.** Review that first; this branch contains its commits until it merges.

## What it deletes

- The `DjmdContent` row.
- Every child row keyed by `ContentID`, found by reflecting over the mapped metadata rather than from a list. A hand-written list omitted the cloud-sync tables `contentCue` and `contentFile`.
- The analysis directory and its prefix directory.
- The artwork files, their directory, and its prefix directory.
- Any artist, album, genre, or label the removal leaves unreferenced. Keys and colours are never collected.

The source audio file is kept unless `--delete-source` is passed, which unlinks it permanently rather than moving it to the trash.

## Two deliberate divergences from Rekordbox

- The orphan sweep repeats until nothing new becomes unreferenced. Rekordbox sweeps once and strands an artist whose only remaining reference was an album that the same sweep collected.
- The emptied artwork directory is removed. Rekordbox leaves it in place and empty.

Both are recorded in `research/remove-track-impact/decisions/remove-command-behavior.md`.

## Guards on the file deletion

- `AnalysisDataPath` and `ImagePath` are checked for emptiness before any path resolves. An empty `AnalysisDataPath` resolves to the share root, an empty `ImagePath` to the directory above it.
- Every path must resolve under the share directory.
- Each directory must sit at its expected depth, so a malformed column value cannot reach an ancestor tier.
- Artwork directories are removed with `rmdir`, so anything unexpected inside halts the cleanup.
- Artwork is kept when another row names the same `ImagePath`.

## API

- `remove(db, args, *, dry_run=False, ops=None) -> RemoveResponse`, exported from `rekordbox_edit.api`.
- `RemoveRequest`, `RemoveOp`, `RemoveResult`, `RemoveResponse`.
- `reserve_usns(db, count)` split out of `stamp_usns`, since a deleted row cannot be stamped but the counter must still advance past it. One USN per deleted row, including child rows and swept orphans.

## CLI

- The removal confirmation defaults to yes, matching `edit` and `convert`.
- The source-file prompt defaults to no and is answered up front by `--delete-source`, matching `convert`'s `--overwrite`.
- Scripting modes cannot prompt, so the flag is the only route there.

## Known

- `rekordbox_edit.api.remove` the submodule is shadowed by the re-exported function. Pre-existing for `edit` and `convert` too; filed as #212.

773 passed, 1 skipped. Lint, format, typecheck, and `mkdocs --strict` clean.
