### PR TITLE
docs(research): investigate integrating rekordbox-edit with beets

### DIFF
--- a/research/README.md
+++ b/research/README.md
@@ -47,6 +47,14 @@ formal and terse, and states findings as the evidence supports them.
   command deliberately diverges from that behavior.
 - **`file-types/`** — how `convert` and the display layer should treat Rekordbox
   `FileType` codes the tool does not map.
+- **`beets-plugin-integration/`** — what beets' plugin architecture permits a
+  rekordbox-edit integration to do: where events fire relative to database
+  inserts and file moves, which events the autotagger gates off, why beets item
+  identifiers do not survive a reimport, and what that forces about how the two
+  databases are joined. Also what it takes for a beets library to follow an
+  `rbe convert`, why the converted file usually needs no move, and why keeping
+  the original leaves the two libraries unable to agree — which is what settles
+  the plugin deleting originals by default where the CLI does not.
 - **`import-track-row-shape/`** — what a `DjmdContent` row holds immediately after
   Rekordbox imports a track and before analysis runs, which columns come from
   tags rather than the audio, and where `pyrekordbox.add_content` diverges from

--- a/research/beets-plugin-integration/beets-plugin-integration.md
+++ b/research/beets-plugin-integration/beets-plugin-integration.md
@@ -1,0 +1,557 @@
+# Integrating rekordbox-edit With Beets
+
+## Question
+
+Beets manages a music library: it tags files, relocates them under a path
+template, and records the result in a SQLite database. Rekordbox maintains its
+own database of the same files, keyed by path. When beets moves or transcodes a
+file, the rekordbox row pointing at it becomes wrong.
+
+What integration does beets' plugin architecture actually permit, and what shape
+should a rekordbox-edit plugin take? Three workflows frame the question:
+
+1. **Convert, then follow.** A user runs `rbe convert` over tracks rekordbox
+   manages. Each file is transcoded beside its source and its rekordbox row is
+   repointed at the output; depending on the mode, the source is then deleted or
+   kept. Beets manages the same files and still points at the sources. The new
+   paths have to reach the beets library, and where the source is kept the two
+   databases end up disagreeing about how many tracks exist.
+2. **Repoint after a move.** A user imports files that beets relocates, and
+   wants the rekordbox rows to follow, along with any columns beets can now
+   populate better than the original tags did.
+3. **Reimport and update.** A user re-runs the autotagger over items already in
+   both databases and wants the improved metadata propagated to rekordbox.
+
+## Terminology
+
+Both tools have a library, a convert, and an import, and this document discusses
+all six. Two conventions keep them apart.
+
+**A "row" without qualification is a `DjmdContent` row**, in rekordbox's
+database. Beets' rows are never called rows: they are *items* and *albums*.
+
+**A bare command name is beets'.** `import`, `convert`, and `modify` mean
+`beet import`, the beets convert plugin, and `beet modify`. rekordbox-edit's are
+always written `rbe convert`, `rbe edit`, `rbe import`, or named by the API
+function behind them (`convert()`, `edit()`, `import_tracks()`).
+
+### Beets
+
+| Term | Meaning |
+| --- | --- |
+| **item** | One row of beets' SQLite library, describing one audio file: its path plus the fields read from its tags. |
+| **album** | A row grouping items. An item's `album_id` names one; `Library.add` leaves it unset. |
+| **singleton** | An item deliberately attached to no album. `beet import -s`, or `import.singletons: yes`. |
+| **library directory** | The root beets relocates files under, the `directory:` config key. |
+| **path template**, path format | The `paths:` config deciding where under the library directory a file belongs, such as `$albumartist/$album/$track $title`. `Item.destination()` evaluates it. The extension is not part of it; it comes from the file the item currently names. |
+| **flexible attribute**, flexattr | A field held only in beets' database and never in the file's tags. Any field name beets does not recognise becomes one. |
+| **media field** | A field bound to a real tag frame in the file, so `item.write()` stores it and `item.read()` recovers it. Plugins may declare new ones. |
+| **the import pipeline** | The staged process `beet import` runs: task construction, tagging, plugin stages, then file relocation. Order matters throughout this document. |
+| **import stage** | A plugin callback running *inside* that pipeline, given the session and the task, able to change what happens next. |
+| **event**, listener | A named notification beets sends. A listener is told what happened; with a single exception it cannot alter the outcome. |
+| **autotag** | Beets matching a file's metadata against MusicBrainz. On by default. |
+| **as-is import**, `-A`, `autotag: no` | Importing with that lookup switched off, so beets keeps the file's existing tags. Internally the task's choice becomes `Action.ASIS` rather than `Action.APPLY`, which is what suppresses three events and tag writing. This document says **as-is import** for all three spellings. |
+| **apply** | The opposite state, `Action.APPLY`: matched metadata is being written onto the item. `task.apply` is true only here. |
+| **reimport** | Re-running the importer over files already in the library, `beet import -L`. It removes the existing items and inserts new ones rather than updating in place. |
+| **the convert plugin** | Beets' bundled transcoder, `beetsplug/convert.py`. Never `rbe convert`. |
+| **`convert.auto`**, `auto_keep`, `--keep-new` | Its modes, which differ in where the output lands and whether the library entry follows it. Tabulated under [Going Through the Beets Convert Plugin Is the Other Direction](#going-through-the-beets-convert-plugin-is-the-other-direction). |
+
+### Rekordbox-edit
+
+| Term | Meaning |
+| --- | --- |
+| **`DjmdContent`** | Rekordbox's track table, one row per track. `FolderPath` and `FileNameL` hold the location, `FileType` a numeric format code. |
+| **`rbe convert`** | rekordbox-edit's transcode command. Encodes beside the source and repoints the existing `DjmdContent` row at the output. |
+| **`rbe edit`** | Its field-editing command. Writes named columns onto matched rows through per-field handlers. |
+| **`rbe import`**, `import_tracks()` | Its command for creating `DjmdContent` rows for files rekordbox does not yet know about, matched by resolved case-folded path. |
+| **field handler** | The per-column unit `rbe edit` is built from, owning one field's validation and write. |
+| **`--delete-originals`** | `rbe convert`'s policy for the source file once the output exists. The default `none` keeps it; `all` always deletes it; `lossless` deletes it only when the conversion lost no audio information. |
+| **USN** | Rekordbox's change counter, global in `agentRegistry.localUpdateCount` and per-row in `rb_local_usn`. Every row rekordbox-edit writes is stamped. |
+| **ANLZ** | Rekordbox's on-disk analysis files for a track, which embed the track's path and so must be rewritten when it moves. |
+
+## Method
+
+Code reading against beets 2.5.1 on Python 3.13.15, and rekordbox-edit at
+`d920d9b`. Five probes under `scripts/` produce the files under `evidence/`:
+
+- `event_probe.py` installs a plugin listening to every event in
+  `beets.plugins.EventType` plus the convert plugin's `after_convert`, then runs
+  an import and a reimport against a throwaway library.
+- `id_stability.py` records item identifiers before and after a reimport, using
+  the unchanged file paths as a control.
+- `media_field_roundtrip.py` stamps a plugin-declared media field and reads the
+  value back out of the file with mediafile alone.
+- `convert_repoint.py` imports fixtures into a throwaway library, transcodes each
+  one beside its source the way `rbe convert` does, and reports what it costs to
+  repoint the existing item at the output or to register the output as a new one.
+- `file_level_encode.py` builds rekordbox-edit's `_EncodeJob` by hand from a path
+  on disk and runs `_encode_one` against it, with and without a declared
+  rekordbox file type. It runs in the rekordbox-edit environment rather than
+  beets'; the rest run against `beet` on `PATH`.
+
+Each builds its own library or output directory in a temp directory, and none
+needs the network. The audio fixtures are `tests/e2e/fixtures/audio/`.
+
+## Findings
+
+### The Plugin Surface
+
+A plugin subclasses `BeetsPlugin` and extends beets through seven mechanisms,
+all in `beets/plugins.py`:
+
+| Mechanism | Entry point | Purpose |
+| --- | --- | --- |
+| Subcommands | `commands()` (line 270) | Add `beet <verb>` |
+| Event listeners | `register_listener()` (line 355) | React to a named event |
+| Import stages | `early_import_stages`, `import_stages` (lines 286, 296) | Run inside the import pipeline |
+| Media fields | `add_media_field()` (line 339) | Bind a field to real tag frames |
+| Flexible types | `item_types`, `album_types` attributes (line 516) | Typed database-only fields |
+| Queries | `queries()` (line 335), `item_queries` | New query prefixes |
+| Template fields | `template_field()` (line 379) | New `$name` in path formats |
+
+Events are declared as a `Literal` of 29 names (line 70). `send()` returns the
+non-None values handlers produced (line 636), but only one caller consumes them:
+`handle_created` treats the return of `import_task_created` as replacement tasks
+(`importer/tasks.py:345-357`). Every other event is notification only. A
+listener cannot veto, defer, or alter what beets is about to do.
+
+Import stages are the mechanism that can. They receive the session and the task
+and run inside the pipeline rather than beside it.
+
+### The Import Pipeline Inserts Items Before It Moves Files
+
+The pipeline is assembled in `importer/session.py:195-228`. Plugin stages are
+appended after the tagging stages and before `manipulate_files`. Because
+`_apply_choice` calls `task.add(session.lib)` (`importer/stages.py:323`) during
+the tagging stage, items reach beets' database well before their files are
+relocated.
+
+The observed order for an album import with `convert.auto_keep` enabled
+(`evidence/event-order.txt`):
+
+| Phase | Events |
+| --- | --- |
+| Startup | `pluginload`, `library_opened`, `import_begin` |
+| Task construction | `import_task_created` |
+| Item insertion | `database_change` per album and item |
+| Plugin stages | convert runs here: `write`, `after_write`, `after_convert` |
+| File relocation | `item_copied` per item, then `database_change` |
+| Finalisation | `import_task_files`, `album_imported`, `import`, `cli_exit` |
+
+Two consequences follow. An import stage observes items already in the database
+at their pre-move paths, so a stage that reads `item.path` reads a path that is
+about to become wrong. And `after_convert` fires **before** `item_copied`, so a
+listener pairing the convert output with `item.path` pairs it with the source
+location rather than the library destination.
+
+### The Autotagger Gates Three Events, None of Them Load-Bearing
+
+Under `autotag: no`, beets substitutes `import_asis` for the candidate lookup and
+user query stages (`importer/stages.py:219-231`). Three events therefore never
+fire: `import_task_start` and `import_task_choice`, which those stages send, and
+`import_task_apply`, which `_apply_choice` sends only when `task.apply` is true.
+That property is `choice_flag == Action.APPLY` (`importer/tasks.py:218`), and an
+as-is import sets `Action.ASIS`. The probe confirms all three absent.
+
+All three report on the tagging decision, which a rekordbox integration does not
+need. Everything it does need survives, for both task types:
+
+| Signal | Album, `-A` | Singleton, `-A` |
+| --- | --- | --- |
+| `item_copied`, with source and destination | fires | fires |
+| Completion | `album_imported` | `item_imported` |
+| `import_task_files`, `cli_exit` | fire | fire |
+
+An as-is import is therefore fully observable. This matters because it is the
+mode a derived or downstream library runs in, and the mode in which nothing
+should be re-queried from a metadata source.
+
+Tag writing is suppressed by the same flag. `manipulate_files` calls
+`item.try_write()` only when `write and (self.apply or self.choice_flag ==
+Action.RETAG)` (`importer/tasks.py:482`), so an as-is import leaves file tags
+untouched even with `write: yes`. That is coherent rather than limiting: beets
+has produced no new tag data, so there is nothing to write. It also costs a
+rekordbox integration nothing, because `import_tracks` reads tags from the file
+rather than from beets.
+
+The gap that does exist is on the other side. `edit` never reads tags;
+`FolderPathField` probes only audio properties (codec, duration, sample rate,
+size). Populating other rekordbox columns from beets metadata has no path
+through the current handler set.
+
+### item_imported Fires for Singletons Only
+
+`album_imported` is sent from the album task's `_emit_imported`
+(`importer/tasks.py:343`); `item_imported` is sent from the singleton task's
+(line 684). An album import emits no per-item completion event. A plugin needing
+per-item notification on both paths must register for both and iterate
+`album.items()` in the album case.
+
+### Relocation Events Carry Source and Destination
+
+`item_moved`, `item_copied`, `item_linked`, `item_hardlinked`, and
+`item_reflinked` are sent from `Item.move()` with `item`, `source`, and
+`destination` (`library/models.py:1033-1065`). These are the only events pairing
+both paths, which makes them the natural repoint trigger: locate the rekordbox
+row whose path equals `source`, rewrite it to `destination`.
+
+Three cautions apply. The event fires per operation, so the mode determines which
+name to listen for and a plugin should register all five. With `copy: no` and
+`move: no`, none fires. And on a reimport of in-library files, `source` and
+`destination` are equal (`evidence/event-order.txt`, events 25 to 30), so a
+handler must compare them before writing anything.
+
+### Beets Item Identifiers Do Not Survive a Reimport
+
+A reimport removes the existing items and inserts new ones. `add` calls
+`record_replaced` then `remove_replaced`, which calls `dup_item.remove()` per
+replaced item (`importer/tasks.py:612-624`), emitting `item_removed` and
+`album_removed`. Measured across three files whose paths did not change
+(`evidence/id-stability.txt`):
+
+| File | ID before | ID after |
+| --- | --- | --- |
+| Wave Alpha.flac | 1 | 4 |
+| Wave Beta.flac | 2 | 5 |
+| High Quality.mp3 | 3 | 6 |
+
+Every identifier changed while every path was preserved. **No mapping between
+the two databases may be keyed on the beets item identifier.** The durable keys
+are the file path, which is what rekordbox itself matches on, and a value stamped
+into the file.
+
+Reimports preserve flexible attributes, with an exception list. `reimport_metadata`
+copies the replaced item's `_values_flex` onto the new item, minus the fields in
+`REIMPORT_FRESH_FIELDS_ITEM` (`importer/tasks.py:54-62`). A database-only
+identifier therefore survives a reimport, provided the plugin does not add its
+field to that list.
+
+### A Plugin-Declared Media Field Round-Trips in the File
+
+`add_media_field` registers a `MediaField` on `mediafile.MediaFile` and adds the
+name to `Item._media_fields`, so `item.read()` and `item.write()` carry it like
+any native tag. Declaring four storage styles covers the containers rekordbox
+accepts. Stamped through `beet modify` and read back with mediafile alone, with
+no beets database involved (`evidence/media-field-roundtrip.txt`):
+
+| Container | Carrier | Result |
+| --- | --- | --- |
+| FLAC | Vorbis comment | round-trips |
+| AIFF | ID3 chunk | round-trips |
+| WAV | ID3 chunk | round-trips |
+| MP3 (CBR and VBR) | TXXX | round-trips |
+
+This is the mechanism for a durable join that survives operations beets does not
+observe, at the cost of writing tags.
+
+### rbe convert Repoints the Row, and the Original File May Outlive It
+
+`_apply_converted_record` (`api/_convert.py:182`) writes the output's file name,
+folder, and audio columns onto the **existing** `DjmdContent` row. Nothing in
+`convert()` inserts a row. The rekordbox identifier is therefore stable across a
+conversion, and rekordbox never holds the source and the output at the same time.
+
+Whether the source file survives is a separate decision. `_deletes_original`
+(`api/_convert.py:471`) consults `--delete-originals`, whose default is `none`:
+the original is kept unless the user asks otherwise. `all` always removes it, and
+`lossless` removes it only when the conversion lost no audio information —
+`_classify_fidelity` counts an unknown bit depth and any down-sample as lossy, and
+MP3 output is never lossless, so under `lossless` a hi-res source is kept and a
+44.1 kHz 16-bit source is not.
+
+| `--delete-originals` | Source file | `DjmdContent` rows | Beets items, if nothing is done |
+| --- | --- | --- | --- |
+| `none` (default) | kept | 1, at the output | 1, at the source; output unknown |
+| `all` | deleted | 1, at the output | 1, at a path that no longer exists |
+| `lossless`, lossless conversion | deleted | 1, at the output | 1, dangling |
+| `lossless`, lossy conversion | kept | 1, at the output | 1, at the source; output unknown |
+
+Rekordbox forgets the original in every row of that table. Beets can keep it. The
+two libraries therefore agree only when the original is deleted; when it is kept,
+a beets library that records both files holds two items where rekordbox holds one,
+and only one of the two corresponds to a rekordbox row. Under the default that is
+not the edge case but the ordinary outcome, so what the plugin does about it is a
+policy question it has to answer up front rather than a corner to handle later. It
+is answered in [What Happens to the Original When the Plugin
+Converts](decisions/converted-original-disposition.md): the plugin keeps the
+`none` default and records the output as the item rekordbox knows about, leaving
+the original as a beets item with no `DjmdContent` row.
+
+### The Converted File Already Sits Where Beets Wants It
+
+`_get_output_path` (`api/_convert.py:389`) writes the output into the source's
+directory, keeping the stem and swapping the extension. `Item.destination` builds
+every path segment from the path template but takes the extension from
+`self.filepath.suffix` (`library/models.py:1227`), so an item pointing at the
+output resolves to the templated path carrying the new extension.
+
+Under a template that does not mention anything the conversion changes, those are
+the same path (`evidence/convert-repoint.txt`):
+
+| Import, template | `rbe convert` output | `item.destination()` | Same |
+| --- | --- | --- | --- |
+| singletons, `$artist/$title` | `Alpha/Wave Alpha.aiff` | `Alpha/Wave Alpha.aiff` | yes |
+| album, `$artist/$title` | `Compilations/Lossless Vol 1/00 Wave Alpha.aiff` | the same | yes |
+| either, `$artist/$format/$title` | as above | `Alpha/FLAC/Wave Alpha.aiff` | no |
+
+In the common case the plugin has no file to move: recording the new path in both
+databases is the whole job. A library whose template keys on `$format`,
+`$bitrate`, or `$samplerate` is the exception, and it fails in two ways at once.
+The destination genuinely differs, so the file has to be moved after the fact —
+which changes the path a second time, after `rbe convert` has already committed
+the rekordbox row, leaving that row pointing at a file that is gone until the move
+is pushed back.
+
+And the `FLAC` segment above is the pre-conversion value: `destination()` reads
+`format` from the beets item, not from the file that item now names. A plugin
+must re-read the item before its destination means anything.
+
+### Repointing an Item Refreshes the Audio Fields and Discards Database-Only Ones
+
+Beets' own way of pointing an item at a transcode is
+`item.path = converted; item.read(); item.store()`, which is what the convert
+plugin does under `--keep-new` (`beetsplug/convert.py:457-459`). Measured against
+a FLAC repointed at its AIFF conversion (`evidence/convert-repoint.txt`):
+
+| | Before | After |
+| --- | --- | --- |
+| `id` | 1 | 1 |
+| `format` | FLAC | AIFF |
+| `bitrate` | 96592 | 705600 |
+| `samplerate` | 44100 | 44100 |
+| a flexible attribute | set | preserved |
+| `comments`, set in the database only | `'db-only edit...'` | `''` |
+
+The identifier survives, so a repoint is not a reimport and nothing keyed on the
+item id breaks. Flexible attributes survive, because `read()` assigns only media
+fields. Fixed fields do not: `read()` overwrites every media field from the
+output's tags. Under `write: yes` beets has already written its metadata to the
+source and ffmpeg's `map_metadata 0` carries those tags into the output, so in
+the ordinary case the file agrees with the database and nothing is lost. A value
+that reached the database without reaching the file is lost.
+
+### A Registered Transcode Has No Album
+
+Where the original is kept, the output has to be registered rather than
+substituted. `Item.from_path` followed by `Library.add` does that: the probe's
+output lands as id 3 with the correct format and bitrate, while the original
+keeps id 2 and stays in the library (`evidence/convert-repoint.txt`).
+
+Its `album_id` is `None`, including in the album import where the original's is
+`1`. Beets attaches items to albums in the import pipeline, not in `add`, so a
+plugin registering a transcode outside the pipeline must set `album_id` itself or
+the new item will not appear under `beet ls -a`, will not inherit album art, and
+will not see album-level flexible attributes.
+
+### Going Through the Beets Convert Plugin Is the Other Direction
+
+The remaining option for workflow 1 is to let beets do the transcoding and have
+the plugin follow it. That inverts which tool owns the conversion, and it is worth
+recording why it is the weaker of the two.
+
+The convert plugin sends `after_convert` with `item`, `dest`, and `keepnew`
+(`beetsplug/convert.py:477-483`). That name is absent from the `EventType`
+literal, so it is a plugin-to-plugin convention rather than part of beets' typed
+event surface, and it carries no compatibility guarantee.
+
+Convert's three modes differ in what they leave behind:
+
+| Mode | Output location | Library entry |
+| --- | --- | --- |
+| `beet convert -d DEST` | under `DEST` | unchanged, still the source |
+| `convert.auto` | temp file, then the library path | repointed at the transcode |
+| `convert.auto_keep` | `convert.dest` | unchanged, still the source |
+| `beet convert --keep-new` | original moved to `-d`, transcode at the item path | repointed at the transcode |
+
+Only the modes that repoint an existing entry put the output in the database, and
+they do so by replacing the source entry rather than adding an item. No mode
+registers the transcode as a new item. Nothing in beets records that the source
+and the output are related.
+
+Following that from a plugin means depending on `after_convert`, an event outside
+`EventType`, and working around its firing before the item has moved. It also
+gives the plugin less than driving `rbe convert` does: in the modes that repoint,
+the source entry is replaced rather than kept, so the plugin sees the same
+kept-original problem with no control over the policy, and in the modes that do
+not repoint, the output is simply absent from the beets database. Neither is a
+better starting point than owning the conversion.
+
+### The Encoder Is Already Separable From Rekordbox
+
+`rbe convert` is built around a plain dataclass rather than around a database
+row. `_EncodeJob` carries a source path, file name, declared file type, output
+path, temp path, and output format, and `_encode_one` is documented as
+"touching no database state" (`api/_convert.py:275`). The thread pool, the
+encode-to-temp-then-move, the ffmpeg argument construction, and the output probe
+are all row-independent already.
+
+Three seams hold the rekordbox coupling:
+
+| Seam | Location | What a file-oriented caller supplies instead |
+| --- | --- | --- |
+| Job construction | `_encode_job_for` (line 260) | The five values directly |
+| Output location | `_get_output_path` (line 389) | Its own destination, rather than the source's directory |
+| Candidate selection | `_classify_convert` (line 404) | Its own list of files |
+
+Driving it that way works today. Built by hand from a path on disk, with no
+session and no row in existence, `_encode_one` encodes each fixture to the
+conversion target and reports fidelity correctly (`evidence/file-level-encode.txt`):
+
+| Source | Declared type | Result |
+| --- | --- | --- |
+| `01-flac-44_1k-16b.flac` | FLAC | `pcm_s16be` 44100 Hz 16-bit, lossless |
+| `02-flac-96k-24b.flac` | FLAC | `pcm_s16be` 44100 Hz 16-bit, lossy (down-sampled) |
+| `06-wav-96k-24b.wav` | WAV | `pcm_s16be` 44100 Hz 16-bit, lossy (down-sampled) |
+
+One decision is semantic rather than mechanical. `_encode_one` calls
+`probe_matches_file_type`, which returns `False` for a `None` file type by
+design, so that "callers treat them as mismatches instead of converting blind"
+(`utils.py:185`). That cross-check exists to catch a rekordbox row disagreeing
+with the file it names. A caller converting a file it already holds has no second
+declaration to check against, so the check is inapplicable rather than failing.
+Run with `file_type=None`, every one of the three files above is skipped with
+`codec_mismatch` and nothing is encoded, so the check cannot simply be left to
+default. Supplying a declared type is the cheaper fix than skipping the check: the
+rekordbox `FileType` code follows from the extension through
+`get_file_type_for_format`, which is what the probe passes and what a beets caller
+holding an `Item` can pass too.
+
+A file-level entry point over `_EncodeJob`, with the present rekordbox-aware
+`convert()` layered on it, would let a plugin transcode without a `DjmdContent`
+row existing first, and would remove any dependency on the convert plugin.
+
+### The rekordbox-edit API Carries Its Own Safety
+
+`rekordbox_edit.api` exports `search`, `edit`, `convert`, `import_tracks`, and
+`remove`. Each takes an open `Rekordbox6Database` and a request model, and each
+is dry-runnable. For the three workflows, `edit` with `field="FolderPath"` repoints
+a row and resynchronises the columns describing the file, and `import_tracks`
+creates rows for files rekordbox does not know about, matching by resolved,
+case-folded path so that repeated runs are idempotent.
+
+Both guards a plugin would otherwise have to reproduce now live in the API.
+`writing()` (`api/_utils.py:23`) raises `RekordboxRunningError` when rekordbox is
+open, then holds the single-writer advisory lock for the duration of the write.
+Every API write enters through it — `convert()`, `edit()`, and `import_tracks()`
+each open `with writing(db, ...)` — and the CLI's own lock nests inside harmlessly.
+A plugin driving the API directly therefore inherits both and must not reimplement
+either.
+
+The guard wraps only the writing region, so a dry run reaches neither check. That
+is the property a plugin wants: it can plan against a library rekordbox has open,
+and will be refused only when it tries to commit.
+
+The refusal is an exception, not an exit, which shapes where a plugin puts its
+write. `RekordboxRunningError` raised out of a `cli_exit` listener surfaces at the
+end of an import that has already finished and cannot be replayed. That is an
+argument for the subcommand below rather than against the guard.
+
+### Rekordbox Writes Must Be Batched and Single-Threaded
+
+Beets imports with `threaded: yes` by default, so relocation events arrive on
+worker threads. Rekordbox-edit keeps every database touch on the main thread
+inside `convert`, because `RekordboxAgentRegistry`'s change buffer is a class
+attribute shared by every instance in the process
+(`research/import-track-row-shape/decisions/commit-semantics-and-usn.md`).
+
+A plugin must therefore not write rekordbox from an event handler. It should
+accumulate the pairs it observes and flush once, from a single thread, at
+`cli_exit`. Batching is also what makes the write inspectable: one transaction
+that can be dry-run and re-run, rather than thousands that cannot.
+
+## Conclusion
+
+Beets permits the integration, and the architecture points at one shape for it.
+
+**Collect during the import, write once at the end.** Relocation events are the
+only source of paired source and destination paths, and they are notification
+only, so a handler cannot usefully do more than record what it saw. A single
+flush at `cli_exit` satisfies the threading constraint and produces one auditable
+rekordbox transaction. The API supplies the guards, so the flush needs only to
+handle being refused.
+
+**Join on the path, never on an identifier beets controls.** Item identifiers
+change on reimport while paths do not. For operations beets does not observe, a
+media field carries a rekordbox identifier through any container rekordbox
+accepts, at the cost of writing tags.
+
+**Offer a subcommand alongside the listeners.** The import-time hook cannot see
+anything done outside beets, and an import that has already completed cannot be
+replayed if rekordbox was open at the time. A `beet rbe sync` style subcommand
+that reconciles the library against rekordbox on demand covers both with the same
+code, is re-runnable, and does not couple a cross-application write to an import
+that has no rollback relationship with it.
+
+Against the three framing workflows:
+
+**Workflow 1, convert and follow**, is mechanically the easiest of the three and
+semantically the hardest. `rbe convert` already writes its output where beets
+wants the file, so under an ordinary path template no file moves and the plugin's
+only filesystem concern is the one case where the template keys on something the
+conversion changes. Both of the library-side operations are one-liners with
+precedent: repointing is `item.path = out; item.read(); item.store()`, which keeps
+the item id, and registering is `Item.from_path` plus `Library.add`
+(`library/models.py:806`, `library/library.py:43`), which needs `album_id` set by
+hand. Neither needs a second import pass and neither needs the convert plugin.
+
+What is not mechanical is which of the two to perform, because `rbe convert`
+repoints the rekordbox row unconditionally while keeping or deleting the source
+file according to `--delete-originals`. Its default is `none`, so by default the
+original survives — rekordbox has forgotten a file that still exists and that
+beets still has an entry for, and no beets-side action reproduces the rekordbox
+state: registering the output gives beets two items to rekordbox's one, and
+repointing loses the surviving original from both. The deleting modes are the
+opt-in case, and only there can the two libraries agree exactly.
+
+**The plugin should not try to mirror rekordbox here**, and it should not buy
+agreement by deleting more than `rbe convert` would. It keeps the `none` default
+and records the output as the item rekordbox knows about — registering a new item
+when the source survives, repointing the existing one when a deleting mode removed
+it — treating a kept original as a beets item with no `DjmdContent` row, which is
+what it now is (`decisions/converted-original-disposition.md`). A beets library
+legitimately larger than the rekordbox one is therefore the normal state, and one
+any reconciliation has to tolerate rather than repair.
+
+The remaining seam is that a beets-driven conversion cannot pass `None` as the
+source file type without every file being skipped, so a file-level entry point
+over `_EncodeJob` must take a declared type from the caller.
+
+**Workflow 2, repoint after a move**, is the best-supported case and needs no
+custom field: `item_copied` and `item_moved` deliver both paths, and
+`edit(field="FolderPath")` already resynchronises the technical columns. Its
+second half is not supported. Pushing beets metadata into other rekordbox columns
+needs either new field handlers or a way to pass explicit per-track values, since
+`edit` reads tags from nothing and derives only audio properties from the file.
+
+**Workflow 3, reimport and update**, is the case most likely to be got wrong,
+because the reimport silently replaces items. A plugin holding beets identifiers
+will appear to work and then quietly address the wrong tracks. Path-keyed
+reconciliation is correct here for the same reason it is correct everywhere else.
+
+## Open Questions
+
+- Which rekordbox columns are worth exposing as editable beyond the current
+  handler set, and which beets fields map onto them without loss.
+- Whether a plugin should write tags at all. The media field is the only join
+  that survives operations beets cannot see, but it modifies files that rekordbox
+  may have analysed.
+- What `edit` costs at library scale. It classifies every candidate, applies
+  every change, and commits once, so a large reconciliation is atomic but
+  unbounded in memory, and `post_commit` rewrites ANLZ files serially for every
+  track whose filename changed.
+- Whether the file-level encode entry point should skip the source probe's codec
+  cross-check or require a declared type from the caller. Requiring one is cheap
+  for a beets caller, which can derive it from the extension, and it keeps the
+  guard that catches a file disagreeing with what names it.
+- Whether an original that `--delete-originals: lossless` kept should carry a
+  marker on its beets item, so a reconciliation can tell a deliberate leftover
+  from a track that has genuinely never reached rekordbox. Raised in
+  `decisions/converted-original-disposition.md`.
+- Whether `rbe convert` should gain an output-directory option. It currently
+  writes beside the source, which is what makes the beets destination match; a
+  destination argument would break that coincidence and put the move back.
+- How to sequence the second path change when the beets path template keys on
+  `$format` or `$bitrate`, given that `rbe convert` commits the rekordbox row
+  before beets has had a chance to move the file.
+- How the plugin should behave when rekordbox is running, since the import that
+  triggered it cannot be replayed.

--- a/research/beets-plugin-integration/decisions/converted-original-disposition.md
+++ b/research/beets-plugin-integration/decisions/converted-original-disposition.md
@@ -1,0 +1,77 @@
+# What Happens to the Original When the Plugin Converts
+
+**Status:** settled 2026-09-07 by the maintainer, before any plugin code exists.
+Closes the open question raised in `../beets-plugin-integration.md`.
+
+## Context
+
+`rbe convert` transcodes a file beside its source and repoints the existing
+`DjmdContent` row at the output. The row is repointed unconditionally; whether
+the source file is deleted is a separate decision, taken by
+`--delete-originals`, whose default is `none`: the original is kept unless the
+user asks for it to go.
+
+That default is what leaves the two libraries unable to agree, and under `none`
+it does so on every conversion rather than occasionally. Rekordbox forgets the
+original in every mode, so when the file survives, a beets library that records
+both files holds two beets items where rekordbox holds one `DjmdContent` row, and
+only one of the two items corresponds to a row. See
+[rbe convert Repoints the Row, and the Original File May Outlive
+It](../beets-plugin-integration.md#rbe-convert-repoints-the-row-and-the-original-file-may-outlive-it).
+
+Deleting originals (`all`) was considered as the plugin default, on the grounds
+that converting during a beets import means replacing the track's source rather
+than adding a rendition of it, and that only deletion produces a state both
+libraries can represent. It was rejected. `all` deletes the original whether or
+not the conversion lost anything, so a 96 kHz 24-bit source going to the 44.1 kHz
+16-bit target, or to MP3, would have its only high-resolution copy destroyed
+during a bulk import, with the loss discovered late. Diverging from the wrapped
+command in the destructive direction is also the wrong way for a default to
+surprise someone.
+
+## Decision
+
+**The plugin inherits `--delete-originals: none`.** It does not diverge from the
+command it wraps. `all` and `lossless` are exposed as plugin configuration for
+users who want them.
+
+**The plugin records the output as the beets item that rekordbox knows about, and
+leaves any surviving original as a beets item of its own.** Concretely:
+
+| Original | Beets action | Result |
+| --- | --- | --- |
+| kept (`none`, the default) | register the output as a new item, leave the existing one alone | 2 items, 1 row; the new item is the one with a row |
+| deleted (`all`, or `lossless` on a lossless conversion) | repoint the existing item at the output | 1 item, 1 `DjmdContent` row, agreeing |
+
+Repointing when the original survives is the option not taken. It would leave the
+source file on disk and named by neither database — managed by nothing, which is
+worse than a duplicate row.
+
+## Consequences
+
+**Registering is the default path; repointing serves the opt-in modes.** Under
+`none` every conversion keeps its original, so the plugin registers and never
+repoints unless the user has chosen `all` or `lossless`. Under `lossless` it does
+both in the same run, since fidelity is decided per file. Both paths have to
+exist; only one is on the default route.
+
+**The repoint keeps the beets item id**, because `item.path = out; item.read();
+item.store()` is an update rather than a reimport. Anything the user has keyed on
+that id survives a conversion.
+
+**The register needs `album_id` set by hand.** `Library.add` does not attach the
+new item to an album; beets does that in the import pipeline, which the plugin is
+not running. Left unset, the transcode will not appear under `beet ls -a` and will
+not inherit album art or album-level flexible attributes.
+
+**A beets library grows past the rekordbox one by default, by design.** Every
+kept original is an item with no `DjmdContent` row, and under `none` that is every
+conversion. It is the honest record of what is on disk, but it makes "beets item
+without a rekordbox row" the normal state rather than an anomaly, and a
+reconciliation must not treat it as an error to repair.
+
+## Open
+
+- Whether a kept original's beets item should carry a marker distinguishing it
+  from an item that has simply never been sent to rekordbox, so a reconciliation
+  can tell a deliberate leftover from a genuine gap.

--- a/research/beets-plugin-integration/evidence/convert-repoint.txt
+++ b/research/beets-plugin-integration/evidence/convert-repoint.txt
@@ -1,0 +1,59 @@
+$ scripts/convert_repoint.py tests/e2e/fixtures/audio/{01-flac-44_1k-16b.flac,02-flac-96k-24b.flac}
+
+── imported as singletons ────────────────────────────────────────
+
+Wave Alpha.flac
+  before                 id=1   format=FLAC   bitrate=96592   samplerate=44100 length=2.00
+    rbe output path      Alpha/Wave Alpha.aiff
+    beets destination    Alpha/Wave Alpha.aiff
+    match (default)      True
+    beets destination    Alpha/FLAC/Wave Alpha.aiff  (paths keyed on $format)
+    match ($format)      False
+  after repoint          id=1   format=AIFF   bitrate=705600  samplerate=44100 length=2.00
+    path                 Alpha/Wave Alpha.aiff
+    flexattr preserved   True
+    db-only comments     ''
+
+Wave Beta.flac
+  before                 id=2   format=FLAC   bitrate=818588  samplerate=96000 length=2.00
+    rbe output path      Beta/Wave Beta.aiff
+    beets destination    Beta/Wave Beta.aiff
+    match (default)      True
+    beets destination    Beta/FLAC/Wave Beta.aiff  (paths keyed on $format)
+    match ($format)      False
+  added item             id=3   format=AIFF   bitrate=705600  samplerate=44100 length=2.00
+    path                 Beta/Wave Beta.aiff
+    album_id             None (original's is None)
+    original still there True, id=2
+
+items in library: 3
+
+$ scripts/convert_repoint.py --albums tests/e2e/fixtures/audio/{01-flac-44_1k-16b.flac,02-flac-96k-24b.flac}
+
+── imported as an album ────────────────────────────────────────
+
+00 Wave Alpha.flac
+  before                 id=1   format=FLAC   bitrate=96592   samplerate=44100 length=2.00
+    rbe output path      Compilations/Lossless Vol 1/00 Wave Alpha.aiff
+    beets destination    Compilations/Lossless Vol 1/00 Wave Alpha.aiff
+    match (default)      True
+    beets destination    Alpha/FLAC/Wave Alpha.aiff  (paths keyed on $format)
+    match ($format)      False
+  after repoint          id=1   format=AIFF   bitrate=705600  samplerate=44100 length=2.00
+    path                 Compilations/Lossless Vol 1/00 Wave Alpha.aiff
+    flexattr preserved   True
+    db-only comments     ''
+
+00 Wave Beta.flac
+  before                 id=2   format=FLAC   bitrate=818588  samplerate=96000 length=2.00
+    rbe output path      Compilations/Lossless Vol 1/00 Wave Beta.aiff
+    beets destination    Compilations/Lossless Vol 1/00 Wave Beta.aiff
+    match (default)      True
+    beets destination    Beta/FLAC/Wave Beta.aiff  (paths keyed on $format)
+    match ($format)      False
+  added item             id=3   format=AIFF   bitrate=705600  samplerate=44100 length=2.00
+    path                 Compilations/Lossless Vol 1/00 Wave Beta.aiff
+    album_id             None (original's is 1)
+    original still there True, id=2
+
+items in library: 3

--- a/research/beets-plugin-integration/evidence/event-order.txt
+++ b/research/beets-plugin-integration/evidence/event-order.txt
@@ -1,0 +1,69 @@
+
+=== import -A (exit 0) ===
+    1. pluginload           
+    2. library_opened       lib=Library
+    3. import_begin         session=TerminalImportSession
+    4. import_task_created  session=TerminalImportSession task=ImportTask(n=2)
+    5. database_change      lib=Library model=Album(id=1)
+    6. database_change      lib=Library model=Item(id=1)
+    7. database_change      lib=Library model=Item(id=2)
+    8. write                item=Item(id=1) path=00 Wave Alpha.mp3 tags=dict
+    9. write                item=Item(id=2) path=00 Wave Beta.mp3 tags=dict
+   10. after_write          item=Item(id=1) path=00 Wave Alpha.mp3
+   11. after_convert        dest=00 Wave Alpha.mp3 item=Item(id=1) keepnew=bool
+   12. after_write          item=Item(id=2) path=00 Wave Beta.mp3
+   13. after_convert        dest=00 Wave Beta.mp3 item=Item(id=2) keepnew=bool
+   14. item_copied          destination=00 Wave Alpha.flac item=Item(id=1) source=01-flac-44_1k-16b.flac
+   15. database_change      lib=Library model=Item(id=1)
+   16. database_change      lib=Library model=Album(id=1)
+   17. item_copied          destination=00 Wave Beta.flac item=Item(id=2) source=02-flac-96k-24b.flac
+   18. database_change      lib=Library model=Item(id=2)
+   19. database_change      lib=Library model=Album(id=1)
+   20. database_change      lib=Library model=Item(id=1)
+   21. database_change      lib=Library model=Item(id=2)
+   22. import_task_files    session=TerminalImportSession task=ImportTask(n=2)
+   23. album_imported       album=Album(id=1) lib=Library
+   24. import               lib=Library paths=list
+   25. cli_exit             lib=Library
+  -- 25 events, 13 distinct
+
+=== reimport (beet import -L) (exit 0) ===
+    1. pluginload           
+    2. library_opened       lib=Library
+    3. import_begin         session=TerminalImportSession
+    4. import_task_created  session=TerminalImportSession task=ImportTask(n=2)
+    5. database_change      lib=Library model=Item(id=1)
+    6. item_removed         item=Item(id=1)
+    7. database_change      lib=Library model=Item(id=2)
+    8. database_change      lib=Library model=Album(id=1)
+    9. album_removed        album=Album(id=1)
+   10. item_removed         item=Item(id=2)
+   11. database_change      lib=Library model=Album(id=1)
+   12. database_change      lib=Library model=Item(id=1)
+   13. database_change      lib=Library model=Item(id=2)
+   14. database_change      lib=Library model=Album(id=1)
+   15. database_change      lib=Library model=Item(id=1)
+   16. database_change      lib=Library model=Item(id=2)
+   17. database_change      lib=Library model=Item(id=1)
+   18. database_change      lib=Library model=Item(id=2)
+   19. write                item=Item(id=1) path=00 Wave Alpha.mp3 tags=dict
+   20. write                item=Item(id=2) path=00 Wave Beta.mp3 tags=dict
+   21. after_write          item=Item(id=1) path=00 Wave Alpha.mp3
+   22. after_convert        dest=00 Wave Alpha.mp3 item=Item(id=1) keepnew=bool
+   23. after_write          item=Item(id=2) path=00 Wave Beta.mp3
+   24. after_convert        dest=00 Wave Beta.mp3 item=Item(id=2) keepnew=bool
+   25. before_item_moved    destination=00 Wave Alpha.flac item=Item(id=1) source=00 Wave Alpha.flac
+   26. item_moved           destination=00 Wave Alpha.flac item=Item(id=1) source=00 Wave Alpha.flac
+   27. database_change      lib=Library model=Item(id=1)
+   28. database_change      lib=Library model=Album(id=1)
+   29. before_item_moved    destination=00 Wave Beta.flac item=Item(id=2) source=00 Wave Beta.flac
+   30. item_moved           destination=00 Wave Beta.flac item=Item(id=2) source=00 Wave Beta.flac
+   31. database_change      lib=Library model=Item(id=2)
+   32. database_change      lib=Library model=Album(id=1)
+   33. database_change      lib=Library model=Item(id=1)
+   34. database_change      lib=Library model=Item(id=2)
+   35. import_task_files    session=TerminalImportSession task=ImportTask(n=2)
+   36. album_imported       album=Album(id=1) lib=Library
+   37. import               lib=Library paths=list
+   38. cli_exit             lib=Library
+  -- 38 events, 16 distinct

--- a/research/beets-plugin-integration/evidence/file-level-encode.txt
+++ b/research/beets-plugin-integration/evidence/file-level-encode.txt
@@ -1,0 +1,11 @@
+$ uv run scripts/file_level_encode.py tests/e2e/fixtures/audio/{01-flac-44_1k-16b.flac,02-flac-96k-24b.flac,06-wav-96k-24b.wav}
+
+01-flac-44_1k-16b.flac (codec=flac 44100Hz 16bit)
+  declared type    encoded: 01-flac-44_1k-16b.aiff codec=pcm_s16be 44100Hz 16bit lossless=True bytes=176590
+  file_type=None   skipped: codec_mismatch
+02-flac-96k-24b.flac (codec=flac 96000Hz 24bit)
+  declared type    encoded: 02-flac-96k-24b.aiff codec=pcm_s16be 44100Hz 16bit lossless=False bytes=176588
+  file_type=None   skipped: codec_mismatch
+06-wav-96k-24b.wav (codec=pcm_s24le 96000Hz 24bit)
+  declared type    encoded: 06-wav-96k-24b.aiff codec=pcm_s16be 44100Hz 16bit lossless=False bytes=176594
+  file_type=None   skipped: codec_mismatch

--- a/research/beets-plugin-integration/evidence/id-stability.txt
+++ b/research/beets-plugin-integration/evidence/id-stability.txt
@@ -1,0 +1,7 @@
+path (basename)                           id before  id after  same?
+Wave Alpha.flac                                   1         4 NO
+Wave Beta.flac                                    2         5 NO
+High Quality.mp3                                  3         6 NO
+
+paths preserved: True
+ids changed:     3 of 3

--- a/research/beets-plugin-integration/evidence/media-field-roundtrip.txt
+++ b/research/beets-plugin-integration/evidence/media-field-roundtrip.txt
@@ -1,0 +1,9 @@
+file                                written  in file  ok?
+_aiff.aiff                           RB0001   RB0001  yes
+_wav.wav                             RB0002   RB0002  yes
+Wave Alpha.flac                      RB0003   RB0003  yes
+High Quality.mp3                     RB0004   RB0004  yes
+Variable Rate.mp3                    RB0005   RB0005  yes
+
+read with: /Users/jamesviall/.local/pipx/venvs/beets/bin/python
+all formats round-tripped: True

--- a/research/beets-plugin-integration/scripts/convert_repoint.py
+++ b/research/beets-plugin-integration/scripts/convert_repoint.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""What does a beets library need in order to follow an `rbe convert`?
+
+`rbe convert` writes its output beside the source, keeping the stem and
+changing the extension, and repoints the rekordbox row at it. This asks what
+the beets side of that looks like:
+
+- whether the path rbe chose is already where beets wants the file, under a
+  path template that ignores the format and under one that does not;
+- whether repointing an item (`item.path = new; item.read(); item.store()`,
+  the pattern the convert plugin uses for `--keep-new`) keeps the item id,
+  refreshes the audio properties, and preserves flexible attributes;
+- what `Item.from_path` plus `Library.add` produces when the original is kept
+  and the transcode has to be registered as a second item.
+
+Builds its own library in a temp directory. Autotagging is off, so no network.
+
+Usage: convert_repoint.py [--albums] <lossless-source> <hi-res-source>
+
+`--albums` imports as an album rather than as singletons, which is what
+decides whether a newly registered transcode can inherit an album.
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+CONFIG = """\
+directory: {lib}
+library: {db}
+import:
+  copy: yes
+  autotag: no
+  quiet: yes
+  singletons: {singletons}
+paths:
+  default: $artist/$title
+  singleton: $artist/$title
+"""
+
+# The ffmpeg invocation rekordbox-edit uses for AIFF output at the conversion
+# target (`_hi_res_output_kwargs` in rekordbox_edit/api/_convert.py).
+FFMPEG_AIFF = [
+    "-acodec", "pcm_s16be", "-ar", "44100",
+    "-map_metadata", "0", "-write_id3v2", "1",
+]
+
+INNER = r'''
+import os, sys
+import beets.ui
+from beets import config
+from beets.library import Item
+from beets.util import bytestring_path, displayable_path
+
+# Open the library the way the CLI does, so the path templates and library
+# directory come from the same config the import ran under.
+config.read()
+lib = beets.ui._open_library(config)
+# The template a library keyed on format would use, for comparison only.
+FORMAT_KEYED = [("default", "$artist/$format/$title")]
+
+def show(label, item):
+    print(f"  {label:22s} id={item.id:<3d} format={item.format:<6s} "
+          f"bitrate={item.bitrate:<7d} samplerate={item.samplerate} "
+          f"length={item.length:.2f}")
+
+ROOT = os.path.realpath(displayable_path(lib.directory)) + "/"
+
+def rel(path):
+    return os.path.realpath(displayable_path(path)).replace(ROOT, "")
+
+items = sorted(lib.items(), key=lambda i: i.path)
+for n, item in enumerate(items):
+    src = displayable_path(item.path)
+    out = os.path.splitext(src)[0] + ".aiff"
+    print(f"{os.path.basename(src)}")
+    show("before", item)
+    print(f"    rbe output path      {rel(bytestring_path(out))}")
+
+    # Where beets would put the file once the item names the .aiff. The
+    # extension comes from `item.filepath.suffix`, so the item has to be
+    # pointing at the output before its destination means anything.
+    source_path = item.path
+    item.path = bytestring_path(out)
+    default_dest = item.destination()
+    keyed_dest = item.destination(path_formats=FORMAT_KEYED)
+    item.path = source_path
+    print(f"    beets destination    {rel(default_dest)}")
+    print(f"    match (default)      {default_dest == bytestring_path(out)}")
+    print(f"    beets destination    {rel(keyed_dest)}  (paths keyed on $format)")
+    print(f"    match ($format)      {keyed_dest == bytestring_path(out)}")
+
+    if n == 0:
+        # Original deleted: repoint the existing item, as the convert plugin
+        # does for --keep-new.
+        item.rbe_probe_flexattr = "kept?"
+        item.comments = "db-only edit, never written to the file"
+        item.store()
+        item.path = bytestring_path(out)
+        item.read()
+        item.store()
+        reloaded = lib.get_item(item.id)
+        show("after repoint", reloaded)
+        print(f"    path                 {rel(reloaded.path)}")
+        print(f"    flexattr preserved   "
+              f"{reloaded.get('rbe_probe_flexattr') == 'kept?'}")
+        print(f"    db-only comments     {reloaded.comments!r}")
+    else:
+        # Original kept: register the transcode as its own item.
+        added = Item.from_path(bytestring_path(out))
+        lib.add(added)
+        show("added item", added)
+        print(f"    path                 {rel(added.path)}")
+        print(f"    album_id             {added.album_id} "
+              f"(original's is {item.album_id})")
+        print(f"    original still there {lib.get_item(item.id) is not None}, "
+              f"id={item.id}")
+    print()
+
+print(f"items in library: {len(list(lib.items()))}")
+'''
+
+
+def beets_python() -> str:
+    """The interpreter beets runs under, read from the `beet` shebang."""
+    beet = shutil.which("beet")
+    if beet:
+        with open(beet, "rb") as fh:
+            line = fh.readline()
+        if line.startswith(b"#!"):
+            candidate = line[2:].strip().decode()
+            if os.path.exists(candidate):
+                return candidate
+    return sys.executable
+
+
+def convert_beside(path: str) -> str:
+    """Transcode to AIFF beside the source, the way `rbe convert` does."""
+    out = os.path.splitext(path)[0] + ".aiff"
+    subprocess.run(
+        ["ffmpeg", "-nostdin", "-y", "-i", path, *FFMPEG_AIFF, out],
+        capture_output=True, check=True,
+    )
+    return out
+
+
+def main(sources: list[str], singletons: bool) -> None:
+    print(f"── imported as {'singletons' if singletons else 'an album'} "
+          f"{'─' * 40}\n")
+    root = tempfile.mkdtemp(prefix="beets-repoint-")
+    try:
+        lib, inbox, bd = (os.path.join(root, d) for d in ("lib", "inbox", "bd"))
+        for d in (lib, inbox, bd):
+            os.makedirs(d)
+        for src in sources:
+            shutil.copy2(src, inbox)
+        db = os.path.join(root, "library.db")
+        with open(os.path.join(bd, "config.yaml"), "w") as fh:
+            fh.write(CONFIG.format(
+                lib=lib, db=db, singletons="yes" if singletons else "no"))
+        env = {**os.environ, "BEETSDIR": bd}
+
+        subprocess.run(["beet", "import", "-q", inbox], env=env,
+                       capture_output=True, check=True)
+
+        paths = subprocess.run(
+            ["beet", "ls", "-f", "$path"], env=env,
+            capture_output=True, text=True, check=True,
+        ).stdout.split("\n")
+        for path in filter(None, paths):
+            convert_beside(path)
+
+        inner = os.path.join(root, "inner.py")
+        with open(inner, "w") as fh:
+            fh.write(INNER)
+        run = subprocess.run([beets_python(), inner], env=env,
+                             capture_output=True, text=True)
+        print(run.stdout, end="")
+        if run.returncode:
+            print(run.stderr, file=sys.stderr)
+            sys.exit(run.returncode)
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    if not shutil.which("beet"):
+        sys.exit("beet not on PATH")
+    if not shutil.which("ffmpeg"):
+        sys.exit("ffmpeg not on PATH")
+    args = [a for a in sys.argv[1:] if a != "--albums"]
+    main(args, singletons="--albums" not in sys.argv[1:])

--- a/research/beets-plugin-integration/scripts/event_probe.py
+++ b/research/beets-plugin-integration/scripts/event_probe.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Record which beets events fire, in what order, and with which arguments.
+
+Builds a throwaway beets library in a temp directory, installs a plugin that
+listens to every event in `beets.plugins.EventType` plus the convert plugin's
+undeclared `after_convert`, runs an import, and prints the observed sequence.
+
+Autotagging is off so the probe needs no network and no MusicBrainz responses;
+the event surface under `-A` is itself one of the questions.
+
+Usage: event_probe.py <audio-file>... [--convert] [--reimport]
+"""
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import textwrap
+
+PROBE_PLUGIN = '''
+import os
+from beets.plugins import BeetsPlugin, EventType
+from typing import get_args
+
+# `after_convert` is sent by beetsplug/convert.py but is absent from EventType.
+EVENTS = list(get_args(EventType)) + ["after_convert"]
+
+LOG = os.environ["PROBE_LOG"]
+
+
+def _short(v):
+    if isinstance(v, bytes):
+        return os.path.basename(v.decode("utf-8", "replace"))
+    name = type(v).__name__
+    if name in ("Item", "Album"):
+        return f"{name}(id={getattr(v, 'id', None)})"
+    if name in ("ImportTask", "SingletonImportTask"):
+        return f"{name}(n={len(getattr(v, 'items', []) or [])})"
+    if name.endswith("Session") or name == "Library":
+        return name
+    return name
+
+
+class ProbePlugin(BeetsPlugin):
+    def __init__(self):
+        super().__init__()
+        for event in EVENTS:
+            self.register_listener(event, self._make(event))
+
+    def _make(self, event):
+        def handler(**kwargs):
+            args = " ".join(f"{k}={_short(v)}" for k, v in sorted(kwargs.items()))
+            with open(LOG, "a") as fh:
+                fh.write(f"{event}\\t{args}\\n")
+        return handler
+'''
+
+CONFIG = """\
+directory: {lib}
+library: {db}
+pluginpath: {plugdir}
+plugins: probe{extra_plugins}
+import:
+  copy: yes
+  write: yes
+  autotag: no
+  quiet: yes
+ignore_hidden: yes
+threaded: yes
+paths:
+  default: $albumartist/$album/$track $title
+  singleton: Singles/$artist/$title
+{convert_block}
+"""
+
+CONVERT_BLOCK = """\
+convert:
+  auto_keep: yes
+  dest: {dest}
+  format: mp3
+  formats:
+    mp3:
+      command: ffmpeg -v error -i $source -y -vn -acodec libmp3lame -b:a 320k $dest
+      extension: mp3
+"""
+
+
+def run(sources, use_convert, reimport):
+    root = tempfile.mkdtemp(prefix="beets-probe-")
+    try:
+        lib = os.path.join(root, "lib")
+        plugdir = os.path.join(root, "plugins")
+        inbox = os.path.join(root, "inbox")
+        dest = os.path.join(root, "converted")
+        for d in (lib, plugdir, inbox, dest):
+            os.makedirs(d, exist_ok=True)
+
+        with open(os.path.join(plugdir, "probe.py"), "w") as fh:
+            fh.write(PROBE_PLUGIN)
+
+        for src in sources:
+            shutil.copy2(src, inbox)
+
+        cfg = CONFIG.format(
+            lib=lib,
+            db=os.path.join(root, "library.db"),
+            plugdir=plugdir,
+            extra_plugins=" convert" if use_convert else "",
+            convert_block=CONVERT_BLOCK.format(dest=dest) if use_convert else "",
+        )
+        beetsdir = os.path.join(root, "beetsdir")
+        os.makedirs(beetsdir, exist_ok=True)
+        with open(os.path.join(beetsdir, "config.yaml"), "w") as fh:
+            fh.write(cfg)
+
+        log = os.path.join(root, "events.log")
+        env = {**os.environ, "BEETSDIR": beetsdir, "PROBE_LOG": log}
+
+        def _import(label, args):
+            open(log, "w").close()
+            proc = subprocess.run(
+                ["beet", "import", *args], env=env,
+                capture_output=True, text=True,
+            )
+            print(f"\n=== {label} (exit {proc.returncode}) ===")
+            if proc.returncode != 0:
+                print(textwrap.indent(proc.stderr.strip()[:800], "    "))
+            seen = []
+            for line in open(log):
+                event, _, args_ = line.rstrip("\n").partition("\t")
+                seen.append((event, args_))
+            width = max((len(e) for e, _ in seen), default=0)
+            for i, (event, args_) in enumerate(seen, 1):
+                print(f"  {i:3d}. {event:{width}s}  {args_}")
+            print(f"  -- {len(seen)} events, "
+                  f"{len({e for e, _ in seen})} distinct")
+            return seen
+
+        _import("import -A", ["-q", inbox])
+        if reimport:
+            _import("reimport (beet import -L)", ["-q", "-L", "path::."])
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("sources", nargs="+")
+    p.add_argument("--convert", action="store_true")
+    p.add_argument("--reimport", action="store_true")
+    a = p.parse_args()
+    if not shutil.which("beet"):
+        sys.exit("beet not on PATH")
+    run(a.sources, a.convert, a.reimport)

--- a/research/beets-plugin-integration/scripts/file_level_encode.py
+++ b/research/beets-plugin-integration/scripts/file_level_encode.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Can rekordbox-edit encode a file with no `DjmdContent` row in play?
+
+`_encode_one` is documented as touching no database state. This builds
+`_EncodeJob` by hand from a path on disk, the way a beets plugin holding an
+`Item` would have to, and runs the encode. It also runs the job twice per
+file: once declaring the source file type the way a rekordbox row does, and
+once declaring `None` the way a caller with no rekordbox row can only do.
+
+Run in the rekordbox-edit environment: `uv run scripts/file_level_encode.py <file>...`
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+from rekordbox_edit.api._convert import _EncodeJob, _encode_one, _temp_output_path
+from rekordbox_edit.utils import (
+    get_audio_info,
+    get_extension_for_format,
+    get_file_type_for_format,
+)
+
+OUTPUT_FORMAT = "AIFF"
+
+
+def job_for(source: str, out_dir: str, file_type: int | None) -> _EncodeJob:
+    """The values `_encode_job_for` copies off a content row, supplied from the
+    file itself instead. `track` is left unset: it only travels into a skip
+    report, so a caller with no `DjmdContent` row can omit it."""
+    output = os.path.join(
+        out_dir, Path(source).stem + get_extension_for_format(OUTPUT_FORMAT)
+    )
+    return _EncodeJob(
+        source_path=source,
+        file_name=os.path.basename(source),
+        file_type=file_type,
+        output_path=output,
+        temp_path=_temp_output_path(output),
+        output_format=OUTPUT_FORMAT,
+    )
+
+
+def declared_type(source: str) -> int | None:
+    """The rekordbox FileType code for this file, from its extension."""
+    return get_file_type_for_format(Path(source).suffix.lstrip(".").upper())
+
+
+def run(label: str, job: _EncodeJob) -> None:
+    result = _encode_one(job)
+    if result.skipped:
+        print(f"  {label:16s} skipped: {result.skipped.reason}")
+        return
+    os.replace(job.temp_path, job.output_path)
+    info = result.probe.audio_info
+    print(
+        f"  {label:16s} encoded: {os.path.basename(job.output_path)} "
+        f"codec={info['codec']} {info['sample_rate']}Hz "
+        f"{info['bit_depth']}bit lossless={result.is_lossless} "
+        f"bytes={result.probe.file_size}"
+    )
+
+
+def main(sources: list[str]) -> None:
+    out_dir = tempfile.mkdtemp(prefix="rbe-file-encode-")
+    try:
+        for source in sources:
+            info = get_audio_info(source)
+            print(
+                f"{os.path.basename(source)} "
+                f"(codec={info['codec']} {info['sample_rate']}Hz "
+                f"{info['bit_depth']}bit)"
+            )
+            run("declared type", job_for(source, out_dir, declared_type(source)))
+            run("file_type=None", job_for(source, out_dir, None))
+    finally:
+        shutil.rmtree(out_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    if not shutil.which("ffmpeg"):
+        sys.exit("ffmpeg not on PATH")
+    main(sys.argv[1:])

--- a/research/beets-plugin-integration/scripts/id_stability.py
+++ b/research/beets-plugin-integration/scripts/id_stability.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Do beets item IDs survive a reimport?
+
+Imports files as singletons into a throwaway library, records (id, path),
+reimports the same items with `beet import -L`, and re-reads them. The paths
+are the control: they must not change, so any ID movement is attributable to
+the reimport rather than to files being relocated.
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+CONFIG = """\
+directory: {lib}
+library: {db}
+import:
+  copy: yes
+  autotag: no
+  quiet: yes
+  singletons: yes
+paths:
+  default: $artist/$title
+  singleton: $artist/$title
+"""
+
+
+def listing(env):
+    out = subprocess.run(
+        ["beet", "ls", "-f", "$id\t$path"], env=env,
+        capture_output=True, text=True, check=True,
+    ).stdout
+    rows = [ln.split("\t", 1) for ln in out.splitlines() if "\t" in ln]
+    return {path: int(i) for i, path in rows}
+
+
+def main(sources):
+    root = tempfile.mkdtemp(prefix="beets-ids-")
+    try:
+        lib, inbox, bd = (os.path.join(root, d) for d in ("lib", "inbox", "bd"))
+        for d in (lib, inbox, bd):
+            os.makedirs(d)
+        for src in sources:
+            shutil.copy2(src, inbox)
+        with open(os.path.join(bd, "config.yaml"), "w") as fh:
+            fh.write(CONFIG.format(lib=lib, db=os.path.join(root, "library.db")))
+        env = {**os.environ, "BEETSDIR": bd}
+
+        subprocess.run(["beet", "import", "-q", inbox], env=env,
+                       capture_output=True, check=True)
+        before = listing(env)
+        subprocess.run(["beet", "import", "-q", "-L", "path::."], env=env,
+                       capture_output=True, check=True)
+        after = listing(env)
+
+        print(f"{'path (basename)':40s} {'id before':>10s} {'id after':>9s}  same?")
+        moved = 0
+        for path in sorted(before):
+            b, a = before[path], after.get(path)
+            same = b == a
+            moved += not same
+            print(f"{os.path.basename(path):40s} {b:>10d} "
+                  f"{'gone' if a is None else a:>9} {'yes' if same else 'NO'}")
+        print(f"\npaths preserved: {set(before) == set(after)}")
+        print(f"ids changed:     {moved} of {len(before)}")
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    if not shutil.which("beet"):
+        sys.exit("beet not on PATH")
+    main(sys.argv[1:])

--- a/research/beets-plugin-integration/scripts/media_field_roundtrip.py
+++ b/research/beets-plugin-integration/scripts/media_field_roundtrip.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Can a plugin-defined field persist in the audio file across containers?
+
+Beets flexible fields live only in the library database. `add_media_field`
+(beets/plugins.py:339) instead binds a name to real tag frames, so the value
+survives outside the database. This probe stamps a distinct value per file
+through a plugin-declared media field, then reads each value straight out of
+the file with mediafile alone, proving the value is in the tag and not merely
+in the library.
+
+A field that round-trips is a candidate carrier for a rekordbox identifier.
+One that does not forces the join back onto the file path.
+
+Usage: media_field_roundtrip.py <audio-file>...
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+FIELD = "rbe_content_id"
+
+# Declared identically in the plugin and in the reader, so the reader depends
+# on the tag rather than on anything beets recorded.
+DECLARE = f'''
+from mediafile import (
+    ASFStorageStyle, MediaField, MediaFile, MP3DescStorageStyle,
+    MP4StorageStyle, StorageStyle,
+)
+
+FIELD = "{FIELD}"
+DESCRIPTOR = MediaField(
+    MP3DescStorageStyle(FIELD),
+    MP4StorageStyle(f"----:com.apple.iTunes:{{FIELD}}"),
+    StorageStyle(FIELD),
+    ASFStorageStyle(FIELD),
+)
+'''
+
+PLUGIN = DECLARE + '''
+from beets.plugins import BeetsPlugin
+
+
+class RbeidPlugin(BeetsPlugin):
+    def __init__(self):
+        super().__init__()
+        self.add_media_field(FIELD, DESCRIPTOR)
+'''
+
+READER = DECLARE + '''
+import sys
+
+MediaFile.add_field(FIELD, DESCRIPTOR)
+print(getattr(MediaFile(sys.argv[1]), FIELD) or "")
+'''
+
+CONFIG = """\
+directory: {lib}
+library: {db}
+pluginpath: {plugdir}
+plugins: rbeid
+import:
+  copy: yes
+  write: yes
+  autotag: no
+  quiet: yes
+  singletons: yes
+paths:
+  default: $title
+  singleton: $title
+"""
+
+
+def beets_python() -> str:
+    """The interpreter beets runs under.
+
+    mediafile is installed alongside beets, which for a pipx or venv install is
+    not the interpreter running this script. Reading the shebang of the `beet`
+    entry point is the reliable way to find it.
+    """
+    beet = shutil.which("beet")
+    if beet:
+        with open(beet, "rb") as fh:
+            line = fh.readline()
+        if line.startswith(b"#!"):
+            candidate = line[2:].strip().decode()
+            if os.path.exists(candidate):
+                return candidate
+    return sys.executable
+
+
+def main(sources: list[str]) -> int:
+    python = beets_python()
+    root = tempfile.mkdtemp(prefix="beets-mediafield-")
+    try:
+        lib, inbox, bd, plugdir = (
+            os.path.join(root, d) for d in ("lib", "inbox", "bd", "plugins")
+        )
+        for d in (lib, inbox, bd, plugdir):
+            os.makedirs(d)
+        for name, body in (("rbeid.py", PLUGIN), ("read_field.py", READER)):
+            with open(os.path.join(plugdir, name), "w") as fh:
+                fh.write(body)
+        for src in sources:
+            shutil.copy2(src, inbox)
+        with open(os.path.join(bd, "config.yaml"), "w") as fh:
+            fh.write(CONFIG.format(
+                lib=lib, db=os.path.join(root, "library.db"), plugdir=plugdir,
+            ))
+        env = {**os.environ, "BEETSDIR": bd}
+
+        def beet(*args):
+            return subprocess.run(["beet", *args], env=env,
+                                  capture_output=True, text=True, check=True)
+
+        beet("import", "-q", inbox)
+        paths = [p for p in beet("ls", "-f", "$path").stdout.splitlines() if p]
+
+        # `modify` writes tags by default; no separate `write` pass is needed.
+        for n, path in enumerate(paths, 1):
+            beet("modify", "-y", f"path:{path}", f"{FIELD}=RB{n:04d}")
+
+        reader = os.path.join(plugdir, "read_field.py")
+        print(f"{'file':34s} {'written':>8s} {'in file':>8s}  ok?")
+        ok_all = True
+        for n, path in enumerate(paths, 1):
+            got = subprocess.run([python, reader, path],
+                                 capture_output=True, text=True).stdout.strip()
+            ok = got == f"RB{n:04d}"
+            ok_all &= ok
+            print(f"{os.path.basename(path):34s} {f'RB{n:04d}':>8s} "
+                  f"{got or '(none)':>8s}  {'yes' if ok else 'NO'}")
+        print(f"\nread with: {python}")
+        print(f"all formats round-tripped: {ok_all}")
+        return 0 if ok_all else 1
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    if not shutil.which("beet"):
+        sys.exit("beet not on PATH")
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Research into what a beets plugin for rekordbox-edit can do, with five probes and their evidence.

- Where beets' events fire relative to its database inserts and file moves, and why only import stages can change an outcome
- Why beets item ids do not survive a reimport, forcing a path-keyed join
- What it takes for a beets library to follow an `rbe convert`: the output already lands where beets wants it, unless the path template keys on the format
- Repointing an item keeps its id but discards fields held only in beets' database; a registered transcode has no album
- `_encode_one` runs from a hand-built job with no `DjmdContent` row, but skips everything when the file type is `None`
- Decision record: the plugin inherits `--delete-originals: none`, registering the output and leaving the original as a beets item with no rekordbox row