### PR TITLE
fix(edit): survive a row whose analysis directory is missing

### DIFF
--- a/rekordbox_edit/api/_utils.py
+++ b/rekordbox_edit/api/_utils.py
@@ -94,8 +94,15 @@ def _update_anlz_paths(
     """
     if not content.AnalysisDataPath:
         return
+    try:
+        anlz_paths = db.get_anlz_paths(content.ID).values()
+    except OSError as e:
+        # A row can name a directory that was never created; get_anlz_paths
+        # scans it, so it raises rather than coming back empty.
+        _logger.warning(f"Could not read the analysis directory for {content.ID}: {e}")
+        return
     new_ppth = f"?/{new_filename}"
-    for anlz_path in db.get_anlz_paths(content.ID).values():
+    for anlz_path in anlz_paths:
         if anlz_path is None:
             continue
         try:

--- a/tests/api/test_utils.py
+++ b/tests/api/test_utils.py
@@ -317,6 +317,19 @@ class TestUpdateAnlzPaths:
 
         db.get_anlz_paths.assert_not_called()
 
+    def test_survives_a_missing_analysis_directory(self, analysed, caplog):
+        """A row can name an analysis directory that was never created.
+        pyrekordbox's get_anlz_paths scans that directory, so it raises rather
+        than returning nothing, and an edit pass must not die on the row."""
+        db, content, _dat, _ext = analysed
+        db.get_anlz_paths.side_effect = FileNotFoundError(
+            2, "The system cannot find the path specified", str(content.AnalysisDataPath)
+        )
+
+        _update_anlz_paths(db, content, "new song.mp3")
+
+        assert "analysis directory" in caplog.text
+
     def test_skips_an_analysis_file_that_does_not_exist(self, analysed, tmp_path):
         db, content, dat, _ext = analysed
         db.get_anlz_paths.return_value = {"DAT": dat, "EXT": tmp_path / "absent.EXT"}


### PR DESCRIPTION
## The bug

`_update_anlz_paths` called `db.get_anlz_paths(content.ID)` outside its per-file
guard. pyrekordbox scans the directory named by the row rather than stating each
file, so a row naming a directory that was never created raises
`FileNotFoundError` instead of coming back empty.

## The fix

Wrap the call and treat an unreadable analysis directory the same way an
unreadable analysis file is already treated: warn, skip the row, carry on.