### PR TITLE
fix(display): keep the new value visible in a change preview

### DIFF
--- a/rekordbox_edit/display.py
+++ b/rekordbox_edit/display.py
@@ -203,8 +203,10 @@ def print_track_info(
     """Print formatted track information.
 
     When ``changed_field`` and ``new_values`` are both provided, the matching
-    column renders each row as a before/after preview: the old value is
-    struck through and the new value is appended.
+    column renders each row as a before/after preview: the old value struck
+    through, the new value beneath it. That column wraps rather than
+    ellipsising, since both values have to stay readable at ordinary terminal
+    widths.
     """
     if (changed_field is None) != (new_values is None):
         raise ValueError("changed_field and new_values must be provided together")
@@ -232,8 +234,16 @@ def print_track_info(
     table.add_column("#", justify="right", min_width=1, no_wrap=True)
     for column in print_columns:
         cfg = _COLUMN_CONFIG.get(column, {"min_width": 5})
+        # The changed column carries both values, so it needs roughly twice the
+        # width of any other. Ellipsised at a real terminal width it shows the
+        # old value and truncates the new one away, which is the half nobody
+        # can check.
+        previewing = column is changed_field and new_values is not None
         table.add_column(
-            PRINT_HEADERS[column], no_wrap=True, overflow="ellipsis", **cfg
+            PRINT_HEADERS[column],
+            no_wrap=not previewing,
+            overflow="fold" if previewing else "ellipsis",
+            **cfg,
         )
 
     for i, track in enumerate(content_list, 1):
@@ -241,7 +251,9 @@ def print_track_info(
         for col in print_columns:
             old = _cell_value(track, col)
             if col is changed_field and new_values is not None:
-                cells.append(f"[strike]{old}[/strike] [bold]{new_values[i - 1]}[/bold]")
+                cells.append(
+                    f"[strike]{old}[/strike]\n[bold]{new_values[i - 1]}[/bold]"
+                )
             else:
                 cells.append(old)
         table.add_row(str(i), *cells)

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -86,6 +86,25 @@ def wide_console(monkeypatch):
     )
 
 
+@pytest.fixture
+def terminal_console(monkeypatch):
+    """Swap the module console for one the width of an ordinary terminal.
+
+    `wide_console` exists to keep substring assertions stable, but a preview
+    that only renders at 400 columns is not a preview anyone sees.
+    """
+    monkeypatch.setattr(
+        display,
+        "console",
+        Console(
+            record=True,
+            width=100,
+            theme=display.RBE_THEME,
+            highlighter=display.RbeHighlighter(),
+        ),
+    )
+
+
 class TestPrintTrackInfo:
     """Test print_track_info function."""
 
@@ -164,6 +183,32 @@ class TestPrintTrackInfo:
         captured = capsys.readouterr()
         assert "Old Name" in captured.out
         assert "New Name" in captured.out
+
+    def test_change_preview_shows_the_new_path_at_terminal_width(
+        self, capsys, terminal_console, make_track
+    ):
+        """A path rewrite is the case this preview exists for, and paths are long.
+
+        Old and new share one no-wrap ellipsis cell, so the old value alone
+        fills the column and the new value is truncated away entirely. A bulk
+        repoint is then unverifiable from --dry-run.
+        """
+        old = (
+            "A:/Music/Any Time, Any Place - Janet Jackson (1994) "
+            "{V25H-38435} [FLAC-CD]/03 Janet Jackson - Any Time, Any Place.flac"
+        )
+        new = old.replace("A:/Music/", "A:/rbe_migration_copy/Music/")
+
+        print_track_info(
+            [make_track(FolderPath=old)],
+            changed_field=PrintableField.FolderPath,
+            new_values=[new],
+        )
+
+        # The cell wraps, so the path is split across lines; join it back up.
+        rendered = "".join(capsys.readouterr().out.split())
+        assert "rbe_migration_copy/Music/" in rendered
+        assert "A:/Music/AnyTime" in rendered
 
     def test_change_preview_requires_both_args(self, make_track):
         """Providing only one of changed_field/new_values raises ValueError."""


### PR DESCRIPTION
## The bug

`print_track_info` renders the changed column as
`[strike]old[/strike] [bold]new[/bold]` into a single cell configured
`no_wrap=True, overflow="ellipsis"`. A `FolderPath` fills that column on its own,
so the new value — the half a reviewer actually has to check — was always the
half discarded.

Now the column wraps rather than ellipsising when it carries a preview, and the new
value renders beneath the struck-through old one.
