### PR TITLE
fix(import): fill the audio columns from the file's stream header

### DIFF
--- a/rekordbox_edit/api/_import.py
+++ b/rekordbox_edit/api/_import.py
@@ -11,7 +11,12 @@ from pyrekordbox.db6 import tables as tb
 
 from rekordbox_edit._tag_fields import TAG_FIELDS
 from rekordbox_edit.api._relations import RELATIONS, find_by_name, get_or_create
-from rekordbox_edit.api._utils import stamp_usns, track_from_content, writing
+from rekordbox_edit.api._utils import (
+    _sync_audio_columns,
+    stamp_usns,
+    track_from_content,
+    writing,
+)
 from rekordbox_edit.errors import (
     DirectoryConfirmationRequired,
     ImportInputError,
@@ -31,7 +36,7 @@ from rekordbox_edit.query import (
     require_session,
 )
 from rekordbox_edit.tags import TrackTags, UnreadableFile, read_tags
-from rekordbox_edit.utils import FILE_TYPES
+from rekordbox_edit.utils import FILE_TYPES, AudioInfo
 
 _logger = logging.getLogger(__name__)
 
@@ -155,10 +160,8 @@ IMPORT_DEFAULTS: dict[str, object] = {
     "rb_local_data_status": 0,
     "rb_local_deleted": 0,
     "rb_local_synced": 0,
-    # Analysis fills these; an import leaves them zero.
-    "SampleRate": 0,
-    "BitRate": 0,
-    "BitDepth": 0,
+    # Analysis fills these; an import leaves them zero. SampleRate, BitDepth,
+    # and BitRate are absent because _build_content reads them from the file.
     "BPM": 0,
     "Analysed": 0,
 }
@@ -196,6 +199,27 @@ def _scalar_columns(tags: TrackTags) -> dict[str, str | int]:
     }
 
 
+def _stream_audio_info(tags: TrackTags) -> AudioInfo:
+    """A track's stream header in the shape `_sync_audio_columns` reads.
+
+    Only the three audio columns are taken from this. The probe-only fields
+    describe nothing an import row records, so they carry no value.
+
+    rekordbox's own import leaves these columns at zero and lets analysis fill
+    them. Reading them here diverges from that deliberately, so that a row an
+    import creates already describes its file the way a repointed `edit` does.
+    """
+    return {
+        "sample_rate": tags["sample_rate"] or 0,
+        "bit_depth": tags["bit_depth"],
+        "bitrate": tags["bitrate"],
+        "channels": 0,
+        "codec": None,
+        "container": None,
+        "duration": None,
+    }
+
+
 def _created_date(path: str) -> str:
     """The file's creation date, as Rekordbox records DateCreated.
 
@@ -230,7 +254,12 @@ def _build_content(
     # add_content types by extension, mapping every .m4a to AAC, and stamps
     # DateCreated with today rather than the file's own date.
     if tags["file_type"] is not None:
-        content.FileType = tags["file_type"]
+        _sync_audio_columns(
+            content,
+            _stream_audio_info(tags),
+            tags["file_type"],
+            content.FileSize,
+        )
     content.DateCreated = _created_date(candidate.path)
     # add_content stores str(Path(path)), which is backslashed on Windows.
     # Rekordbox forward-slashes FolderPath on every platform.

--- a/rekordbox_edit/api/_utils.py
+++ b/rekordbox_edit/api/_utils.py
@@ -111,7 +111,11 @@ def _update_anlz_paths(
             with open(anlz_path, "wb") as fh:
                 fh.write(updated)
         except (AnlzFormatError, OSError) as e:
-            _logger.warning(f"Could not rewrite the path tag in {anlz_path}: {e}")
+            _logger.warning(
+                f"Could not rewrite the path tag in {anlz_path}: {e}. It still "
+                "names the previous file; re-analyze the track in Rekordbox to "
+                "rebuild the analysis."
+            )
             continue
         _logger.debug(f"Updated PPTH of {anlz_path} to {new_ppth}")
 

--- a/rekordbox_edit/tags.py
+++ b/rekordbox_edit/tags.py
@@ -37,6 +37,9 @@ class TrackTags(TypedDict):
     release_year: int | None
     length: int | None
     file_type: int | None
+    sample_rate: int | None
+    bit_depth: int | None
+    bitrate: int | None
 
 
 # Rekordbox FileType by mutagen's file class. MP4 splits on the codec because
@@ -158,6 +161,11 @@ def _file_type(audio) -> int | None:
     return file_type.code if file_type else None
 
 
+def _kbps(bitrate: int | None) -> int | None:
+    """A stream header's bits per second in the whole kilobits rekordbox stores."""
+    return bitrate // 1000 if bitrate else None
+
+
 def read_tags(path: str) -> TrackTags:
     """Read one file's tags and stream header.
 
@@ -184,7 +192,8 @@ def read_tags(path: str) -> TrackTags:
     read = {field: _first(tags, tag_keys) for field, tag_keys in keys.items()}
 
     isrc = _mp4_isrc(tags) if name == "MP4" else read.get("isrc")
-    length = getattr(audio.info, "length", None)
+    info = audio.info
+    length = getattr(info, "length", None)
 
     result: TrackTags = {
         "title": read.get("title") or os.path.splitext(os.path.basename(path))[0],
@@ -201,6 +210,10 @@ def read_tags(path: str) -> TrackTags:
         "release_year": _leading_int(read.get("release_year")),
         "length": int(length) if length is not None else None,
         "file_type": _file_type(audio),
+        "sample_rate": getattr(info, "sample_rate", None),
+        # MP3 and some MP4 headers report no depth; the caller supplies one.
+        "bit_depth": getattr(info, "bits_per_sample", None) or None,
+        "bitrate": _kbps(getattr(info, "bitrate", None)),
     }
     _logger.debug(f"read tags for {path}: file_type={result['file_type']}")
     return result

--- a/rekordbox_edit/utils.py
+++ b/rekordbox_edit/utils.py
@@ -237,7 +237,8 @@ Install it with `brew install ffmpeg`, or from https://ffmpeg.org/download.html
 
 
 class AudioInfo(TypedDict):
-    """Fields extracted from an ffmpeg probe of one audio file."""
+    """One audio file's stream characteristics, from an ffmpeg probe or from
+    the header mutagen reads."""
 
     bit_depth: int | None
     sample_rate: int

--- a/tests/api/test_import.py
+++ b/tests/api/test_import.py
@@ -182,6 +182,9 @@ def tags() -> TrackTags:
         "release_year": 2022,
         "length": 254,
         "file_type": 5,
+        "sample_rate": 44100,
+        "bit_depth": 16,
+        "bitrate": 96,
     }
 
 
@@ -193,9 +196,15 @@ class TestImportDefaults:
         assert IMPORT_DEFAULTS["ExtInfo"] == "null"
 
     def test_leaves_the_analysis_columns_at_zero(self):
-        for column in ("SampleRate", "BitRate", "BitDepth", "BPM", "Analysed"):
+        for column in ("BPM", "Analysed"):
             assert IMPORT_DEFAULTS[column] == 0
         assert IMPORT_DEFAULTS["AnalysisDataPath"] == ""
+
+    def test_omits_the_columns_read_from_the_stream_header(self):
+        # _build_content writes these from the file, so a default here would
+        # be overwritten anyway and reads as though an import left them zero.
+        for column in ("SampleRate", "BitRate", "BitDepth"):
+            assert column not in IMPORT_DEFAULTS
 
     def test_omits_searchstr_so_it_stays_null(self):
         # NULL on all 924 content rows sampled; no observed value to imitate.
@@ -308,6 +317,19 @@ class TestBuildContent:
         assert kwargs["DiscNo"] == tags["disc_no"]
         assert kwargs["ReleaseYear"] == tags["release_year"]
         assert kwargs["Length"] == tags["length"]
+
+    def test_writes_the_audio_columns_from_the_stream_header(
+        self, mock_db, tags, tmp_path, stale_content
+    ):
+        track = tmp_path / "a.flac"
+        track.write_bytes(b"")
+
+        content = _build_content(mock_db, _candidate(str(track), tags))
+
+        assert content.SampleRate == tags["sample_rate"]
+        assert content.BitDepth == tags["bit_depth"]
+        # FLAC bitrate is stored as 0, the same convention edit applies.
+        assert content.BitRate == 0
 
     def test_overrides_file_type_and_date_created_after_add_content(
         self, mock_db, tags, tmp_path, stale_content

--- a/tests/e2e/test_import.py
+++ b/tests/e2e/test_import.py
@@ -55,10 +55,10 @@ EXPECTED_EMPTY = {
     "rb_local_synced": 0,
 }
 
-# Analysis fills SampleRate, BitDepth, BPM, and Analysed; an import leaves
-# them at zero. BitRate is not analysis-filled: rekordbox stores it as 0 for
-# variable-rate audio, and it stays 0 through analysis on this FLAC fixture.
-EXPECTED_ZERO = ("SampleRate", "BitRate", "BitDepth", "BPM", "Analysed")
+# Analysis fills BPM and Analysed, so an import leaves them at zero.
+# SampleRate, BitDepth, and BitRate are read from the file instead: rekordbox
+# waits for analysis to fill them, and this tool deliberately does not.
+EXPECTED_ZERO = ("BPM", "Analysed")
 
 
 @pytest.fixture
@@ -97,6 +97,12 @@ def test_imported_row_matches_the_rekordbox_import_shape(
     assert row.AlbumName == "Lossless Vol 1"
     assert row.Length == 2
     assert row.FileSize == track.stat().st_size
+
+    # Read from the stream header at import, following the same conventions
+    # `edit` applies. FLAC bitrate is stored as 0 for variable-rate audio.
+    assert row.SampleRate == 44100
+    assert row.BitDepth == 16
+    assert row.BitRate == 0
 
     for column, expected in EXPECTED_EMPTY.items():
         assert getattr(row, column) == expected, f"{column} diverges from Rekordbox"

--- a/tests/test_tag_fields.py
+++ b/tests/test_tag_fields.py
@@ -16,8 +16,8 @@ from rekordbox_edit.display import PrintableField
 from rekordbox_edit.tags import TrackTags
 
 #: TrackTags keys read off the audio stream rather than a tag, so they have no
-#: registry row: `import` derives both and neither is editable.
-_STREAM_KEYS = {"length", "file_type"}
+#: registry row: `import` derives them all and none is editable.
+_STREAM_KEYS = {"length", "file_type", "sample_rate", "bit_depth", "bitrate"}
 
 #: Fields `edit` offers that are not audio tags at all.
 _NON_TAG_FIELDS = {"Rating", "FolderPath"}

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -52,6 +52,29 @@ class TestScalarTags:
         assert tags["title"] == "05-aiff-44_1k-16b"
         assert tags["artist"] is None
 
+    @pytest.mark.parametrize(
+        "name,sample_rate,bit_depth,bitrate",
+        [
+            ("01-flac-44_1k-16b.flac", 44100, 16, 96),
+            ("05-aiff-44_1k-16b.aiff", 44100, 16, 705),
+            ("06-wav-96k-24b.wav", 96000, 24, 2304),
+            # MP3 carries no bit depth; the import conventions supply one.
+            ("07-mp3-44_1k-320cbr.mp3", 44100, None, 320),
+            # ALAC reports the PCM-equivalent rate, which is what Rekordbox
+            # stores. An ffmpeg probe reports the compressed rate instead.
+            ("03-alac-44_1k-16b.m4a", 44100, 16, 705),
+            ("09-aac-44_1k-256kbps.m4a", 44100, 16, 132),
+        ],
+    )
+    def test_reads_the_stream_header_numbers(
+        self, name, sample_rate, bit_depth, bitrate
+    ):
+        tags = read_tags(str(FIXTURES / name))
+
+        assert tags["sample_rate"] == sample_rate
+        assert tags["bit_depth"] == bit_depth
+        assert tags["bitrate"] == bitrate
+
     def test_reads_length_as_whole_seconds(self):
         assert read_tags(str(FIXTURES / "01-flac-44_1k-16b.flac"))["length"] == 2
 


### PR DESCRIPTION
this diverges from rekordbox in that it normally doesn't wright these, but it's easy for us to pull these off the file metatdata and if we're slightly off from what RB would do an analysis will correct it anyway.