### PR TITLE
fix: use rekordbox's 0-5 scale, not the XML x51 encoding

### DIFF
--- a/rekordbox_edit/api/_field_handlers.py
+++ b/rekordbox_edit/api/_field_handlers.py
@@ -27,8 +27,6 @@ from rekordbox_edit.utils import (
     get_audio_info,
     get_file_type_for_probe,
     parse_star_rating,
-    star_rating_to_stored,
-    stored_to_star_rating,
 )
 
 _logger = logging.getLogger(__name__)
@@ -127,7 +125,8 @@ class StringField(FieldHandler):
 
 
 class RatingField(FieldHandler):
-    """A 0-5 star rating, stored as stars * 51. `--match` does not apply."""
+    """A 0-5 star rating, stored as the star count itself. `--match` does not
+    apply."""
 
     name = "Rating"
     supports_match = False
@@ -141,13 +140,13 @@ class RatingField(FieldHandler):
 
     def current_value(self, content):
         stored = content.Rating
-        return None if stored is None else str(stored_to_star_rating(stored))
+        return None if stored is None else str(stored)
 
     def compute_new_value(self, current, args):
         return str(parse_star_rating(args.replace_value))
 
     def apply(self, db, content, new_value):
-        content.Rating = star_rating_to_stored(int(new_value))
+        content.Rating = int(new_value)
         return NO_INCIDENTAL_ROWS
 
 

--- a/rekordbox_edit/display.py
+++ b/rekordbox_edit/display.py
@@ -22,7 +22,7 @@ from rich.table import Table
 from rich.theme import Theme
 
 from rekordbox_edit.models import Track
-from rekordbox_edit.utils import FILE_TYPES, get_file_type_name, stored_to_star_rating
+from rekordbox_edit.utils import FILE_TYPES, get_file_type_name
 
 _logger = logging.getLogger(__name__)
 
@@ -189,7 +189,7 @@ def _cell_value(track: Track, column: PrintableField) -> str:
     if column is PrintableField.FolderPath:
         return os.path.dirname(track.FolderPath or "")
     if column is PrintableField.Rating:
-        return "" if track.Rating is None else str(stored_to_star_rating(track.Rating))
+        return "" if track.Rating is None else str(track.Rating)
     value = getattr(track, column.value, None)
     return "" if value is None else str(value)
 

--- a/rekordbox_edit/utils.py
+++ b/rekordbox_edit/utils.py
@@ -331,8 +331,10 @@ def get_audio_info(file_path) -> AudioInfo:
         raise e
 
 
+#: DjmdContent.Rating holds the star count itself, 0-5. rekordbox's XML export
+#: encodes the same rating as 0/51/102/153/204/255, which is a property of that
+#: file format and not of this column.
 _RATING_STARS_MAX = 5
-_RATING_STEP = 51  # Rekordbox stores N stars as N * 51.
 
 
 def parse_star_rating(value: "str | int") -> int:
@@ -348,13 +350,3 @@ def parse_star_rating(value: "str | int") -> int:
             f"Rating must be between 0 and {_RATING_STARS_MAX}, got {stars}"
         )
     return stars
-
-
-def star_rating_to_stored(stars: int) -> int:
-    """Convert a 0-5 star rating to the value Rekordbox stores."""
-    return stars * _RATING_STEP
-
-
-def stored_to_star_rating(stored: int) -> int:
-    """Convert a stored rating back to a 0-5 star count."""
-    return round(stored / _RATING_STEP)

--- a/tests/api/test_field_handlers.py
+++ b/tests/api/test_field_handlers.py
@@ -107,10 +107,12 @@ class TestRatingField:
 
     def test_current_value_is_star_string(self, make_djmd_content_item):
         content = make_djmd_content_item(ID="1")
-        content.Rating = 153
+        content.Rating = 3
         assert FIELD_HANDLERS["Rating"].current_value(content) == "3"
 
-    def test_compute_and_apply_star_to_stored(self, make_djmd_content_item):
+    def test_apply_writes_the_star_count_itself(self, make_djmd_content_item):
+        # DjmdContent.Rating holds 0-5. The 0/51/102/153/204/255 encoding
+        # belongs to rekordbox's XML export, not to this column.
         content = make_djmd_content_item(ID="1")
         content.Rating = 0
         handler = FIELD_HANDLERS["Rating"]
@@ -118,7 +120,7 @@ class TestRatingField:
         new_value = handler.compute_new_value(handler.current_value(content), args)
         assert new_value == "4"
         handler.apply(db=MagicMock(), content=content, new_value=new_value)
-        assert content.Rating == 204
+        assert content.Rating == 4
 
 
 #: Every relational field, as (edit field, foreign key column, relation kind).

--- a/tests/e2e/test_edit_fields.py
+++ b/tests/e2e/test_edit_fields.py
@@ -110,14 +110,14 @@ def test_album_create_new_has_no_album_artist(fresh_db):
     db.close()
 
 
-def test_rating_written_as_stored_value(fresh_db):
+def test_rating_written_as_the_star_count(fresh_db):
     db = Rekordbox6Database(str(fresh_db))
     assert db.session is not None
     edit(
         db, EditRequest(exact_title=["Apple Alpha"], field="Rating", replace_value="4")
     )
     moved = db.session.query(tb.DjmdContent).filter_by(Title="Apple Alpha").one()
-    assert moved.Rating == 204
+    assert moved.Rating == 4
     db.close()
 
 

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -295,7 +295,7 @@ def test_comment_column_renders(capsys, wide_console, make_track):
 
 def test_rating_renders_as_stars(capsys, wide_console, make_track):
     track = make_track(ID="1")
-    track.Rating = 204
+    track.Rating = 4
     print_track_info([track], print_columns=[PrintableField.Rating])
     rendered = capsys.readouterr().out
     assert "4" in rendered

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,8 +14,6 @@ from rekordbox_edit.utils import (
     parse_star_rating,
     get_file_type_for_probe,
     probe_matches_file_type,
-    star_rating_to_stored,
-    stored_to_star_rating,
 )
 
 
@@ -492,12 +490,6 @@ class TestGetFileTypeForProbe:
     )
     def test_mapping(self, codec, container, expected):
         assert get_file_type_for_probe(codec, container) == expected
-
-
-@pytest.mark.parametrize("stars,stored", [(0, 0), (1, 51), (3, 153), (5, 255)])
-def test_star_stored_roundtrip(stars, stored):
-    assert star_rating_to_stored(stars) == stored
-    assert stored_to_star_rating(stored) == stars
 
 
 @pytest.mark.parametrize("value,expected", [("0", 0), ("5", 5), (3, 3)])


### PR DESCRIPTION
We were incorrectly writing the Rating column based on what we observed in XML files. But double checking against how rekordbox records these revealed that it's just simple whole numbers (thank gosh).